### PR TITLE
Fix olmocr2-vllm.py import crash on vLLM 0.22.x (closes #14)

### DIFF
--- a/ocr/olmocr2-vllm.py
+++ b/ocr/olmocr2-vllm.py
@@ -55,7 +55,6 @@ from tqdm.auto import tqdm
 # lets the plain default-image command work. On the vllm/vllm-openai image it's a harmless no-op.
 os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
 from vllm import LLM, SamplingParams
-from vllm.sampling_params import GuidedDecodingParams
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -369,13 +368,25 @@ def main(
         "stop": ["<|im_end|>", "<|endoftext|>"],
     }
 
-    # Add guided decoding if requested (enforces YAML front matter structure)
+    # Add guided decoding if requested (enforces YAML front matter structure).
+    # vLLM 0.22.x renamed this API: GuidedDecodingParams (guided_decoding=) →
+    # StructuredOutputsParams (structured_outputs=). Import lazily + shim so the
+    # default path (guided_decoding=False) never touches the moved symbol.
     if guided_decoding:
         logger.info("Enabling guided decoding with YAML front matter regex")
-        guided_params = GuidedDecodingParams(
-            regex=r"---\nprimary_language: (?:[a-z]{2}|null)\nis_rotation_valid: (?:True|False|true|false)\nrotation_correction: (?:0|90|180|270)\nis_table: (?:True|False|true|false)\nis_diagram: (?:True|False|true|false)\n(?:---|---\n[\s\S]+)"
-        )
-        sampling_params_kwargs["guided_decoding"] = guided_params
+        front_matter_regex = r"---\nprimary_language: (?:[a-z]{2}|null)\nis_rotation_valid: (?:True|False|true|false)\nrotation_correction: (?:0|90|180|270)\nis_table: (?:True|False|true|false)\nis_diagram: (?:True|False|true|false)\n(?:---|---\n[\s\S]+)"
+        try:
+            from vllm.sampling_params import StructuredOutputsParams
+
+            sampling_params_kwargs["structured_outputs"] = StructuredOutputsParams(
+                regex=front_matter_regex
+            )
+        except ImportError:
+            from vllm.sampling_params import GuidedDecodingParams
+
+            sampling_params_kwargs["guided_decoding"] = GuidedDecodingParams(
+                regex=front_matter_regex
+            )
 
     sampling_params = SamplingParams(**sampling_params_kwargs)
 


### PR DESCRIPTION
Closes #14.

## The bug

`olmocr2-vllm.py` imported the structured-output class at the **top level**:
```python
from vllm.sampling_params import GuidedDecodingParams
```
vLLM 0.22.x renamed it (`GuidedDecodingParams` → `StructuredOutputsParams`), so this fired an `ImportError` **at module load** — crashing the recipe on the default image even though `--guided-decoding` defaults to **off**. So the common path was needlessly broken (surfaced by the #12 fleet re-test).

## The fix

- Drop the top-level import.
- Inside the `if guided_decoding:` block, apply the same compat shim `ocr-vllm-judge.py` already uses — try `StructuredOutputsParams` (vLLM ≥ 0.12, passed via `structured_outputs=`), fall back to `GuidedDecodingParams` (older, `guided_decoding=`). Here it's the **regex** variant (YAML front-matter), regex preserved byte-for-byte.

Net: the default OCR path never touches the moved symbol, and `--guided-decoding` works across vLLM versions.

## Validation

- `ruff check` clean; `py_compile` OK.
- Not GPU-re-tested here (olmOCR-2 is 7B → needs `a100-large`; on `l4x1` it OOMs per #12). The change is the same proven shim pattern as `ocr-vllm-judge.py`, and the default path is now identical in shape to the rest of the post-#12 fleet. Happy to run an `a100-large` smoke test if you want belt-and-braces before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
