### PR TITLE
Add uv-recipes agent skill (+ internal refresh audit skill)

### DIFF
--- a/.claude/skills/refresh-uv-recipes/SKILL.md
+++ b/.claude/skills/refresh-uv-recipes/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: refresh-uv-recipes
+description: "Audit the shippable `uv-recipes` skill against the live Hugging Face Hub and `hf` CLI to catch drift. Use periodically — monthly, after an `hf`/`huggingface_hub`/vLLM release, or when adding a recipe family — to confirm the run pattern (INPUT_DATASET OUTPUT_DATASET, Hub-in/Hub-out), the `hf jobs uv run` flags, the hardware flavors, the default image, the discovery commands, and the task-family list in `skills/uv-recipes/SKILL.md` still match reality. Reports what is stale and proposes minimal edits; does not change the shippable skill without review."
+---
+
+# refresh-uv-recipes
+
+Verify that `skills/uv-recipes/SKILL.md` still reflects reality. The recipe *list* is
+self-refreshing (discovered live), so this audits only the baked-in **assumptions**.
+
+Copy this checklist and work through it; report results, propose edits, apply only after review.
+
+```
+- [ ] 1. Pattern still holds: recipes take INPUT_DATASET OUTPUT_DATASET and write to the Hub
+- [ ] 2. Invocation flags unchanged (--flavor/--secrets/--image/--timeout) AND setup still valid
+- [ ] 3. Hardware flavors + default image still as documented
+- [ ] 4. Discovery endpoints still return the expected shape
+- [ ] 5. Task families: any new org repo the description doesn't mention
+- [ ] 6. Gotchas still accurate; any new common failure to surface
+- [ ] 7. Best-practices conformance (description <1024 chars, 3rd person, refs 1 level deep)
+```
+
+**1. Core pattern.** Pick a few real recipes (via step 4) across families and read their headers,
+e.g. `uv run https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py --help`. Confirm
+`INPUT OUTPUT` arg order and Hub output (`push_to_hub`). If a new dominant pattern appeared
+(bucket-first I/O, multi-output, a non-dataset input), flag it — that changes the skill's premise.
+
+**2. Invocation & setup.**
+```bash
+hf jobs uv run --help     # do --flavor/--secrets/--image/--timeout still exist, same names?
+```
+Also confirm the setup still works: the `hf` install URL (`https://hf.co/cli/install.sh`) resolves,
+and `hf skills add` still installs the `hf-cli` skill (`hf skills list` to check the marketplace).
+
+**3. Hardware & image.**
+```bash
+hf jobs hardware          # do the flavor names in SKILL.md still exist?
+```
+Confirm the default image is still `astral-sh/uv:python3.12-bookworm` and the 30-min default timeout.
+
+**4. Discovery.**
+```bash
+curl -s "https://huggingface.co/api/datasets?author=uv-scripts" | jq -r '.[].id'
+curl -s "https://huggingface.co/api/datasets/uv-scripts/ocr/tree/main" | jq -r '.[].path | select(endswith(".py"))'
+```
+Both must still return repos / `.py` files. If the API shape changed, update the commands.
+
+**5. Coverage.** Diff the org repo list (step 4) against the task families named in the
+`uv-recipes` description. A new family (e.g. an audio-generation repo) → propose adding it to the
+description's trigger list so the skill activates for it.
+
+**6. Gotchas.** Re-check documented gotchas (the `vllm/vllm-openai` image note) and skim recent
+issues on the GitHub repo and the `uv-scripts/ocr` Hub repo for any new fleet-wide failure worth
+surfacing (this is how the FlashInfer issue would have been caught).
+
+**7. Conformance.** Description ≤1024 chars and third-person; SKILL.md body reasonable; any
+reference files one level deep.
+
+**Output.** A short verdict — *still sensible* / *needs update* — with a concrete diff per stale
+item. Apply edits to `skills/uv-recipes/SKILL.md` only after the maintainer confirms.

--- a/.github/ISSUE_TEMPLATE/recipe-failure.yml
+++ b/.github/ISSUE_TEMPLATE/recipe-failure.yml
@@ -54,7 +54,7 @@ body:
   - type: dropdown
     id: repro
     attributes:
