### PR TITLE
Reframe README: script-as-unit for humans + agents, runs anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hf jobs uv run --flavor l4x1 \
   davanstrien/ufo-ColPali your-username/ufo-ocr
 ```
 
-No GPU of your own, no `pip install`. (Jobs needs the `hf` CLI — `uv tool install huggingface_hub` — and a Hub account with a positive [credit balance](https://huggingface.co/settings/billing); a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors and prices.)
+No GPU of your own, no `pip install`. (Jobs needs the `hf` CLI — `uv tool install huggingface_hub` — and a [Pro, Team, or Enterprise](https://huggingface.co/pricing) account; it's pay-as-you-go, billed by the second, and a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors and prices.)
 
 ## What's a UV script?
 
@@ -53,7 +53,7 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 - **Composable** — recipes hand off through the Hub (usually a dataset in, a dataset or model out), so you can chain them into a pipeline.
 - **Runs anywhere** — `uv run` locally, `hf jobs uv run` for GPU, or anywhere `uv` is installed.
 
-**Built for agents, too.** Every recipe takes its arguments in the same `input output` order and runs from a URL, so an AI agent can pick a tool from its header and run it with no setup. On Jobs the agent runs in a sandbox: a throwaway disk, access limited to what the token's repo permissions allow, and a cost cap per job — not arbitrary code on your machine.
+**Built for agents, too.** Every recipe takes its arguments in the same `input output` order and runs from a URL, so an AI agent can pick a tool from its header and run it with no setup. On Jobs the agent runs in a sandbox: a throwaway disk, access limited to what the token's repo permissions allow, and a cost cap per job — not arbitrary code on your machine. (Hugging Face also ships an [`hf` CLI skill for agents](https://huggingface.co/docs/hub/agents-cli) for driving Jobs from an editor.)
 
 ## Recipes
 
@@ -87,18 +87,23 @@ Each arrow is a Hub dataset; each box is one `hf jobs uv run` (or `uv run`), and
 
 ## Run anywhere; use Jobs for a GPU
 
-Every recipe runs the same way wherever `uv` is installed:
+Every recipe runs the same way wherever `uv` is installed — locally, or on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) for a managed GPU. Same file, same arguments:
 
 ```bash
