### PR TITLE
Add Hugging Face follow badges (org + personal) to the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # uv-scripts-for-ai
 
+<a href="https://huggingface.co/uv-scripts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-md-dark.svg"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-md.svg" alt="Follow uv-scripts on Hugging Face"></picture></a>
+<a href="https://huggingface.co/davanstrien"><picture><source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-me-on-HF-md-dark.svg"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-me-on-HF-md.svg" alt="Follow davanstrien on Hugging Face"></picture></a>
+
 > **A UV script is a single Python file that declares its own dependencies inline — a *portable* unit you run with `uv run` where you have the hardware, or hand to `hf jobs uv run` on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) for a GPU. Chain several into a pipeline.**
 
 Each script carries its own dependencies, so people and agents can run one without cloning a repo, making a virtualenv, or installing a `requirements.txt` first.


### PR DESCRIPTION
Adds a two-badge row under the title linking to the **`uv-scripts` org** and to **`davanstrien`** on the Hub — so GitHub-star traffic has a one-click path to following on Hugging Face (the org-follow is the real funnel; the org page is also the README homepage).

### What's here
- Dark-mode-aware `<picture>` badges (swap with the viewer's theme on both GitHub and Hub cards), using HF's official assets from [`huggingface/badges`](https://huggingface.co/datasets/huggingface/badges):
  - `follow-us-on-hf-md` → links to `https://huggingface.co/uv-scripts`
  - `follow-me-on-HF-md` → links to `https://huggingface.co/davanstrien`
- Root README only — **not mirrored to the Hub**, so no sync workflow fires on this change.

### Why root-only (for now)
The org badge would also fit at the top of the mirrored `ocr/README.md` (the dataset card GitHub stars land on), but that's a Hub-facing change that syncs live on merge, and the card is currently tightly tidied/emoji-free. Proposing to fold a single **org** badge into `ocr/README.md` as part of the launch-polish pass rather than here — happy to add it to this PR instead if preferred.

### Note
There's no reliable one-click-follow URL param — linking the badge to the profile/org page (which carries the Follow button) is the documented pattern.