### PR TITLE
Mirror the org profile card from GitHub (org-card/ → uv-scripts/README)

### DIFF
--- a/.github/workflows/_sync-folder.yml
+++ b/.github/workflows/_sync-folder.yml
@@ -1,14 +1,27 @@
 name: _sync-folder
 
-# Reusable: gate (superset) + LFS guard + hub-sync for one folder → uv-scripts/<folder>.
-# Per-repo callers (sync-<repo>.yml) invoke this with the folder name; the logic lives here only.
+# Reusable: gate (superset) + LFS guard + hub-sync for one folder → a uv-scripts Hub repo.
+# Per-repo callers (sync-<repo>.yml) invoke this; the logic lives here only.
+# Defaults mirror a top-level folder to uv-scripts/<folder> as a dataset. The optional
+# repo_id / repo_type let a folder map to a differently-named repo or a non-dataset repo
+# (e.g. the org profile card: org-card/ → uv-scripts/README, a static Space).
 on:
   workflow_call:
     inputs:
       folder:
-        description: top-level folder = uv-scripts/<folder> Hub repo name
+        description: local top-level folder to mirror
         required: true
         type: string
+      repo_id:
+        description: target Hub repo id (default uv-scripts/<folder>)
+        required: false
+        type: string
+        default: ''
+      repo_type:
+        description: Hub repo type (dataset | space | model)
+        required: false
+        type: string
+        default: dataset
     secrets:
       HF_TOKEN:
         required: true
