### PR TITLE
Make vLLM OCR scripts run on Jobs: FlashInfer guard (default image) + documented image fallback

### DIFF
--- a/ocr/README.md
+++ b/ocr/README.md
@@ -60,7 +60,7 @@ _Sorted by model size:_
 | `nanonets-ocr2.py` | [Nanonets-OCR2-3B](https://huggingface.co/nanonets/Nanonets-OCR2-s) | 3B | vLLM | Next-gen, Qwen2.5-VL base |
 | `deepseek-ocr-vllm.py` | [DeepSeek-OCR](https://huggingface.co/deepseek-ai/DeepSeek-OCR) | 4B | vLLM | 5 resolution + 5 prompt modes |
 | `deepseek-ocr.py` | [DeepSeek-OCR](https://huggingface.co/deepseek-ai/DeepSeek-OCR) | 4B | Transformers | Same model, Transformers backend |
-| `deepseek-ocr2-vllm.py` | [DeepSeek-OCR-2](https://huggingface.co/deepseek-ai/DeepSeek-OCR-2) | 3B | vLLM | Newer, requires nightly vLLM |
+| `deepseek-ocr2-vllm.py` | [DeepSeek-OCR-2](https://huggingface.co/deepseek-ai/DeepSeek-OCR-2) | 3B | vLLM | Newer; needs nightly vLLM **+ the `vllm/vllm-openai` image** ([why](#if-a-vllm-script-crashes-at-startup-the-nvcc--nvrtc-error)) |
 | `nuextract3.py` | [NuExtract3](https://huggingface.co/numind/NuExtract3) | 4B | vLLM | Markdown OCR **+ schema-guided JSON extraction** (template/Pydantic). Needs `vllm/vllm-openai` image |
 | `qianfan-ocr.py` | [Qianfan-OCR](https://huggingface.co/baidu/Qianfan-OCR) | 4.7B | vLLM | #1 OmniDocBench v1.5 (93.12), Layout-as-Thought, 192 languages |
 | `olmocr2-vllm.py` | [olmOCR-2-7B](https://huggingface.co/allenai/olmOCR-2-7B-1025-FP8) | 7B | vLLM | 82.4% olmOCR-Bench |
@@ -105,6 +105,27 @@ hf jobs uv run --flavor l4x1 -s HF_TOKEN \
 ```
 
 Source/sink can be either an HF dataset repo OR an `hf://buckets/...` URL (auto-detected). Bucket output writes incremental zstd parquet shards via the buckets API — resumable across runs (snapshot-backed source listing) and no git/commit overhead. See the script's `--help` for all flags.
+
+## If a vLLM script crashes at startup (the `nvcc` / `nvrtc` error)
+
+The vLLM recipes run on the **default** Jobs image and carry a guard (`VLLM_USE_FLASHINFER_SAMPLER=0`) so they work there with the plain command. But some — especially nightly-vLLM ones — JIT-compile a CUDA kernel at engine init and crash on the default image with one of:
+
+```
+RuntimeError: Could not find nvcc and default cuda_home='/usr/local/cuda' doesn't exist
+nvrtc: error: failed to open libnvrtc-builtins.so...
+```
+
+Run those on the **`vllm/vllm-openai` image**, which ships the full CUDA toolkit. Add these flags to any recipe — they point `import vllm` at the image's CUDA-matched build:
+
+```bash
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+    --image vllm/vllm-openai --python /usr/bin/python3 \
+    -e PYTHONPATH=/usr/local/lib/python3.12/dist-packages \
+    https://huggingface.co/datasets/uv-scripts/ocr/raw/main/<script>.py \
+    INPUT OUTPUT --max-samples 10
+```
+
+This is **required** for a few scripts (e.g. `deepseek-ocr2-vllm.py`, `abot-ocr.py`, `nuextract3.py`) and a safe fallback for any vLLM recipe that crashes at startup. (It's also the more robust way to run any vLLM recipe — full CUDA toolkit, ABI-matched build. It isn't a speed-up: uv still reinstalls the script's deps either way.)
 
 ## Common Options
 

--- a/ocr/abot-ocr.py
+++ b/ocr/abot-ocr.py
@@ -49,6 +49,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/deepseek-ocr-vllm.py
+++ b/ocr/deepseek-ocr-vllm.py
@@ -48,6 +48,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 from vllm.model_executor.models.deepseek_ocr import NGramPerReqLogitsProcessor
 

--- a/ocr/deepseek-ocr2-vllm.py
+++ b/ocr/deepseek-ocr2-vllm.py
@@ -59,6 +59,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 from vllm.model_executor.models.deepseek_ocr import NGramPerReqLogitsProcessor
 

--- a/ocr/dots-mocr.py
+++ b/ocr/dots-mocr.py
@@ -53,6 +53,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image, UnidentifiedImageError
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/dots-ocr.py
+++ b/ocr/dots-ocr.py
@@ -45,6 +45,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/firered-ocr.py
+++ b/ocr/firered-ocr.py
@@ -39,6 +39,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/glm-ocr-bucket.py
+++ b/ocr/glm-ocr-bucket.py
@@ -56,6 +56,11 @@ from pathlib import Path
 
 import torch
 from PIL import Image
+import os
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")

--- a/ocr/glm-ocr-v2.py
+++ b/ocr/glm-ocr-v2.py
@@ -69,6 +69,10 @@ from datasets import load_dataset
 from huggingface_hub import CommitScheduler, DatasetCard, HfApi, login
 from PIL import Image
 from toolz import partition_all
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/glm-ocr.py
+++ b/ocr/glm-ocr.py
@@ -60,6 +60,10 @@ from datasets import load_dataset
 from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/hunyuan-ocr.py
+++ b/ocr/hunyuan-ocr.py
@@ -49,6 +49,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/lighton-ocr.py
+++ b/ocr/lighton-ocr.py
@@ -57,6 +57,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/lighton-ocr2.py
+++ b/ocr/lighton-ocr2.py
@@ -53,6 +53,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/nanonets-ocr.py
+++ b/ocr/nanonets-ocr.py
@@ -40,6 +40,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 from datetime import datetime
 

--- a/ocr/nanonets-ocr2.py
+++ b/ocr/nanonets-ocr2.py
@@ -44,6 +44,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/nuextract3.py
+++ b/ocr/nuextract3.py
@@ -70,6 +70,10 @@ from datasets import load_dataset
 from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/numarkdown-ocr.py
+++ b/ocr/numarkdown-ocr.py
@@ -47,6 +47,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/olmocr2-vllm.py
+++ b/ocr/olmocr2-vllm.py
@@ -50,6 +50,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 from vllm.sampling_params import GuidedDecodingParams
 

--- a/ocr/paddleocr-vl-1.6.py
+++ b/ocr/paddleocr-vl-1.6.py
@@ -62,6 +62,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/paddleocr-vl.py
+++ b/ocr/paddleocr-vl.py
@@ -56,6 +56,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/qianfan-ocr.py
+++ b/ocr/qianfan-ocr.py
@@ -47,6 +47,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)

--- a/ocr/rolm-ocr.py
+++ b/ocr/rolm-ocr.py
@@ -40,6 +40,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 from datetime import datetime
 

--- a/ocr/smoldocling-ocr.py
+++ b/ocr/smoldocling-ocr.py
@@ -45,6 +45,10 @@ from huggingface_hub import DatasetCard, login
 from PIL import Image, UnidentifiedImageError
 from toolz import partition_all
 from tqdm.auto import tqdm
+# Disable vLLM's FlashInfer sampler: it JIT-compiles a CUDA kernel needing nvcc, which the
+# default uv-script image lacks (engine init then crashes). Greedy OCR doesn't use it; this
+# lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## What

Cold-testing the OCR fleet found **4 of 6 high-impact recipes failing identically** on the default Jobs image:

```
RuntimeError: Could not find nvcc and default cuda_home='/usr/local/cuda' doesn't exist
```

Recent vLLM (even the *stable* `>=0.15.1` pins now resolve to **0.22.x**) defaults to the **FlashInfer top-k/top-p sampler**, which JIT-compiles a CUDA kernel needing `nvcc` — absent from the default `ghcr.io/astral-sh/uv:python3.12-bookworm` image — so the engine crashes at init. This is the **fleet-wide form of #9**, not glm-ocr-specific.

## Fix

Bake `os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")` before the vLLM import in **all 22 vLLM-engine OCR scripts**. vLLM falls back to the PyTorch-native sampler — no `nvcc` needed — so the **plain default-image command works again**. Greedy OCR (temperature 0) doesn't use the FlashInfer sampler, so output is unchanged; on the `vllm/vllm-openai` image it's a harmless no-op.

Validated previously on glm-ocr and the LFM recipes. Lint clean (the one pre-existing `E722` is in the untouched `deepseek-ocr.py`).

## Re-tests (posting results below)

Re-running the previously-failing scripts + the 7–8B models (OOM check on `l4x1`) from these fixed scripts on the default image.

Merging syncs to the live `uv-scripts/ocr` Hub page (additive — 22 scripts gain one guard line each).