-uv run <script-url> [args]          # local — your CPU/GPU
-hf jobs uv run <script-url> [args]  # managed — runs on a rented GPU, no setup
+SCRIPT=https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py
+
+# locally — on your own machine
+uv run $SCRIPT davanstrien/ufo-ColPali your-username/ufo-ocr
+
+# on a managed GPU — pick hardware with --flavor
+hf jobs uv run --flavor l4x1 $SCRIPT davanstrien/ufo-ColPali your-username/ufo-ocr
 ```
 
-Why reach for Jobs:
+Why reach for [Jobs](https://huggingface.co/docs/hub/jobs):
 
-- **Pay by the minute** — you're billed only while the job runs.
-- **No infra** — `hf jobs uv run <url>` and you're done.
-- **Hub-native** — mount datasets/models/buckets with `-v hf://…`; write results straight back to the Hub. Running from the `https://huggingface.co/datasets/uv-scripts/…` URL also attributes usage to the recipe.
+- **Pay by the second** — billed only while the job runs. Run `hf jobs hardware`, or see the [flavors](https://huggingface.co/docs/huggingface_hub/guides/jobs#select-the-hardware) and [pricing](https://huggingface.co/docs/hub/jobs).
+- **No infra** — `hf jobs uv run <url>` and you're done. See the [`hf jobs` CLI](https://huggingface.co/docs/huggingface_hub/guides/cli#hf-jobs).
+- **Hub-native** — read and write datasets, models, and [storage buckets](https://huggingface.co/docs/hub/storage-buckets) directly. Running from the `https://huggingface.co/datasets/uv-scripts/…` URL also attributes usage to the recipe.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # uv-scripts-for-ai
 
-> **UV scripts for working with data on the Hugging Face Hub — run any of them in one command as a Job. No install, no setup.**
+> **Single-purpose UV scripts for data & ML work — self-contained, version-pinned, and self-describing, so both you and your agents can run one in a command and chain many into a pipeline. Run them locally with `uv run`, or on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) for zero-setup GPU.**
 
-Each recipe here is a single, self-contained [UV script](https://docs.astral.sh/uv/guides/scripts/) (Python with its dependencies declared inline). You don't clone anything or set up an environment — you point Hugging Face Jobs at the script's URL and it runs on managed CPU/GPU infrastructure, reading and writing straight from the Hub.
+Each recipe is a single [UV script](https://docs.astral.sh/uv/guides/scripts/): one Python file that declares its own dependencies inline. Nothing to clone, no environment to set up, no `requirements.txt`. The script *is* the unit — and because its deps are pinned in the file, it runs the same today as in six months, on your laptop or on managed GPU.
+
+Every recipe reads and writes the [Hugging Face Hub](https://huggingface.co/datasets): a dataset goes in, a dataset comes out.
 
 ## Quickstart
 
-OCR an image dataset and push the text back to the Hub — one command:
+**Test any recipe locally in two seconds** — the script declares its own deps, so `uv` builds the environment for you:
+
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py --help
+```
+
+**Run it for real on a GPU** — point Hugging Face Jobs at the same URL; it runs on managed infrastructure, reading and writing straight from the Hub:
 
 ```bash
 hf jobs uv run --flavor l4x1 \
@@ -14,7 +22,21 @@ hf jobs uv run --flavor l4x1 \
   your-username/my-images your-username/my-images-text
 ```
 
-That's it — no GPU of your own, no `pip install`. (You need a Hub account with a positive [credit balance](https://huggingface.co/settings/billing); a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors + prices.)
+No GPU of your own, no `pip install`. (Jobs needs a Hub account with a positive [credit balance](https://huggingface.co/settings/billing); a small CPU job costs ~$0.01/hr — run `hf jobs hardware` for current flavors and prices.)
+
+## Why UV scripts
+
+A self-contained, pinned script is the smallest *reliable* unit of work — which is exactly what makes it a good building block for both people and agents:
+
+- **Discrete & single-purpose** — one script does one task. You pick the right tool by reading a header, not a codebase.
+- **Self-describing** — the [PEP 723](https://peps.python.org/pep-0723/) dependency block, the docstring, and `--help` together declare everything needed to run it.
+- **Reproducible by construction** — dependencies are pinned *in the file*. No env drift, nothing to debug later, no "works on my machine."
+- **Composable** — each recipe is dataset-in → dataset-out, so the Hub is the glue. Chain several into a pipeline.
+- **Runs anywhere** — `uv run` locally, `hf jobs uv run` for GPU, or anywhere `uv` is installed. Same file, same result.
+
+### Good tools for agents
+
+The same properties make these scripts natural tools for AI agents: an agent can **discover** a recipe from its header, **run** it from a URL with no setup, and trust the result is **reproducible** because the environment is pinned. And on Jobs, the agent runs sandboxed managed compute — not arbitrary code on your machine.
 
 ## What's a UV script?
 
@@ -22,39 +44,54 @@ A normal Python file with a metadata block at the top declaring its dependencies
 
 ```python
 # /// script
+# requires-python = ">=3.10"
 # dependencies = ["datasets", "transformers", "torch"]
 # ///
 ```
 
-`uv` — and `hf jobs uv run` — reads that block, builds the environment, and runs the file. One file, no `requirements.txt`, no setup.
-
-This is the standard [PEP 723](https://peps.python.org/pep-0723/) inline-script-metadata format — see the [uv scripts guide](https://docs.astral.sh/uv/guides/scripts/) to learn more.
+`uv` — and `hf jobs uv run` — reads that block, builds the environment, and runs the file. One file, no `requirements.txt`, no setup. This is the standard [PEP 723](https://peps.python.org/pep-0723/) inline-script-metadata format — see the [uv scripts guide](https://docs.astral.sh/uv/guides/scripts/) to learn more.
 
 ## Recipes
 
-| Domain | What it does | Status |
+| Domain | What it does | On the Hub |
 |---|---|---|
-| **[ocr/](ocr/)** | OCR / document → text & structured data (model zoo: GLM, PaddleOCR-VL, Nanonets, olmOCR, …) | ⭐ flagship |
-| data-processing/ | Filter / dedup / stats over large datasets (DuckDB, Polars) | _coming_ |
-| vision/ | Zero-shot detection & segmentation over datasets (SAM3, VLMs) | _coming_ |
-| embeddings/ | Embed a dataset; build an interactive atlas | _coming_ |
-| dataset-creation/ | Turn raw files (PDFs, image URLs) into Hub datasets | _coming_ |
-| synthetic-data/ | Generate datasets with LLMs | _coming_ |
-| audio/ | Transcription & speech translation | _coming_ |
+| **[ocr/](ocr/)** ⭐ | OCR / document → text & structured data — GLM, PaddleOCR-VL, Nanonets, olmOCR, dots, … (30+ models) | [`uv-scripts/ocr`](https://huggingface.co/datasets/uv-scripts/ocr) |
+| **vision** | Zero-shot detection & segmentation over image datasets | [`sam3`](https://huggingface.co/datasets/uv-scripts/sam3) · [`object-detection`](https://huggingface.co/datasets/uv-scripts/object-detection) · [`vlm-object-detection`](https://huggingface.co/datasets/uv-scripts/vlm-object-detection) |
+| **audio** | Transcription & speech translation | [`transcription`](https://huggingface.co/datasets/uv-scripts/transcription) |
+| **embeddings & atlas** | Embed a dataset; build an interactive map | [`build-atlas`](https://huggingface.co/datasets/uv-scripts/build-atlas) |
+| **data processing** | Filter / dedup / stats over large datasets | [`dataset-stats`](https://huggingface.co/datasets/uv-scripts/dataset-stats) · [`deduplication`](https://huggingface.co/datasets/uv-scripts/deduplication) · [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
+| **dataset creation** | Turn PDFs / image URLs into Hub datasets | [`dataset-creation`](https://huggingface.co/datasets/uv-scripts/dataset-creation) · [`iiif-tiles`](https://huggingface.co/datasets/uv-scripts/iiif-tiles) |
+| **synthetic data** | Generate datasets with LLMs | [`synthetic-data`](https://huggingface.co/datasets/uv-scripts/synthetic-data) |
+| **inference** | Run any open LLM / VLM over a dataset | [`vllm`](https://huggingface.co/datasets/uv-scripts/vllm) · [`openai-oss`](https://huggingface.co/datasets/uv-scripts/openai-oss) · [`transformers-inference`](https://huggingface.co/datasets/uv-scripts/transformers-inference) |
+| **entity extraction** | NER / structured extraction over text | [`gliner`](https://huggingface.co/datasets/uv-scripts/gliner) |
 
-## Why Hugging Face Jobs?
+Only **[ocr/](ocr/)** lives in this repo so far — the others link to the [`uv-scripts`](https://huggingface.co/uv-scripts) Hugging Face org where they run today, and migrate here over time. (GitHub is the source of truth; each folder mirrors to its Hub dataset.)
+
+## Compose a pipeline
+
+Because every recipe is dataset-in → dataset-out, you can chain them — the Hub passes data from one step to the next. A document-collection pipeline, end to end:
+
+```
+PDFs / scans          →   OCR to markdown      →   dedup + stats        →   embed + visualise
+dataset-creation          ocr/glm-ocr.py           deduplication            build-atlas
+```
+
+Each arrow is a Hub dataset; each box is one `hf jobs uv run` (or `uv run`). A human writes that as a shell script; an agent writes it as a plan — same scripts either way.
+
+## Run anywhere — Jobs is the easy GPU button
+
+Every recipe runs the same way wherever `uv` is:
+
+```bash
+uv run <script-url> [args]          # local — your CPU/GPU
+hf jobs uv run <script-url> [args]  # managed — HF Jobs picks up the GPU
+```
+
+Why reach for Jobs:
 
 - **Cheapest managed serverless GPU** — pay by the minute, only while the job runs.
 - **No infra** — `hf jobs uv run <url>` and you're done.
-- **Hub-native** — mount datasets/models/buckets with `-v hf://…`; write results straight back to the Hub.
-
-## Run from anywhere
-
-Every recipe runs the same way — pass the script URL to `hf jobs uv run`:
-
-```bash
-hf jobs uv run <script-url> [args]
-```
+- **Hub-native** — mount datasets/models/buckets with `-v hf://…`; write results straight back to the Hub. Running from the `https://huggingface.co/datasets/uv-scripts/…` URL also attributes usage to the recipe.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # uv-scripts-for-ai
 
-> **A UV script is the smallest reliable unit of data & ML work: one file, with its dependencies pinned inside it, that runs the same on your laptop or on a managed GPU. Run one in a command — `uv run` locally or `hf jobs uv run` on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) — and chain many into a pipeline.**
+> **A UV script is a single Python file that declares its own dependencies inline, so it runs the same way on your laptop or on a managed GPU. Run one with `uv run` locally or `hf jobs uv run` on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs), and chain several into a pipeline.**
 
-Because each script is self-contained and self-describing, it's easy for **people and AI agents alike** to run and compose. No clone, no environment to set up, no `requirements.txt` — the script *is* the unit.
+Each script carries its own dependencies, so people and agents can run one without cloning a repo, making a virtualenv, or installing a `requirements.txt` first.
 
-A **recipe** here is one such UV script: a single Python file that declares its own dependencies inline. Most read and write the [Hugging Face Hub](https://huggingface.co/datasets), so the Hub is the substrate that passes data from one step to the next.
+A **recipe** here is one such script. Most read and write the [Hugging Face Hub](https://huggingface.co/datasets), so one script's output dataset becomes the next one's input.
 
 ## Quickstart
 
@@ -14,13 +14,13 @@ A **recipe** here is one such UV script: a single Python file that declares its 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-**Kick the tires** — run a recipe straight from its URL; `uv` reads its dependency block and builds the environment for you (a few seconds, no account needed):
+**Try it locally** — run a recipe straight from its URL. `uv` reads its dependency block and builds the environment for you (a few seconds, no account needed):
 
 ```bash
 uv run https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py --help
 ```
 
-**Run it for real on a GPU** — point Hugging Face Jobs at the same URL. Here `davanstrien/ufo-ColPali` is a small *public* image dataset you can use as-is; the output lands in your namespace:
+**Run it on a GPU** — point Hugging Face Jobs at the same URL. Here `davanstrien/ufo-ColPali` is a small *public* image dataset you can use as-is; the output lands in your namespace:
 
 ```bash
 hf jobs uv run --flavor l4x1 \
@@ -32,7 +32,7 @@ No GPU of your own, no `pip install`. (Jobs needs the `hf` CLI — `uv tool inst
 
 ## What's a UV script?
 
-A normal Python file with a metadata block at the top declaring its dependencies:
+A normal Python file with a metadata block at the top that lists its dependencies:
 
 ```python
 # /// script
@@ -41,19 +41,19 @@ A normal Python file with a metadata block at the top declaring its dependencies
 # ///
 ```
 
-`uv` — and `hf jobs uv run` — reads that block, builds the environment, and runs the file. One file, no `requirements.txt`, no setup. This is the standard [PEP 723](https://peps.python.org/pep-0723/) inline-script-metadata format — see the [uv scripts guide](https://docs.astral.sh/uv/guides/scripts/) to learn more.
+Normally, running someone's Python script means cloning their repo, making a virtual environment, and `pip install`-ing a `requirements.txt` first — and if your versions don't match theirs, it can still break. Here the dependencies live inside the file, in that comment block, so `uv` (and `hf jobs uv run`) reads them, installs exactly those versions into a throwaway environment, and runs the file — straight from a URL, with nothing to set up. This is the standard [PEP 723](https://peps.python.org/pep-0723/) inline-script-metadata format; see the [uv scripts guide](https://docs.astral.sh/uv/guides/scripts/) to learn more.
 
 ## Why UV scripts
 
-A self-contained, pinned script is the smallest *reliable* unit of work — which is what makes it a good building block for both people and agents:
+A self-contained, pinned script is easy to run and reuse, for a few reasons:
 
-- **Discrete & single-purpose** — one script, one job. That job can be a two-second transform or a multi-hour fine-tune; either way it's one self-contained unit you pick by reading a header, not a codebase.
-- **Self-describing** — the [PEP 723](https://peps.python.org/pep-0723/) dependency block, the docstring, and `--help` together declare what it needs and how to call it.
-- **Reproducible by construction** — dependencies are pinned *in the file*. No env drift, nothing to debug later, no "works on my machine."
+- **Discrete & single-purpose** — one script, one job. That job can be a two-second transform or a multi-hour fine-tune; either way it's one self-contained unit you pick by reading a header instead of a whole codebase.
+- **Self-describing** — the [PEP 723](https://peps.python.org/pep-0723/) dependency block, the docstring, and `--help` tell you what it needs and how to call it.
+- **Reproducible** — dependencies are pinned *in the file*, so there's no env drift and no "works on my machine."
 - **Composable** — recipes hand off through the Hub (usually a dataset in, a dataset or model out), so you can chain them into a pipeline.
-- **Runs anywhere** — `uv run` locally, `hf jobs uv run` for GPU, or anywhere `uv` is installed. Same file, same result.
+- **Runs anywhere** — `uv run` locally, `hf jobs uv run` for GPU, or anywhere `uv` is installed.
 
-**Built for agents, too.** Every recipe takes the same `input output` shape and is callable from a URL, so an AI agent can pick a tool from its header and run it with no setup. And on Jobs the agent runs **disposable, Hub-scoped managed compute** — ephemeral disk, I/O bounded by the token's repo permissions, a per-job cost ceiling — never arbitrary code on your machine. That sandboxing is the difference between "an agent *could* call this" and "I'd let an agent run this unattended."
+**Built for agents, too.** Every recipe takes its arguments in the same `input output` order and runs from a URL, so an AI agent can pick a tool from its header and run it with no setup. On Jobs the agent runs in a sandbox: a throwaway disk, access limited to what the token's repo permissions allow, and a cost cap per job — not arbitrary code on your machine.
 
 ## Recipes
 
@@ -83,20 +83,20 @@ PDFs / scans          →   OCR to markdown      →   dedup + stats        → 
 dataset-creation          ocr/glm-ocr.py           deduplication            build-atlas
 ```
 
-Each arrow is a Hub dataset; each box is one `hf jobs uv run` (or `uv run`) — and every box runs today from its Hub URL, even before it's migrated into this repo. A pipeline can just as well end in a *trained model* instead of another dataset. A human writes the chain as a shell script; an agent writes it as a plan — same scripts either way.
+Each arrow is a Hub dataset; each box is one `hf jobs uv run` (or `uv run`), and every box runs today from its Hub URL, even before it's migrated into this repo. A pipeline can also end in a *trained model* instead of another dataset. You can write the chain as a shell script, or an agent can generate it — the scripts are the same.
 
-## Run anywhere — and reach for Jobs when you need a GPU
+## Run anywhere; use Jobs for a GPU
 
 Every recipe runs the same way wherever `uv` is installed:
 
 ```bash
 uv run <script-url> [args]          # local — your CPU/GPU
-hf jobs uv run <script-url> [args]  # managed — HF Jobs is the easy GPU button
+hf jobs uv run <script-url> [args]  # managed — runs on a rented GPU, no setup
 ```
 
 Why reach for Jobs:
 
-- **Cheapest managed serverless GPU** — pay by the minute, only while the job runs.
+- **Pay by the minute** — you're billed only while the job runs.
 - **No infra** — `hf jobs uv run <url>` and you're done.
 - **Hub-native** — mount datasets/models/buckets with `-v hf://…`; write results straight back to the Hub. Running from the `https://huggingface.co/datasets/uv-scripts/…` URL also attributes usage to the recipe.
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,34 @@
 # uv-scripts-for-ai
 
-> **Single-purpose UV scripts for data & ML work — self-contained, version-pinned, and self-describing, so both you and your agents can run one in a command and chain many into a pipeline. Run them locally with `uv run`, or on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) for zero-setup GPU.**
+> **A UV script is the smallest reliable unit of data & ML work: one file, with its dependencies pinned inside it, that runs the same on your laptop or on a managed GPU. Run one in a command — `uv run` locally or `hf jobs uv run` on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) — and chain many into a pipeline.**
 
-Each recipe is a single [UV script](https://docs.astral.sh/uv/guides/scripts/): one Python file that declares its own dependencies inline. Nothing to clone, no environment to set up, no `requirements.txt`. The script *is* the unit — and because its deps are pinned in the file, it runs the same today as in six months, on your laptop or on managed GPU.
+Because each script is self-contained and self-describing, it's easy for **people and AI agents alike** to run and compose. No clone, no environment to set up, no `requirements.txt` — the script *is* the unit.
 
-Every recipe reads and writes the [Hugging Face Hub](https://huggingface.co/datasets): a dataset goes in, a dataset comes out.
+A **recipe** here is one such UV script: a single Python file that declares its own dependencies inline. Most read and write the [Hugging Face Hub](https://huggingface.co/datasets), so the Hub is the substrate that passes data from one step to the next.
 
 ## Quickstart
 
-**Test any recipe locally in two seconds** — the script declares its own deps, so `uv` builds the environment for you:
+**First, install [uv](https://docs.astral.sh/uv/getting-started/installation/)** — it's the only thing you install; every script brings its own Python dependencies:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+**Kick the tires** — run a recipe straight from its URL; `uv` reads its dependency block and builds the environment for you (a few seconds, no account needed):
 
 ```bash
 uv run https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py --help
 ```
 
-**Run it for real on a GPU** — point Hugging Face Jobs at the same URL; it runs on managed infrastructure, reading and writing straight from the Hub:
+**Run it for real on a GPU** — point Hugging Face Jobs at the same URL. Here `davanstrien/ufo-ColPali` is a small *public* image dataset you can use as-is; the output lands in your namespace:
 
 ```bash
 hf jobs uv run --flavor l4x1 \
   https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py \
-  your-username/my-images your-username/my-images-text
+  davanstrien/ufo-ColPali your-username/ufo-ocr
 ```
 
-No GPU of your own, no `pip install`. (Jobs needs a Hub account with a positive [credit balance](https://huggingface.co/settings/billing); a small CPU job costs ~$0.01/hr — run `hf jobs hardware` for current flavors and prices.)
-
-## Why UV scripts
-
-A self-contained, pinned script is the smallest *reliable* unit of work — which is exactly what makes it a good building block for both people and agents:
-
-- **Discrete & single-purpose** — one script does one task. You pick the right tool by reading a header, not a codebase.
-- **Self-describing** — the [PEP 723](https://peps.python.org/pep-0723/) dependency block, the docstring, and `--help` together declare everything needed to run it.
-- **Reproducible by construction** — dependencies are pinned *in the file*. No env drift, nothing to debug later, no "works on my machine."
-- **Composable** — each recipe is dataset-in → dataset-out, so the Hub is the glue. Chain several into a pipeline.
-- **Runs anywhere** — `uv run` locally, `hf jobs uv run` for GPU, or anywhere `uv` is installed. Same file, same result.
-
-### Good tools for agents
-
-The same properties make these scripts natural tools for AI agents: an agent can **discover** a recipe from its header, **run** it from a URL with no setup, and trust the result is **reproducible** because the environment is pinned. And on Jobs, the agent runs sandboxed managed compute — not arbitrary code on your machine.
+No GPU of your own, no `pip install`. (Jobs needs the `hf` CLI — `uv tool install huggingface_hub` — and a Hub account with a positive [credit balance](https://huggingface.co/settings/billing); a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors and prices.)
 
 ## What's a UV script?
 
@@ -51,6 +43,18 @@ A normal Python file with a metadata block at the top declaring its dependencies
 
 `uv` — and `hf jobs uv run` — reads that block, builds the environment, and runs the file. One file, no `requirements.txt`, no setup. This is the standard [PEP 723](https://peps.python.org/pep-0723/) inline-script-metadata format — see the [uv scripts guide](https://docs.astral.sh/uv/guides/scripts/) to learn more.
 
+## Why UV scripts
+
+A self-contained, pinned script is the smallest *reliable* unit of work — which is what makes it a good building block for both people and agents:
+
+- **Discrete & single-purpose** — one script, one job. That job can be a two-second transform or a multi-hour fine-tune; either way it's one self-contained unit you pick by reading a header, not a codebase.
+- **Self-describing** — the [PEP 723](https://peps.python.org/pep-0723/) dependency block, the docstring, and `--help` together declare what it needs and how to call it.
+- **Reproducible by construction** — dependencies are pinned *in the file*. No env drift, nothing to debug later, no "works on my machine."
+- **Composable** — recipes hand off through the Hub (usually a dataset in, a dataset or model out), so you can chain them into a pipeline.
+- **Runs anywhere** — `uv run` locally, `hf jobs uv run` for GPU, or anywhere `uv` is installed. Same file, same result.
+
+**Built for agents, too.** Every recipe takes the same `input output` shape and is callable from a URL, so an AI agent can pick a tool from its header and run it with no setup. And on Jobs the agent runs **disposable, Hub-scoped managed compute** — ephemeral disk, I/O bounded by the token's repo permissions, a per-job cost ceiling — never arbitrary code on your machine. That sandboxing is the difference between "an agent *could* call this" and "I'd let an agent run this unattended."
+
 ## Recipes
 
 | Domain | What it does | On the Hub |
@@ -64,27 +68,30 @@ A normal Python file with a metadata block at the top declaring its dependencies
 | **synthetic data** | Generate datasets with LLMs | [`synthetic-data`](https://huggingface.co/datasets/uv-scripts/synthetic-data) |
 | **inference** | Run any open LLM / VLM over a dataset | [`vllm`](https://huggingface.co/datasets/uv-scripts/vllm) · [`openai-oss`](https://huggingface.co/datasets/uv-scripts/openai-oss) · [`transformers-inference`](https://huggingface.co/datasets/uv-scripts/transformers-inference) |
 | **entity extraction** | NER / structured extraction over text | [`gliner`](https://huggingface.co/datasets/uv-scripts/gliner) |
+| ***…and more*** | *Training, evaluation, RAG indexing — migrating as they mature* | [`training`](https://huggingface.co/datasets/uv-scripts/training) · [`transformers-training`](https://huggingface.co/datasets/uv-scripts/transformers-training) |
 
 Only **[ocr/](ocr/)** lives in this repo so far — the others link to the [`uv-scripts`](https://huggingface.co/uv-scripts) Hugging Face org where they run today, and migrate here over time. (GitHub is the source of truth; each folder mirrors to its Hub dataset.)
 
+**What fits here:** any self-contained UV script for data or ML work on the Hub. OCR and dataset work are the current focus, but inference, evaluation, RAG indexing, and **training** (fine-tuning with TRL / `transformers`, producing a model) are all in scope. If it's one pinned script that reads from or writes to the Hub, it belongs.
+
 ## Compose a pipeline
 
-Because every recipe is dataset-in → dataset-out, you can chain them — the Hub passes data from one step to the next. A document-collection pipeline, end to end:
+Because recipes hand off through the Hub, you can chain them — each step's output dataset is the next step's input. A document-collection pipeline, end to end:
 
 ```
 PDFs / scans          →   OCR to markdown      →   dedup + stats        →   embed + visualise
 dataset-creation          ocr/glm-ocr.py           deduplication            build-atlas
 ```
 
-Each arrow is a Hub dataset; each box is one `hf jobs uv run` (or `uv run`). A human writes that as a shell script; an agent writes it as a plan — same scripts either way.
+Each arrow is a Hub dataset; each box is one `hf jobs uv run` (or `uv run`) — and every box runs today from its Hub URL, even before it's migrated into this repo. A pipeline can just as well end in a *trained model* instead of another dataset. A human writes the chain as a shell script; an agent writes it as a plan — same scripts either way.
 
-## Run anywhere — Jobs is the easy GPU button
+## Run anywhere — and reach for Jobs when you need a GPU
 
-Every recipe runs the same way wherever `uv` is:
+Every recipe runs the same way wherever `uv` is installed:
 
 ```bash
 uv run <script-url> [args]          # local — your CPU/GPU
-hf jobs uv run <script-url> [args]  # managed — HF Jobs picks up the GPU
+hf jobs uv run <script-url> [args]  # managed — HF Jobs is the easy GPU button
 ```
 
 Why reach for Jobs:


### PR DESCRIPTION
Reframes the root README around a sharper thesis, for feedback in the GitHub UI.

**The shift:** from *"a cookbook of scripts you run as Jobs"* → *"the UV script is the smallest reliable unit of data/ML work — for humans **and** agents — that runs anywhere; Jobs is the easy GPU button."*

Why:
- **Earns the repo name.** `for-ai` now means both *AI/ML tasks* and *AI agents as consumers* — a new "Good tools for agents" beat (discover by header, run by URL, reproducible because pinned, sandboxed on Jobs).
- **Jobs becomes a feature, not the premise.** Quickstart now shows both `uv run … --help` (test locally in 2s) and `hf jobs uv run` (GPU). More people star "portable reliable scripts" than "a Jobs cookbook" — and we keep the trackable HF-raw-URL invocation.
- **Sells the reliability story** you flagged: a new "Why UV scripts" section leads on pinned/reproducible-by-construction + self-describing + single-purpose.
- **Sells composability:** a "Compose a pipeline" section showing dataset-creation → ocr → dedup → build-atlas, every arrow a Hub dataset.
- **Links out to HF everywhere:** the recipes table now links each domain to its live `uv-scripts/<repo>` Hub page (they all exist today, even pre-migration).

Open questions for you (comment inline):
1. Is the hero thesis the right altitude, or still too far from Jobs?
2. "Good tools for agents" — keep as a sub-beat, or pull it up as its own top section?
3. Recipes table — domain groupings vs. one-row-per-repo?
4. Pipeline example — is dataset-creation → ocr → dedup → build-atlas the best showcase chain?

No content was changed on the Hub (root README isn't mirrored; sync workflows are path-filtered to `ocr/**`).