@@ -16,13 +29,15 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      REPO_ID: ${{ inputs.repo_id != '' && inputs.repo_id || format('uv-scripts/{0}', inputs.folder) }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Gate — folder must be a superset of the Hub repo (guards --delete="*")
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: bash ./tools/verify-superset.sh "${{ inputs.folder }}" "uv-scripts/${{ inputs.folder }}"
+        run: bash ./tools/verify-superset.sh "${{ inputs.folder }}" "$REPO_ID" "${{ inputs.repo_type }}"
 
       - name: Guard — no LFS pointers (would corrupt Hub binaries)
         run: |
@@ -34,7 +49,7 @@ jobs:
       - uses: huggingface/hub-sync@v0.1.0
         with:
           github_repo_id: ${{ github.repository }}
-          huggingface_repo_id: uv-scripts/${{ inputs.folder }}
-          repo_type: dataset          # required — action defaults to 'space'
+          huggingface_repo_id: ${{ env.REPO_ID }}
+          repo_type: ${{ inputs.repo_type }}
           subdirectory: ${{ inputs.folder }}
           hf_token: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/sync-org-card.yml
+++ b/.github/workflows/sync-org-card.yml
@@ -1,0 +1,15 @@
+name: Sync org card → HF
+on:
+  push:
+    branches: [main]
+    paths: ['org-card/**', '.github/workflows/sync-org-card.yml']
+
+jobs:
+  sync:
+    uses: ./.github/workflows/_sync-folder.yml
+    with:
+      folder: org-card
+      repo_id: uv-scripts/README
+      repo_type: space
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ absent from its GitHub folder is permanently deleted.** Therefore:
 
 `ocr/ → uv-scripts/ocr`, `sam3/ → uv-scripts/sam3`, … `subdirectory == folder == repo name`, so the mapping
 can't be mis-typed. Domain grouping for readers lives in the root `README.md`, not in folder nesting. Don't
-mirror the org's Spaces; don't add a folder for the private `embeddings` repo.
+mirror the org's *demo* Spaces; don't add a folder for the private `embeddings` repo. (One Space *is*
+mirrored — the org profile card: `org-card/` → `uv-scripts/README`, a static Space, via the reusable
+workflow's optional `repo_id` / `repo_type` inputs.)
 
 ## Script conventions
 

--- a/org-card/README.md
+++ b/org-card/README.md
@@ -1,0 +1,44 @@
+---
+title: README
+emoji: 📚
+colorFrom: red
+colorTo: indigo
+sdk: static
+pinned: false
+---
+
+# UV Scripts
+
+**Run a data or ML task over a Hugging Face dataset in one command — for humans and agents.**
+
+Each recipe is a single self-contained [UV script](https://docs.astral.sh/uv/guides/scripts/): dependencies are declared inline, so you run it straight from a URL with no clone, no virtualenv, no `pip install`. Run it locally with `uv run` where you have the hardware, or hand it to [Hugging Face Jobs](https://huggingface.co/docs/hub/jobs) for a managed GPU. Most recipes read a Hub dataset and write a new one, so they chain into pipelines.
+
+## Quickstart
+
+```bash
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+  https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py \
+  davanstrien/ufo-ColPali your-username/ufo-ocr --max-samples 10
+```
+
+One command → a new dataset with a `markdown` column. No GPU of your own needed (Jobs is pay-per-second). Works locally too with just `uv run`.
+
+## Browse recipes
+
+- **[ocr](https://huggingface.co/datasets/uv-scripts/ocr)** — document → text & structured data (30+ models)
+- **[sam3](https://huggingface.co/datasets/uv-scripts/sam3)** · **[object-detection](https://huggingface.co/datasets/uv-scripts/object-detection)** · **[vlm-object-detection](https://huggingface.co/datasets/uv-scripts/vlm-object-detection)** — detection & segmentation
+- **[transcription](https://huggingface.co/datasets/uv-scripts/transcription)** — audio → text
+- **[gliner](https://huggingface.co/datasets/uv-scripts/gliner)** — NER over text · **[classification](https://huggingface.co/datasets/uv-scripts/classification)** — text/image classification
+- **[build-atlas](https://huggingface.co/datasets/uv-scripts/build-atlas)** — embed a dataset & build an interactive map
+- **[vllm](https://huggingface.co/datasets/uv-scripts/vllm)** · **[openai-oss](https://huggingface.co/datasets/uv-scripts/openai-oss)** — batch LLM/VLM inference
+- **[synthetic-data](https://huggingface.co/datasets/uv-scripts/synthetic-data)** · **[dataset-creation](https://huggingface.co/datasets/uv-scripts/dataset-creation)** · **[dataset-stats](https://huggingface.co/datasets/uv-scripts/dataset-stats)**
+
+## Built for agents
+
+Every recipe takes its arguments in the same `input output` order and runs from a URL, so an agent can pick one from its header and run it with no setup. The cookbook ships a ready-to-use **agent skill** for discovering, running, and adapting recipes — see the GitHub repo.
+
+## Learn more
+
+- **[GitHub: davanstrien/uv-scripts-for-ai](https://github.com/davanstrien/uv-scripts-for-ai)** — the source of truth (these dataset repos mirror from it)
+- [Hugging Face Jobs docs](https://huggingface.co/docs/hub/jobs) — run `hf jobs hardware` for GPUs & pricing
+- [UV scripts guide](https://docs.astral.sh/uv/guides/scripts/)

--- a/org-card/README.md
+++ b/org-card/README.md
@@ -13,7 +13,19 @@ pinned: false
 
 Each recipe is a single self-contained [UV script](https://docs.astral.sh/uv/guides/scripts/): dependencies are declared inline, so you run it straight from a URL with no clone, no virtualenv, no `pip install`. Run it locally with `uv run` where you have the hardware, or hand it to [Hugging Face Jobs](https://huggingface.co/docs/hub/jobs) for a managed GPU. Most recipes read a Hub dataset and write a new one, so they chain into pipelines.
 
-## Quickstart
+## See every recipe (no GPU, no token)
+
+The lowest-friction start — just [uv](https://docs.astral.sh/uv/getting-started/installation/), runs locally in seconds:
+
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/list-recipes.py
+```
+
+It prints a runnable URL for every recipe in the org. Run any of them the same way: `uv run <url>` locally, or `hf jobs uv run <url>` on a GPU.
+
+## Run one for real
+
+The flagship is **[OCR](https://huggingface.co/datasets/uv-scripts/ocr)** — turn an image dataset into text & structured data, 30+ models. On a managed GPU (no hardware of your own; pay-per-second):
 
 ```bash
 hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
@@ -21,24 +33,35 @@ hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
   davanstrien/ufo-ColPali your-username/ufo-ocr --max-samples 10
 ```
 
-One command → a new dataset with a `markdown` column. No GPU of your own needed (Jobs is pay-per-second). Works locally too with just `uv run`.
+One command → a new dataset with a `markdown` column.
 
-## Browse recipes
+## For your coding agent
 
-- **[ocr](https://huggingface.co/datasets/uv-scripts/ocr)** — document → text & structured data (30+ models)
-- **[sam3](https://huggingface.co/datasets/uv-scripts/sam3)** · **[object-detection](https://huggingface.co/datasets/uv-scripts/object-detection)** · **[vlm-object-detection](https://huggingface.co/datasets/uv-scripts/vlm-object-detection)** — detection & segmentation
-- **[transcription](https://huggingface.co/datasets/uv-scripts/transcription)** — audio → text
-- **[gliner](https://huggingface.co/datasets/uv-scripts/gliner)** — NER over text · **[classification](https://huggingface.co/datasets/uv-scripts/classification)** — text/image classification
-- **[build-atlas](https://huggingface.co/datasets/uv-scripts/build-atlas)** — embed a dataset & build an interactive map
-- **[vllm](https://huggingface.co/datasets/uv-scripts/vllm)** · **[openai-oss](https://huggingface.co/datasets/uv-scripts/openai-oss)** — batch LLM/VLM inference
-- **[synthetic-data](https://huggingface.co/datasets/uv-scripts/synthetic-data)** · **[dataset-creation](https://huggingface.co/datasets/uv-scripts/dataset-creation)** · **[dataset-stats](https://huggingface.co/datasets/uv-scripts/dataset-stats)**
+Recipes are built to be agent-driven — same `input output` arg order, runnable from a URL, self-describing headers. Two prompts to paste into Claude Code, Cursor, or similar:
 
-## Built for agents
+**Try it now** — runs a real OCR job and hands back a dataset:
 
-Every recipe takes its arguments in the same `input output` order and runs from a URL, so an agent can pick one from its header and run it with no setup. The cookbook ships a ready-to-use **agent skill** for discovering, running, and adapting recipes — see the GitHub repo.
+```
+Using uv-scripts, OCR a sample dataset on Hugging Face Jobs:
+  hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+    https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr.py \
+    davanstrien/ufo-ColPali $MY_HF_USERNAME/ufo-ocr-test --max-samples 10
+Then open the output dataset and show me the `markdown` column.
+```
 
-## Learn more
+**Put it to work** — when you need data for a task:
 
-- **[GitHub: davanstrien/uv-scripts-for-ai](https://github.com/davanstrien/uv-scripts-for-ai)** — the full cookbook and how to contribute
-- [Hugging Face Jobs docs](https://huggingface.co/docs/hub/jobs) — run `hf jobs hardware` for GPUs & pricing
-- [UV scripts guide](https://docs.astral.sh/uv/guides/scripts/)
+```
+I need a dataset for <my task>. uv-scripts has recipes that create, OCR,
+transcribe, classify, deduplicate, and embed datasets on Hugging Face. List them:
+  uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/list-recipes.py
+Pick the one that fits, read its script header for the arguments, and run it with:
+  hf jobs uv run --flavor l4x1 --secrets HF_TOKEN <script-url> INPUT_DATASET OUTPUT_DATASET
+Each recipe reads a Hub dataset and writes a new one, so chain them as needed.
+```
+
+Prefer a packaged setup? The cookbook ships an **agent skill** for discovering and running recipes — see the [GitHub repo](https://github.com/davanstrien/uv-scripts-for-ai). Hugging Face also ships an [`hf` CLI skill for agents](https://huggingface.co/docs/hub/agents-cli). _(We'll refine these prompts over time.)_
+
+## More
+
+Every other recipe is in the list below — detection & segmentation, audio transcription, NER & classification, embeddings & atlas maps, batch LLM/VLM inference, synthetic data, and dataset creation. Or browse on **[GitHub](https://github.com/davanstrien/uv-scripts-for-ai)** · run `hf jobs hardware` for GPU flavors & pricing.

--- a/org-card/README.md
+++ b/org-card/README.md
@@ -39,6 +39,6 @@ Every recipe takes its arguments in the same `input output` order and runs from 
 
 ## Learn more
 
-- **[GitHub: davanstrien/uv-scripts-for-ai](https://github.com/davanstrien/uv-scripts-for-ai)** — the source of truth (these dataset repos mirror from it)
+- **[GitHub: davanstrien/uv-scripts-for-ai](https://github.com/davanstrien/uv-scripts-for-ai)** — the full cookbook and how to contribute
 - [Hugging Face Jobs docs](https://huggingface.co/docs/hub/jobs) — run `hf jobs hardware` for GPUs & pricing
 - [UV scripts guide](https://docs.astral.sh/uv/guides/scripts/)

--- a/tools/verify-superset.sh
+++ b/tools/verify-superset.sh
@@ -8,13 +8,14 @@
 # Runs both locally (after `git add <folder>`) and as a CI pre-step in the sync workflow.
 set -euo pipefail
 
-folder="${1:?usage: verify-superset.sh <folder> <hf_repo_id>}"
-repo="${2:?usage: verify-superset.sh <folder> <hf_repo_id>}"
+folder="${1:?usage: verify-superset.sh <folder> <hf_repo_id> [repo_type]}"
+repo="${2:?usage: verify-superset.sh <folder> <hf_repo_id> [repo_type]}"
+rtype="${3:-dataset}"   # dataset | space | model — selects the /api/<type>s tree endpoint
 tok="${HF_TOKEN:-$(hf auth token 2>/dev/null)}"
 
 code=$(curl -s -o /tmp/tree.json -w '%{http_code}' \
   -H "Authorization: Bearer $tok" \
-  "https://huggingface.co/api/datasets/$repo/tree/main?recursive=true")
+  "https://huggingface.co/api/${rtype}s/$repo/tree/main?recursive=true")
 
 case "$code" in
   404) echo "✅ OK — $repo doesn't exist yet (brand-new repo); nothing on the Hub to preserve."; exit 0 ;;


### PR DESCRIPTION
Mirrors the org profile card from GitHub (`org-card/` → the `uv-scripts/README` Space) via a new `sync-org-card.yml`, and reworks the card content.

### Card content — a discover → try → put-to-work ladder
Rather than re-listing every repo (which HF already shows in the repo grid below the card, and which drifts from the root README), the card is now an onboarding ladder:

1. **See every recipe** — `uv run …/jobs-utils/list-recipes.py` — zero friction, no GPU/token/account, runs locally in seconds.
2. **Run one for real** — the flagship OCR job on a managed GPU.
3. **For your coding agent** — two copy-paste prompts: a "try it now" (runs the OCR job → dataset back) and a "put it to work" (hands the agent the catalog when it needs data for a task), plus a link to the repo's agent skill + HF's `hf` CLI agent skill.

### ⚠️ Depends on #39 (merge that first)
The headline command links to `uv-scripts/jobs-utils/list-recipes.py`, which **#39** creates. Merge #39 first (so jobs-utils syncs and the URL resolves), then this.

### Note — mirrors to a Space
`org-card/` syncs to `uv-scripts/README` (repo_type **space**, not dataset). This PR also updates `_sync-folder.yml` + `verify-superset.sh` to handle the Space target. Closes #11.