### PR TITLE
Add uv-scripts org follow badge to the OCR dataset card

### DIFF
--- a/ocr/README.md
+++ b/ocr/README.md
@@ -5,6 +5,8 @@ tags: [uv-script, ocr, extraction, vision-language-model, document-processing, h
 
 # OCR UV Scripts
 
+<a href="https://huggingface.co/uv-scripts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-md-dark.svg"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-md.svg" alt="Follow uv-scripts on Hugging Face"></picture></a>
+
 > Part of [uv-scripts](https://huggingface.co/uv-scripts) — self-contained UV scripts you run on Hugging Face Jobs in one command.
 
 A model zoo of OCR scripts — one per model — that add a `markdown` column to an image dataset. Pick a model from the table below, point it at your dataset, and run it on a GPU with one command. A few recipes do **structured extraction** instead — image *or* text → JSON given a schema (see [Structured extraction](#structured-extraction-image-or-text--json) below). Two more companions sit alongside: `pp-doclayout.py` detects layout regions (bboxes for text/title/table/figure/…) instead of text, and `ocr-vllm-judge.py` compares model outputs head-to-head.


### PR DESCRIPTION
Adds the **`follow-us-on-hf`** badge under the title of `ocr/README.md`, linking to the [`uv-scripts`](https://huggingface.co/uv-scripts) org — so the dataset card GitHub-star traffic lands on has a one-click path to following the org.

- Dark-mode-aware `<picture>` (HF renders this on the dataset card), org badge only — keeps the card on-brand (no personal-follow on an org repo).
- Sits just above the existing "Part of uv-scripts" line.

### Heads up — this folder is mirrored
`ocr/` syncs to `uv-scripts/ocr` on merge to `main`. The change is purely additive (one line in the README), so the superset gate passes and no Hub file is touched beyond the README update.