-      label: Reproduces on the public sample davanstrien/ufo-ColPali with --max-samples 10?
+      label: Reproduces on a small public dataset (maintainer-runnable) with --max-samples 10?
       options:
         - "Yes"
         - "No (only my data)"

--- a/.github/ISSUE_TEMPLATE/recipe-failure.yml
+++ b/.github/ISSUE_TEMPLATE/recipe-failure.yml
@@ -1,0 +1,82 @@
+name: Recipe failure
+description: "Report a reproducible bug in a uv-scripts recipe (agents: read the checklist first)"
+title: "[recipe-bug] <recipe>.py: <short summary>"
+labels: ["agent-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before filing — most failures are environment or usage, not recipe bugs.** Check:
+        401 → add `--secrets HF_TOKEN`; OOM / CUDA → bigger `--flavor`; timeout → `--timeout 2h`;
+        `nvcc` / init crash → try `--image vllm/vllm-openai` (see the recipe header);
+        gated model → accept terms on the model page; nightly-wheel build blip → retry.
+        File only a **genuine, reproducible defect in the recipe itself**, and search existing issues first.
+        Also check the recipe `--help` / header and the [Jobs docs](https://huggingface.co/docs/hub/jobs) before filing.
+        Your reproducer must use **public data** and contain **no tokens or secrets** (redact the command and logs).
+  - type: input
+    id: recipe
+    attributes:
+      label: Recipe URL
+      placeholder: https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Reproducer command (public dataset, runnable as-is, tokens redacted)
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: flavor
+    attributes:
+      label: Flavor
+      placeholder: l4x1
+    validations:
+      required: true
+  - type: input
+    id: image
+    attributes:
+      label: Image
+      placeholder: default (astral-sh/uv:python3.12-bookworm), or vllm/vllm-openai
+  - type: textarea
+    id: error
+    attributes:
+      label: Error (last ~30 lines)
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: job
+    attributes:
+      label: Job ID or URL
+      placeholder: https://huggingface.co/jobs/<user>/<id>
+  - type: dropdown
+    id: repro
+    attributes:
+      label: Reproduces on the public sample davanstrien/ufo-ColPali with --max-samples 10?
+      options:
+        - "Yes"
+        - "No (only my data)"
+        - "Did not try"
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I already tried
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirms
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: This is a defect in the recipe, not a usage error / OOM / gated model / transient infra
+          required: true
+        - label: The reproducer uses a public dataset and runs as-is (no private data)
+          required: true
+        - label: I removed all tokens/secrets from the command and logs
+          required: true

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: uv-recipes
+description: "Run self-contained UV-script recipes over Hugging Face datasets on Hugging Face Jobs (`hf jobs uv run <url>`): OCR & document extraction, audio transcription, object detection & segmentation, NER/entity extraction, text & image classification, embeddings & dataset maps, synthetic data, and batch LLM/VLM inference. Each recipe reads a Hub dataset and writes a new one, so recipes chain into pipelines. Use when the user wants to batch-process a dataset at scale, pre-label data for human review, run a model over many images/audio/documents/rows, or build a data pipeline on Hugging Face — locally with `uv run` or on a managed GPU with `hf jobs uv run`. Recipes live at huggingface.co/uv-scripts (one dataset repo per task family); discover them and read a recipe's header before running."
+---
+
+# uv-recipes
+
+A recipe is one self-contained Python file (PEP 723 UV script) that reads a Hugging Face dataset and writes a new one. Recipes take arguments in the same `INPUT_DATASET OUTPUT_DATASET` order and run straight from a URL — no clone, no venv, no install. They're self-describing: the dependency block, docstring, and `--help` say what each needs.
+
+## Requires
+
+- **`uv`** — `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- **The `hf` CLI** — `curl -LsSf https://hf.co/cli/install.sh | bash -s` (or `uv tool install "huggingface_hub[cli]"`). Authenticate with `hf auth login`, or set `HF_TOKEN`. Jobs needs a Pro/Team/Enterprise account.
+- **Strongly recommended — install the Hugging Face skills:** `hf skills add`. This installs the **`hf-cli`** skill (the full `hf` surface: jobs, auth, repos, datasets, buckets, webhooks) and stays current via `hf skills update`. The two compose: `uv-recipes` picks and runs a recipe, `hf-cli` drives everything else on the Hub.
+
+## Run a recipe (prefer Jobs)
+
+Default to **Hugging Face Jobs** — managed GPU, no local CUDA, pay-per-second:
+
+```bash
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+  https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py \
+  INPUT_DATASET OUTPUT_DATASET --max-samples 10
+```
+
+- `--secrets HF_TOKEN` forwards the user's token so the job can write the output dataset back.
+- `--flavor` picks hardware: `cpu-basic`, `t4-small`, `l4x1` (good default for ≤3B vision models), `a10g-large`, `a100-large`. Run `hf jobs hardware` for live prices.
+- **Default timeout is 30 min.** For training or large batches add `--timeout 2h`.
+- Default image is `astral-sh/uv:python3.12-bookworm`. Some vLLM recipes need `--image vllm/vllm-openai` — **the recipe's docstring has the exact command; read it first.**
+- Track a run: `hf jobs logs <job-id>`, `hf jobs ps`, `hf jobs inspect <job-id>`.
+
+**Local alternative** (only if the machine has the hardware — most recipes need a CUDA GPU):
+`uv run <url> INPUT OUTPUT`. Inspect without running: `uv run <url> --help`.
+
+## Discover recipes (no fixed list — read it live)
+
+```bash
+# task families — one dataset repo per task
+curl -s "https://huggingface.co/api/datasets?author=uv-scripts" | jq -r '.[].id'
+
+# recipes inside a family
+curl -s "https://huggingface.co/api/datasets/uv-scripts/ocr/tree/main" \
+  | jq -r '.[].path | select(endswith(".py"))'
+
+# what a specific recipe needs: args, required image, output column
+uv run https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py --help
+```
+
+Repo name is the task family (e.g. `ocr`, `transcription`, `sam3`, `gliner`, `classification`, `build-atlas`); a few repos are utilities, not recipes. Prefer a smaller model first (0.3–1B on `l4x1`); scale up only if quality demands it.
+
+## Compose a pipeline
+
+Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model.
+
+## Pre-label, then review
+
+A recipe's prediction column is a set of **suggestions, not final labels**. To put a human in the loop, **build a small, task-specific review UI on the spot** — a single-file Gradio app or static HTML that shows each input beside its predicted label with an accept / edit control, writing corrections back to a Hub dataset. Tailor it to the task: image + markdown side-by-side for OCR, image with box overlay for detection, text with highlighted spans for NER. Keep it minimal.
+
+To spend review effort well (active learning), order the queue by informativeness first — by model **uncertainty** (low confidence from a `classification` recipe) or by **diversity** (embed with `build-atlas`, sample to cover the space). Review the most-informative first; optionally fine-tune on the verified labels and re-predict, repeating until predictions stop changing. A **scheduled job** or **webhook** can re-run pre-labelling as new data lands.
+
+## Rules that keep jobs working
+
+- Jobs disk is ephemeral — recipes write to the **Hub** (`push_to_hub`) or a **bucket** (`-v hf://…`), never local paths.
+- GPU recipes check `torch.cuda.is_available()` and exit clearly if missing — match `--flavor` to the recipe.
+- Test on `--max-samples 10` first.

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -28,6 +28,7 @@ hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
 - **Default timeout is 30 min.** For training or large batches add `--timeout 2h`.
 - Default image is `astral-sh/uv:python3.12-bookworm`. Some vLLM recipes need `--image vllm/vllm-openai` — **the recipe's docstring has the exact command; read it first.**
 - Track a run: `hf jobs logs <job-id>`, `hf jobs ps`, `hf jobs inspect <job-id>`.
+- Jobs concepts, hardware flavors, and pricing: https://huggingface.co/docs/hub/jobs
 
 **Local alternative** (only if the machine has the hardware — most recipes need a CUDA GPU):
 `uv run <url> INPUT OUTPUT`. Inspect without running: `uv run <url> --help`.
@@ -48,6 +49,18 @@ uv run https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py --help
 
 Repo name is the task family (e.g. `ocr`, `transcription`, `sam3`, `gliner`, `classification`, `build-atlas`); a few repos are utilities, not recipes. Prefer a smaller model first (0.3–1B on `l4x1`); scale up only if quality demands it.
 
+## Adapt a recipe
+
+A recipe is one readable file, so you can **copy and modify it** instead of only running it as-is — change the prompt, add or rename an output column, swap the model id, add a CLI flag or a row filter, or add a dependency to the PEP 723 block at the top. Fetch it, edit, and run the local copy (`hf jobs uv run` takes a local path or a URL; a local file is packaged into a temporary job repo):
+
+```bash
+curl -sLO https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py
+# edit glm-ocr.py — prompt, columns, model, deps …
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN ./glm-ocr.py INPUT OUTPUT --max-samples 10
+```
+
+Keep the inline dependency block valid (new deps install at runtime); update the docstring if you change behaviour; test on `--max-samples 10` first.
+
 ## Compose a pipeline
 
 Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model.
@@ -63,3 +76,19 @@ To spend review effort well (active learning), order the queue by informativenes
 - Jobs disk is ephemeral — recipes write to the **Hub** (`push_to_hub`) or a **bucket** (`-v hf://…`), never local paths.
 - GPU recipes check `torch.cuda.is_available()` and exit clearly if missing — match `--flavor` to the recipe.
 - Test on `--max-samples 10` first.
+
+## If a recipe fails
+
+Most failures are environment or usage, not recipe bugs — triage before reporting:
+
+- **401 / auth** → add `--secrets HF_TOKEN`, or run `hf auth login`.
+- **OOM / CUDA error** → flavor too small; bump `--flavor` (`l4x1` → `a10g-large` → `a100-large`).
+- **Hit the 30-min timeout** → add `--timeout 2h`.
+- **`nvcc` / engine-init crash** → try the recipe's documented `--image vllm/vllm-openai` fallback (see its header).
+- **Model gated / license error** → accept the terms on the model's Hub page.
+- **Transient build failure on a nightly wheel** → wait and retry.
+- **Check the docs** — the recipe's `--help` / header and the [Jobs docs](https://huggingface.co/docs/hub/jobs) for the exact invocation and known constraints.
+
+If it still fails, reproduce minimally: re-run with `--max-samples 10` on the public sample `davanstrien/ufo-ColPali` to confirm it's the recipe, not your data.
+
+**Only if that is a genuine, reproducible defect in the recipe itself**, open an issue at https://github.com/davanstrien/uv-scripts-for-ai/issues — but first **search existing issues** (one per distinct failure) and **confirm with the user**. The report must give a **full reproducer the maintainer can run as-is: a public input dataset** (e.g. `davanstrien/ufo-ColPali`) and the exact command — never the user's private data. **Redact every token/secret** from the command and logs. Include the recipe URL, flavor + image, the error tail, the job ID/URL, and what you already tried. Do **not** open issues for usage errors, flavor/OOM, gated models, or transient infra.

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -5,7 +5,7 @@ description: "Run self-contained UV-script recipes over Hugging Face datasets on
 
 # uv-recipes
 
-A recipe is one self-contained Python file (PEP 723 UV script) that reads a Hugging Face dataset and writes a new one. Recipes take arguments in the same `INPUT_DATASET OUTPUT_DATASET` order and run straight from a URL — no clone, no venv, no install. They're self-describing: the dependency block, docstring, and `--help` say what each needs.
+A recipe is one self-contained Python file (a [PEP 723](https://peps.python.org/pep-0723/) [UV script](https://docs.astral.sh/uv/guides/scripts/)) that reads a Hugging Face dataset and writes a new one. Recipes take arguments in the same `INPUT_DATASET OUTPUT_DATASET` order and run straight from a URL — no clone, no venv, no install. They're self-describing: the dependency block, docstring, and `--help` say what each needs.
 
 ## Requires
 
@@ -13,9 +13,9 @@ A recipe is one self-contained Python file (PEP 723 UV script) that reads a Hugg
 - **The `hf` CLI** — `curl -LsSf https://hf.co/cli/install.sh | bash -s` (or `uv tool install "huggingface_hub[cli]"`). Authenticate with `hf auth login`, or set `HF_TOKEN`. Jobs needs a Pro/Team/Enterprise account.
 - **Strongly recommended — install the Hugging Face skills:** `hf skills add`. This installs the **`hf-cli`** skill (the full `hf` surface: jobs, auth, repos, datasets, buckets, webhooks) and stays current via `hf skills update`. The two compose: `uv-recipes` picks and runs a recipe, `hf-cli` drives everything else on the Hub.
 
-## Run a recipe (prefer Jobs)
+## Run a recipe
 
-Default to **Hugging Face Jobs** — managed GPU, no local CUDA, pay-per-second:
+**Jobs is recommended, not required.** It gives a managed GPU — pay-per-second, no local CUDA — which matters because most recipes need a GPU you may not have locally. Run a recipe on Jobs:
 
 ```bash
 hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
@@ -30,8 +30,7 @@ hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
 - Track a run: `hf jobs logs <job-id>`, `hf jobs ps`, `hf jobs inspect <job-id>`.
 - Jobs concepts, hardware flavors, and pricing: https://huggingface.co/docs/hub/jobs
 
-**Local alternative** (only if the machine has the hardware — most recipes need a CUDA GPU):
-`uv run <url> INPUT OUTPUT`. Inspect without running: `uv run <url> --help`.
+**Or run locally** — the same file works with `uv run <url> INPUT OUTPUT` when your machine has the hardware it needs (usually a CUDA GPU). Inspect without running: `uv run <url> --help`.
 
 ## Discover recipes (no fixed list — read it live)
 
@@ -73,7 +72,7 @@ To spend review effort well (active learning), order the queue by informativenes
 
 ## Rules that keep jobs working
 
-- Jobs disk is ephemeral — recipes write to the **Hub** (`push_to_hub`) or a **bucket** (`-v hf://…`), never local paths.
+- Jobs disk is ephemeral — write to the Hub, never local paths. The default pattern is **a dataset in, a dataset out** (`push_to_hub`). For data you rewrite often (mutable, incremental writes, checkpoints, one file per item), use a [storage bucket](https://huggingface.co/docs/hub/storage-buckets) instead — mount one with `-v hf://buckets/<user>/<bucket>:/mnt`, or read/write `hf://buckets/…` paths via fsspec. See [buckets.md](buckets.md).
 - GPU recipes check `torch.cuda.is_available()` and exit clearly if missing — match `--flavor` to the recipe.
 - Test on `--max-samples 10` first.
 
@@ -89,6 +88,6 @@ Most failures are environment or usage, not recipe bugs — triage before report
 - **Transient build failure on a nightly wheel** → wait and retry.
 - **Check the docs** — the recipe's `--help` / header and the [Jobs docs](https://huggingface.co/docs/hub/jobs) for the exact invocation and known constraints.
 
-If it still fails, reproduce minimally: re-run with `--max-samples 10` on the public sample `davanstrien/ufo-ColPali` to confirm it's the recipe, not your data.
+If it still fails, reproduce minimally: re-run with `--max-samples 10` on a **small public dataset appropriate to the task** (e.g. `davanstrien/ufo-ColPali` for image/OCR recipes; a public audio set for transcription, a public text set for NER) to confirm it's the recipe, not your data.
 
-**Only if that is a genuine, reproducible defect in the recipe itself**, open an issue at https://github.com/davanstrien/uv-scripts-for-ai/issues — but first **search existing issues** (one per distinct failure) and **confirm with the user**. The report must give a **full reproducer the maintainer can run as-is: a public input dataset** (e.g. `davanstrien/ufo-ColPali`) and the exact command — never the user's private data. **Redact every token/secret** from the command and logs. Include the recipe URL, flavor + image, the error tail, the job ID/URL, and what you already tried. Do **not** open issues for usage errors, flavor/OOM, gated models, or transient infra.
+**Only if that is a genuine, reproducible defect in the recipe itself**, open an issue at https://github.com/davanstrien/uv-scripts-for-ai/issues — but first **search existing issues** (one per distinct failure) and **confirm with the user**. The report must give a **full reproducer the maintainer can run as-is: a public input dataset** (one appropriate to the task) and the exact command — never the user's private data. **Redact every token/secret** from the command and logs. Include the recipe URL, flavor + image, the error tail, the job ID/URL, and what you already tried. Do **not** open issues for usage errors, flavor/OOM, gated models, or transient infra.

--- a/skills/uv-recipes/buckets.md
+++ b/skills/uv-recipes/buckets.md
@@ -1,0 +1,43 @@
+# Buckets: mutable storage for data that changes a lot
+
+The default recipe pattern is **a Hub dataset in, a Hub dataset out** — versioned and easy to hand off between recipes. Reach for a **[storage bucket](https://huggingface.co/docs/hub/storage-buckets)** when data churns: incremental/streaming writes, checkpoints, scratch space, or one-file-per-item output. Buckets are S3-like mutable object storage on the Hub — overwrite or delete in place, no commit overhead.
+
+## Dataset or bucket?
+
+| Use a **dataset** | Use a **bucket** |
+|---|---|
+| One read, one write (recipe handoff) | Frequent / incremental writes, mutable scratch |
+| Versioned, shareable result | Checkpoints, partial results, one file per page |
+| The common case | Large or resumable jobs; data rewritten often |
+
+## Mount a bucket in a Job
+
+`hf jobs uv run` mounts volumes with `-v hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]` — datasets and spaces are read-only, **buckets are read+write**:
+
+```bash
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+  -v hf://buckets/<user>/<bucket>:/mnt \
+  https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr-bucket.py \
+  /mnt/input /mnt/output
+```
+
+The `ocr` family already ships bucket-aware recipes — **`glm-ocr-bucket.py`** and **`falcon-ocr-bucket.py`** read images/PDFs from a mounted bucket and write one `.md` per page. Read the recipe's `--help` for exact arguments.
+
+## Write to a bucket from Python (fsspec)
+
+A recipe that writes incrementally can use `hf://buckets/…` paths directly:
+
+```python
+batch_ds.to_parquet(f"hf://buckets/{user}/{bucket}/shard-{i:05d}.parquet")
+```
+
+Read the shards back and `push_to_hub` a clean dataset as the final step if you also want a versioned result.
+
+## Manage buckets (hf CLI)
+
+```bash
+hf buckets create <user>/<bucket>
+hf buckets list <user>/<bucket> --tree
+```
+
+More: the [storage buckets docs](https://huggingface.co/docs/hub/storage-buckets) and the `hf-cli` skill (`hf buckets --help`).


### PR DESCRIPTION
## What

Adds the repo's first **Agent Skill** — making the "built for agents" claim a thing you can point at, not just words.

- **`skills/uv-recipes/SKILL.md`** (shippable) — teaches an agent to run UV-script recipes over Hub datasets on **Hugging Face Jobs** (`hf jobs uv run <url>`). It:
  - **Discovers recipes live** from the `uv-scripts` org (`repo == task family`) and the recipe headers — no static catalog to drift out of date. This *is* the repo's "self-describing script" thesis.
  - Declares the **`hf` CLI** as a requirement and **strongly recommends `hf skills add`** (the `hf-cli` companion skill) for the full Hub surface.
  - Keeps the **quickstart** as the one worked example; covers pipelines and a tool-agnostic **pre-label → review / active-learning** loop (agent builds a small task-specific review UI rather than prescribing a labelling platform).
  - Is **task-organized**, so it already covers OCR *and* the families migrating in after it (transcription, detection, NER, classification, embeddings, …).

- **`.claude/skills/refresh-uv-recipes/SKILL.md`** (internal, dev-only) — a periodic audit of the assumptions the dynamic skill *can't* self-check: the `INPUT→OUTPUT` pattern, `hf jobs` flag names, hardware flavors, default image, discovery endpoints, and the task-family list. Run it after an `hf`/vLLM release or when adding a family.

## Design notes

- **Mirror-safe:** `skills/` is a new top-level folder with **no `sync-skills.yml` caller**, so it does **not** mirror to the Hub (consistent with AGENTS.md). The internal skill lives under `.claude/skills/` and is never shipped.
- **No leaks:** files reference only public resources (the `uv-scripts` org, `hf` CLI, the public Hub API). No tokens, no private `embeddings` repo, no local paths.
- All discovery commands in both files were verified live against the Hub API.

## Open decision

- **Name** — went with `uv-recipes` (matches the `uv-scripts` org). Trivial to rename to `hf-jobs-recipes` / `running-uv-recipes` in review if preferred.

## Suggested follow-ups (not in this PR)

- A one-line pointer from the root README's "Built for agents" paragraph to this skill (closes the discovery loop).
- Later: upstream `skills/uv-recipes/` to [`huggingface/skills`](https://github.com/huggingface/skills) for cross-agent reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
