### PR TITLE
Migrate dataset-stats + deduplication + iiif-tiles (CPU tooling)

### DIFF
--- a/.github/workflows/sync-dataset-stats.yml
+++ b/.github/workflows/sync-dataset-stats.yml
@@ -1,0 +1,13 @@
+name: Sync dataset-stats → HF
+on:
+  push:
+    branches: [main]
+    paths: ['dataset-stats/**', '.github/workflows/sync-dataset-stats.yml']
+
+jobs:
+  sync:
+    uses: ./.github/workflows/_sync-folder.yml
+    with:
+      folder: dataset-stats
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/sync-deduplication.yml
+++ b/.github/workflows/sync-deduplication.yml
@@ -1,0 +1,13 @@
+name: Sync deduplication → HF
+on:
+  push:
+    branches: [main]
+    paths: ['deduplication/**', '.github/workflows/sync-deduplication.yml']
+
+jobs:
+  sync:
+    uses: ./.github/workflows/_sync-folder.yml
+    with:
+      folder: deduplication
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/sync-iiif-tiles.yml
+++ b/.github/workflows/sync-iiif-tiles.yml
@@ -1,0 +1,13 @@
+name: Sync iiif-tiles → HF
+on:
+  push:
+    branches: [main]
+    paths: ['iiif-tiles/**', '.github/workflows/sync-iiif-tiles.yml']
+
+jobs:
+  sync:
+    uses: ./.github/workflows/_sync-folder.yml
+    with:
+      folder: iiif-tiles
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 | **entity extraction** | NER / structured extraction over text | [`gliner`](https://huggingface.co/datasets/uv-scripts/gliner) |
 | ***…and more*** | *Training, evaluation, RAG indexing — migrating as they mature* | [`training`](https://huggingface.co/datasets/uv-scripts/training) · [`transformers-training`](https://huggingface.co/datasets/uv-scripts/transformers-training) |
 
-So far **[ocr/](ocr/)**, **[sam3/](sam3/)**, **[transcription/](transcription/)**, **[build-atlas/](build-atlas/)**, **[vlm-object-detection/](vlm-object-detection/)**, **[gliner/](gliner/)**, and **[object-detection/](object-detection/)** live in this repo; the rest link to the [`uv-scripts`](https://huggingface.co/uv-scripts) Hugging Face org where they run today, and migrate here over time. (each folder mirrors to its Hub dataset repo.)
+Most recipes now live in this repo; the rest link to the [`uv-scripts`](https://huggingface.co/uv-scripts) Hugging Face org where they run today, and migrate here over time. (each folder mirrors to its Hub dataset repo.)
 
 **What fits here:** any self-contained UV script for data or ML work on the Hub. OCR and dataset work are the current focus, but inference, evaluation, RAG indexing, and **training** (fine-tuning with TRL / `transformers`, producing a model) are all in scope. If it's one pinned script that reads from or writes to the Hub, it belongs.
 

--- a/dataset-stats/.gitignore
+++ b/dataset-stats/.gitignore
@@ -1,0 +1,4 @@
+stats_output/
+*.parquet
+*.json
+__pycache__/

--- a/dataset-stats/README.md
+++ b/dataset-stats/README.md
@@ -1,0 +1,77 @@
+---
+viewer: false
+tags:
+  - uv-script
+  - dataset-statistics
+  - polars
+  - temporal-analysis
+  - hf-jobs
+license: apache-2.0
+---
+
+# Dataset Statistics
+
+UV scripts for analyzing HuggingFace datasets using streaming mode.
+
+## Scripts
+
+### `finepdfs-stats.py` - Temporal Educational Quality Analysis
+
+Analyze educational quality trends across CommonCrawl dumps using Polars streaming. Answers: **"Is the web getting more educational over time?"**
+
+**Features:**
+- Polars streaming (no download of 300GB+ dataset)
+- Temporal analysis across 106 CommonCrawl dumps (2013-2025)
+- ASCII chart visualizations
+- Uploads results to HF Hub with auto-generated dataset card
+- Supports single language or all 70+ languages
+
+**Quick Examples:**
+
+```bash
+# Quick test (10K samples)
+uv run https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \
+    --limit 10000 --show-plan
+
+# Analyze English PDFs
+uv run https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \
+    --output-repo username/my-stats
+
+# Analyze ALL 70+ languages
+uv run https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \
+    --all-languages --output-repo username/my-stats
+```
+
+**Run on HF Jobs (recommended for full dataset):**
+
+```bash
+hf jobs uv run \
+    -s HF_TOKEN \
+    -e HF_XET_HIGH_PERFORMANCE=1 \
+    https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \
+    -- --all-languages --output-repo username/finepdfs-temporal-stats
+```
+
+**Example output:** [davanstrien/finepdfs-temporal-stats-all](https://huggingface.co/datasets/davanstrien/finepdfs-temporal-stats-all)
+
+**Performance:**
+- 50M docs in ~14 minutes (~60K docs/sec)
+- Single scan using [Polars HF Hub integration](https://huggingface.co/docs/hub/datasets-polars)
+- Works on HF Jobs CPU instances
+
+## Related Scripts
+
+Check out other scripts in the [uv-scripts organization](https://huggingface.co/uv-scripts):
+- **dataset-creation**: Create datasets from PDFs and other formats
+- **vllm**: GPU-accelerated classification and inference
+- **ocr**: Document OCR using vision-language models
+
+## Why UV Scripts?
+
+UV scripts are self-contained Python scripts that:
+- Run with a single `uv run` command (no setup required)
+- Include all dependencies in PEP 723 inline metadata
+- Work seamlessly on both local machines and HF Jobs
+
+Learn more about UV: https://docs.astral.sh/uv/
+

--- a/dataset-stats/finepdfs-stats.py
+++ b/dataset-stats/finepdfs-stats.py
@@ -1,0 +1,546 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "polars>=1.31.0",
+#     "huggingface-hub",
+#     "datasets",
+#     "ascii-graph",
+# ]
+# ///
+"""
+Analyze educational quality trends across CommonCrawl dumps using Polars streaming.
+
+Answers: "Is the web getting more educational over time?"
+
+Demonstrates Polars HF Hub integration - process 50M+ docs without downloading 300GB+.
+
+Example usage:
+    # Analyze English PDFs (default)
+    uv run finepdfs-stats.py
+
+    # Analyze all 70+ languages
+    uv run finepdfs-stats.py --all-languages
+
+    # Quick test
+    uv run finepdfs-stats.py --limit 10000 --show-plan
+
+    # Save results to HF Hub
+    uv run finepdfs-stats.py --output-repo username/finepdfs-temporal-stats
+
+    # Run on HF Jobs
+    hf jobs uv run \\
+        -s HF_TOKEN \\
+        -e HF_XET_HIGH_PERFORMANCE=1 \\
+        https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \\
+        -- --output-repo username/stats
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import polars as pl
+from ascii_graph import Pyasciigraph
+from datasets import Dataset
+from huggingface_hub import HfApi, create_repo, list_repo_tree, login
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# Common language+script codes for finepdfs-edu
+COMMON_LANGUAGES = {
+    "eng_Latn": "English (Latin script)",
+    "fra_Latn": "French (Latin script)",
+    "deu_Latn": "German (Latin script)",
+    "spa_Latn": "Spanish (Latin script)",
+    "por_Latn": "Portuguese (Latin script)",
+    "ita_Latn": "Italian (Latin script)",
+    "nld_Latn": "Dutch (Latin script)",
+    "pol_Latn": "Polish (Latin script)",
+    "rus_Cyrl": "Russian (Cyrillic script)",
+    "zho_Hans": "Chinese (Simplified)",
+    "zho_Hant": "Chinese (Traditional)",
+    "jpn_Jpan": "Japanese",
+    "kor_Hang": "Korean",
+    "ara_Arab": "Arabic",
+    "hin_Deva": "Hindi (Devanagari)",
+}
+
+
+def list_available_languages(dataset_id: str) -> list[str]:
+    """List available language subsets in the dataset."""
+    try:
+        tree = list_repo_tree(dataset_id, path_in_repo="data", repo_type="dataset")
+        languages = [
+            item.path.replace("data/", "")
+            for item in tree
+            if item.path.startswith("data/")
+            and "/" not in item.path.replace("data/", "")
+        ]
+        return sorted(languages)
+    except Exception as e:
+        logger.warning(f"Could not list languages: {e}")
+        return list(COMMON_LANGUAGES.keys())
+
+
+def compute_temporal_stats(df: pl.LazyFrame, output_path: Path) -> pl.DataFrame:
+    """Single scan: compute stats grouped by dump for temporal analysis."""
+    query = df.group_by("dump").agg(
+        pl.len().alias("doc_count"),
+        pl.col("token_count").sum().alias("total_tokens"),
+        pl.col("fw_edu_scores").list.mean().mean().alias("avg_edu_score"),
+        (pl.col("fw_edu_scores").list.mean() >= 3).sum().alias("high_edu_count"),
+    )
+    query.sink_parquet(output_path, engine="streaming")
+    return pl.read_parquet(output_path)
+
+
+def compute_global_stats(temporal: pl.DataFrame) -> pl.DataFrame:
+    """Compute global stats from temporal breakdown."""
+    total = temporal["doc_count"].sum()
+    return pl.DataFrame(
+        {
+            "total_docs": [total],
+            "total_tokens": [temporal["total_tokens"].sum()],
+            "avg_edu_score": [
+                (temporal["avg_edu_score"] * temporal["doc_count"]).sum() / total
+            ],
+            "high_edu_rate": [temporal["high_edu_count"].sum() / total],
+            "num_dumps": [len(temporal)],
+        }
+    )
+
+
+def format_temporal_stats(temporal: pl.DataFrame) -> pl.DataFrame:
+    """Format temporal stats with high_edu_rate, sorted chronologically."""
+    return (
+        temporal.with_columns(
+            (pl.col("high_edu_count") / pl.col("doc_count")).alias("high_edu_rate")
+        )
+        .select(["dump", "doc_count", "avg_edu_score", "high_edu_rate"])
+        .sort(
+            "dump"
+        )  # Chronological order (CC-MAIN-2017-xx comes before CC-MAIN-2024-xx)
+    )
+
+
+def create_ascii_charts(temporal_stats: pl.DataFrame) -> str:
+    """Create ASCII bar charts showing temporal trends."""
+    # Extract year from dump name (CC-MAIN-2024-42 -> 2024)
+    # Group by year and average the values for cleaner display
+    yearly = (
+        temporal_stats.with_columns(
+            pl.col("dump").str.extract(r"CC-MAIN-(\d{4})", 1).alias("year")
+        )
+        .group_by("year")
+        .agg(
+            pl.col("doc_count").sum(),
+            pl.col("avg_edu_score").mean(),
+            pl.col("high_edu_rate").mean(),
+        )
+        .sort("year")
+    )
+
+    lines = []
+
+    # High edu rate chart (more dramatic differences)
+    data_rate = [
+        (row["year"], row["high_edu_rate"] * 100)
+        for row in yearly.iter_rows(named=True)
+    ]
+    graph = Pyasciigraph(line_length=60, float_format="{0:.1f}%")
+    lines.extend(graph.graph("High Educational Content (edu >= 3)", data_rate))
+
+    lines.append("")
+
+    # Avg edu score chart
+    data_score = [
+        (row["year"], row["avg_edu_score"]) for row in yearly.iter_rows(named=True)
+    ]
+    graph2 = Pyasciigraph(line_length=60, float_format="{0:.2f}")
+    lines.extend(graph2.graph("Average Educational Score", data_score))
+
+    return "\n".join(lines)
+
+
+def create_readme(
+    args,
+    global_stats: pl.DataFrame,
+    temporal_stats: pl.DataFrame,
+    scan_time: float,
+    ascii_charts: str,
+) -> str:
+    """Create README content for the stats dataset."""
+    stats = global_stats.to_dicts()[0]
+    total_docs = stats.get("total_docs", 0)
+    docs_per_sec = total_docs / scan_time if scan_time > 0 else 0
+
+    # Get first and last year averages for trend (more representative than single dumps)
+    yearly = (
+        temporal_stats.with_columns(
+            pl.col("dump").str.extract(r"CC-MAIN-(\d{4})", 1).alias("year")
+        )
+        .group_by("year")
+        .agg(
+            pl.col("doc_count").sum(),
+            pl.col("avg_edu_score").mean(),
+            pl.col("high_edu_rate").mean(),
+        )
+        .sort("year")
+    )
+    first_year = yearly.head(1).to_dicts()[0]
+    last_year = yearly.tail(1).to_dicts()[0]
+
+    scope = (
+        "all languages"
+        if args.all_languages
+        else COMMON_LANGUAGES.get(args.lang, args.lang)
+    )
+
+    return f"""---
+tags:
+  - uv-script
+  - statistics
+  - polars
+  - finepdfs-edu
+  - temporal-analysis
+license: odc-by
+configs:
+  - config_name: global_stats
+    data_files: global_stats/train-*.parquet
+  - config_name: temporal_stats
+    data_files: temporal_stats/train-*.parquet
+default_viewer_config: temporal_stats
+---
+
+# Is the Web Getting More Educational?
+
+Temporal analysis of educational quality in **{scope}** across {stats.get("num_dumps", 0)} CommonCrawl dumps.
+
+## Trend
+
+```
+{ascii_charts}
+```
+
+## Key Finding
+
+| Year | Avg Edu Score | High Edu Rate |
+|------|---------------|---------------|
+| {first_year["year"]} | {first_year["avg_edu_score"]:.2f} | {first_year["high_edu_rate"] * 100:.1f}% |
+| {last_year["year"]} | {last_year["avg_edu_score"]:.2f} | {last_year["high_edu_rate"] * 100:.1f}% |
+
+## Performance
+
+- **{total_docs:,} documents** processed in **{scan_time:.0f} seconds**
+- **{docs_per_sec:,.0f} docs/sec** using Polars streaming
+- Single scan, no full dataset download required
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Scope | {scope} |
+| Total Documents | {total_docs:,} |
+| Total Tokens | {stats.get("total_tokens", 0):,} |
+| Avg Edu Score | {stats.get("avg_edu_score", 0):.3f} |
+| High Edu Rate | {stats.get("high_edu_rate", 0) * 100:.1f}% |
+| CommonCrawl Dumps | {stats.get("num_dumps", 0)} |
+
+## Files
+
+- `global_stats` - Overall summary
+- `temporal_stats` - Per-dump breakdown (sorted chronologically)
+
+## Reproduce
+
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \\
+    {"--all-languages" if args.all_languages else f"--lang {args.lang}"} --output-repo your-username/stats
+```
+
+## Source
+
+- **Dataset**: [{args.source_dataset}](https://huggingface.co/datasets/{args.source_dataset})
+- **Script**: [uv-scripts/dataset-stats](https://huggingface.co/datasets/uv-scripts/dataset-stats)
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze educational quality trends across CommonCrawl dumps",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    parser.add_argument(
+        "--source-dataset",
+        type=str,
+        default="HuggingFaceFW/finepdfs-edu",
+        help="Source dataset (default: HuggingFaceFW/finepdfs-edu)",
+    )
+
+    parser.add_argument(
+        "--lang",
+        type=str,
+        default="eng_Latn",
+        help="Language+script code (default: eng_Latn)",
+    )
+
+    parser.add_argument(
+        "--all-languages",
+        action="store_true",
+        help="Analyze all languages (70+) instead of single language",
+    )
+
+    parser.add_argument(
+        "--show-plan",
+        action="store_true",
+        help="Show Polars query plan (demonstrates optimization)",
+    )
+
+    parser.add_argument(
+        "--list-languages",
+        action="store_true",
+        help="List available languages and exit",
+    )
+
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Limit to first N rows (for testing)",
+    )
+
+    parser.add_argument(
+        "--output-repo",
+        type=str,
+        help="HuggingFace dataset repository to upload results",
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="./stats_output",
+        help="Local directory for output files",
+    )
+
+    parser.add_argument(
+        "--hf-token",
+        type=str,
+        help="HuggingFace API token (or set HF_TOKEN env var)",
+    )
+
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Make the output dataset private",
+    )
+
+    args = parser.parse_args()
+
+    # Check for high-performance mode
+    if os.environ.get("HF_XET_HIGH_PERFORMANCE"):
+        logger.info("High-performance mode enabled (HF_XET_HIGH_PERFORMANCE=1)")
+
+    # List languages mode
+    if args.list_languages:
+        print(f"Available language+script codes for {args.source_dataset}:\n")
+        print("Common languages:")
+        for code, name in COMMON_LANGUAGES.items():
+            print(f"  {code:12} - {name}")
+        print("\nFetching full list from HF Hub...")
+        all_langs = list_available_languages(args.source_dataset)
+        print(f"\nAll available ({len(all_langs)} total):")
+        for lang in all_langs[:30]:  # Show first 30
+            name = COMMON_LANGUAGES.get(lang, "")
+            print(f"  {lang:12} {name}")
+        if len(all_langs) > 30:
+            print(f"  ... and {len(all_langs) - 30} more")
+        sys.exit(0)
+
+    # Build the parquet path
+    if args.all_languages:
+        source_path = f"hf://datasets/{args.source_dataset}/data/*/train/*.parquet"
+        scope_desc = "all languages"
+    else:
+        source_path = (
+            f"hf://datasets/{args.source_dataset}/data/{args.lang}/train/*.parquet"
+        )
+        scope_desc = f"{args.lang} ({COMMON_LANGUAGES.get(args.lang, 'unknown')})"
+
+    logger.info(f"Scanning: {source_path}")
+    logger.info(f"Scope: {scope_desc}")
+
+    # Create lazy frame - this doesn't load any data yet!
+    logger.info("Creating lazy query plan...")
+    df = pl.scan_parquet(source_path)
+
+    # Apply limit if specified
+    if args.limit:
+        logger.info(f"Limiting to first {args.limit:,} rows")
+        df = df.head(args.limit)
+
+    # Show query plan if requested
+    if args.show_plan:
+        # Build a sample query to show the plan
+        sample_query = df.select(
+            pl.len(),
+            pl.col("token_count").sum(),
+            pl.col("language").n_unique(),
+        )
+        print("\nQuery Plan (showing Polars optimization):")
+        print("=" * 60)
+        print(sample_query.explain())
+        print("=" * 60)
+        print("\nNote: Polars uses projection pushdown - only reads columns needed!")
+        print("The 'text' column is never loaded, making this very fast.\n")
+
+    # Create output directory
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Single scan: compute temporal stats
+    logger.info("Computing temporal stats (single scan)...")
+    start = time.perf_counter()
+    temporal_path = output_dir / "temporal_stats.parquet"
+    temporal_raw = compute_temporal_stats(df, temporal_path)
+    scan_time = time.perf_counter() - start
+    logger.info(f"Scan complete in {scan_time:.2f}s - {len(temporal_raw)} dumps")
+
+    # Compute stats
+    global_stats = compute_global_stats(temporal_raw)
+    temporal_stats = format_temporal_stats(temporal_raw)
+
+    # Save
+    global_stats.write_parquet(output_dir / "global_stats.parquet")
+    temporal_stats.write_parquet(output_dir / "temporal_stats.parquet")
+
+    # Print results
+    total_docs = global_stats["total_docs"][0]
+    docs_per_sec = total_docs / scan_time if scan_time > 0 else 0
+
+    print("\n" + "=" * 70)
+    print("IS THE WEB GETTING MORE EDUCATIONAL?")
+    print("=" * 70)
+
+    print(f"\nScope: {scope_desc}")
+    print(f"Dataset: {args.source_dataset}")
+
+    print("\n" + "-" * 70)
+    print("GLOBAL STATS")
+    print("-" * 70)
+    print(global_stats)
+
+    print("\n" + "-" * 70)
+    print(f"TEMPORAL TREND ({len(temporal_stats)} CommonCrawl dumps)")
+    print("-" * 70)
+    # Show first 5 and last 5
+    if len(temporal_stats) > 10:
+        print("Earliest dumps:")
+        print(temporal_stats.head(5))
+        print("\n...")
+        print("\nLatest dumps:")
+        print(temporal_stats.tail(5))
+    else:
+        print(temporal_stats)
+
+    # Create ASCII charts
+    ascii_charts = create_ascii_charts(temporal_stats)
+    print("\n" + "-" * 70)
+    print("TREND VISUALIZATION")
+    print("-" * 70)
+    print(ascii_charts)
+
+    print("\n" + "-" * 70)
+    print("PERFORMANCE")
+    print("-" * 70)
+    print(f"Scan time: {scan_time:.2f}s")
+    print(f"Documents: {total_docs:,}")
+    print(f"Throughput: {docs_per_sec:,.0f} docs/sec")
+
+    logger.info(f"Results saved to: {output_dir}")
+
+    # Upload to HF Hub if requested
+    if args.output_repo:
+        hf_token = args.hf_token or os.environ.get("HF_TOKEN")
+        if hf_token:
+            login(token=hf_token)
+
+        api = HfApi(token=hf_token)
+
+        logger.info(f"Creating/updating dataset repository: {args.output_repo}")
+        create_repo(
+            args.output_repo,
+            repo_type="dataset",
+            private=args.private,
+            token=hf_token,
+            exist_ok=True,
+        )
+
+        # Upload each as a dataset config
+        configs = [
+            ("global_stats", global_stats),
+            ("temporal_stats", temporal_stats),
+        ]
+
+        for config_name, stats_df in configs:
+            logger.info(f"Uploading {config_name}...")
+            ds = Dataset.from_polars(stats_df)
+            ds.push_to_hub(
+                args.output_repo,
+                config_name=config_name,
+                token=hf_token,
+                private=args.private,
+            )
+            time.sleep(1)  # Avoid 409 conflicts
+
+        # Upload README
+        readme_content = create_readme(
+            args, global_stats, temporal_stats, scan_time, ascii_charts
+        )
+        api.upload_file(
+            path_or_fileobj=readme_content.encode(),
+            path_in_repo="README.md",
+            repo_id=args.output_repo,
+            repo_type="dataset",
+            token=hf_token,
+        )
+
+        dataset_url = f"https://huggingface.co/datasets/{args.output_repo}"
+        logger.info(f"Dataset uploaded: {dataset_url}")
+        print(f"\nResults uploaded to: {dataset_url}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print("Is the Web Getting More Educational?")
+        print("=" * 40)
+        print("\nAnalyze educational quality trends across CommonCrawl dumps")
+        print("using Polars streaming - no download needed!\n")
+        print("Example commands:\n")
+        print("# Quick test:")
+        print("uv run finepdfs-stats.py --limit 10000\n")
+        print("# Analyze English PDFs:")
+        print("uv run finepdfs-stats.py\n")
+        print("# Analyze ALL 70+ languages:")
+        print("uv run finepdfs-stats.py --all-languages\n")
+        print("# Show query plan (see Polars optimization):")
+        print("uv run finepdfs-stats.py --show-plan --limit 1000\n")
+        print("# Save results to HF Hub:")
+        print("uv run finepdfs-stats.py --output-repo username/temporal-stats\n")
+        print("# Run on HF Jobs:")
+        print("hf jobs uv run \\")
+        print("    -s HF_TOKEN \\")
+        print("    -e HF_XET_HIGH_PERFORMANCE=1 \\")
+        print(
+            "    https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/finepdfs-stats.py \\"
+        )
+        print("    -- --output-repo username/stats")
+        sys.exit(0)
+
+    main()

--- a/dataset-stats/long-context-pdfs.py
+++ b/dataset-stats/long-context-pdfs.py
@@ -1,0 +1,157 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "polars>=1.0",
+#     "datasets",
+# ]
+# ///
+"""
+Extract long-context, high-quality PDFs from finepdfs.
+
+Creates a curated subset of long documents with high OCR quality -
+useful for long-context model training.
+
+Examples:
+    # Quick test (Welsh)
+    uv run long-context-pdfs.py --lang cym_Latn --limit 100
+
+    # English long docs
+    uv run long-context-pdfs.py --lang eng_Latn --output user/finepdfs-eng-long
+
+    # All Latin scripts
+    uv run long-context-pdfs.py --lang "*_Latn" --output user/finepdfs-long-context
+
+    # HF Jobs (memory-efficient with small chunk size)
+    hf jobs uv run \\
+        -s HF_TOKEN \\
+        https://huggingface.co/datasets/uv-scripts/dataset-stats/raw/main/long-context-pdfs.py \\
+        -- --lang eng_Latn --output user/finepdfs-eng-long
+"""
+
+import argparse
+import tempfile
+from pathlib import Path
+
+import polars as pl
+from datasets import Dataset
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract long-context high-quality PDFs"
+    )
+    parser.add_argument(
+        "--lang",
+        type=str,
+        default="cym_Latn",
+        help="Language code or glob pattern (default: cym_Latn, use '*_Latn' for all Latin)",
+    )
+    parser.add_argument(
+        "--min-tokens",
+        type=int,
+        default=10000,
+        help="Minimum token count (default: 10000)",
+    )
+    parser.add_argument(
+        "--min-lid-score",
+        type=float,
+        default=0.8,
+        help="Minimum language ID score (default: 0.8)",
+    )
+    parser.add_argument("--limit", type=int, help="Limit rows")
+    parser.add_argument("--output", type=str, help="Output dataset repo")
+    parser.add_argument("--private", action="store_true")
+
+    args = parser.parse_args()
+
+    source = f"hf://datasets/HuggingFaceFW/finepdfs/data/{args.lang}/train/*.parquet"
+
+    print("=" * 60)
+    print("Long-Context High-Quality PDF Extraction")
+    print("=" * 60)
+    print(f"Source: {source}")
+    print("Filters:")
+    print(f"  - token_count >= {args.min_tokens}")
+    print(f"  - page_average_lid_score >= {args.min_lid_score}")
+    print("  - extractor == 'docling'")
+    if args.limit:
+        print(f"  - limit: {args.limit}")
+    print("=" * 60)
+
+    # Build query - simpler filters first, OCR quality filter can be tricky
+    lf = (
+        pl.scan_parquet(source)
+        .filter(
+            (pl.col("token_count") >= args.min_tokens)
+            & (pl.col("page_average_lid_score") >= args.min_lid_score)
+            & (pl.col("extractor") == "docling")
+        )
+        .select(
+            [
+                "id",
+                "url",
+                "text",
+                "language",
+                "token_count",
+                "dump",
+                "page_average_lid_score",
+            ]
+        )
+    )
+
+    if args.limit:
+        lf = lf.limit(args.limit)
+
+    # Preview
+    print("\nPreviewing...")
+    preview = lf.limit(5).collect()
+    print(f"Sample rows: {len(preview)}")
+    if len(preview) > 0:
+        print(preview.select(["language", "token_count", "page_average_lid_score"]))
+    else:
+        print("No rows matched! Try lowering thresholds.")
+        return
+
+    if not args.output:
+        print("\nNo --output specified. Use --output to push to Hub.")
+        return
+
+    # Rebuild query for streaming to parquet
+    lf = (
+        pl.scan_parquet(source)
+        .filter(
+            (pl.col("token_count") >= args.min_tokens)
+            & (pl.col("page_average_lid_score") >= args.min_lid_score)
+            & (pl.col("extractor") == "docling")
+        )
+        .select(
+            [
+                "id",
+                "url",
+                "text",
+                "language",
+                "token_count",
+                "dump",
+                "page_average_lid_score",
+            ]
+        )
+    )
+    if args.limit:
+        lf = lf.limit(args.limit)
+
+    # Use sink_parquet for true streaming (minimal memory)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "data.parquet"
+        print("\nStreaming to parquet (sink_parquet)...")
+        lf.sink_parquet(output_path)
+
+        print(f"\nLoading parquet and pushing to {args.output}...")
+        ds = Dataset.from_parquet(str(output_path))
+        print(f"Dataset: {len(ds)} rows")
+        ds.push_to_hub(args.output, private=args.private)
+
+    print(f"\nDone! https://huggingface.co/datasets/{args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/deduplication/README.md
+++ b/deduplication/README.md
@@ -1,0 +1,25 @@
+---
+viewer: false
+tags: [uv-script, deduplication, semantic-similarity, data-processing, hf-jobs]
+---
+
+# Semantic Deduplication UV Script
+
+> Part of [uv-scripts](https://huggingface.co/uv-scripts) — self-contained UV scripts you run locally or on Hugging Face Jobs in one command.
+
+Remove duplicate / near-duplicate text samples from a Hugging Face dataset by semantic similarity — clean training data and prevent train/test leakage. Uses [SemHash](https://github.com/MinishLab/semhash) with Model2Vec embeddings: **CPU-optimized, no GPU required.**
+
+## Quick start
+
+```bash
+# CPU is enough — run on Hugging Face Jobs
+hf jobs uv run --flavor cpu-upgrade --secrets HF_TOKEN \
+    https://huggingface.co/datasets/uv-scripts/deduplication/raw/main/semantic-dedupe.py \
+    your-input-dataset text your-output-dataset
+
+# or locally
+uv run https://huggingface.co/datasets/uv-scripts/deduplication/raw/main/semantic-dedupe.py \
+    your-input-dataset text your-output-dataset
+```
+
+Arguments are `INPUT_DATASET TEXT_COLUMN OUTPUT_DATASET`. Tune with `--threshold` (similarity cutoff) and `--max-samples` (for testing); run with `--help` for all options.

--- a/deduplication/semantic-dedupe.py
+++ b/deduplication/semantic-dedupe.py
@@ -1,0 +1,268 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "semhash",
+#     "datasets",
+#     "huggingface-hub",
+#     "hf-transfer",
+# ]
+# ///
+
+"""
+Semantic deduplication for Hugging Face datasets using SemHash.
+
+This script removes duplicate or near-duplicate text samples from datasets based on
+semantic similarity, helping to clean training data and prevent train/test leakage.
+
+SemHash is CPU-optimized and uses Model2Vec embeddings that are 500x faster on CPU
+than traditional transformers. No GPU required!
+
+Example usage:
+    # Basic deduplication
+    uv run semantic-dedupe.py username/dataset text username/dataset-deduped
+
+    # With custom threshold and max samples for testing
+    uv run semantic-dedupe.py username/dataset text username/dataset-deduped \\
+        --threshold 0.85 --max-samples 1000
+
+    # Using HF Jobs (CPU is sufficient)
+    hf jobs uv run --flavor cpu-4x-xlarge \\
+        -e HF_TOKEN=$(python3 -c "from huggingface_hub import get_token; print(get_token())") \\
+        https://huggingface.co/datasets/uv-scripts/deduplication/raw/main/semantic-dedupe.py \\
+        username/dataset text username/dataset-deduped
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+from typing import Optional
+
+from datasets import Dataset, load_dataset
+from huggingface_hub import DatasetCard, login
+from semhash import SemHash
+
+# Enable fast transfers
+os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Deduplicate a dataset using semantic similarity",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Basic usage
+  uv run semantic-dedupe.py imdb text imdb-deduped
+
+  # With options
+  uv run semantic-dedupe.py squad question squad-deduped --threshold 0.85 --method duplicates
+
+  # Test with small sample
+  uv run semantic-dedupe.py large-dataset text test-dedup --max-samples 100
+        """,
+    )
+    
+    parser.add_argument("dataset", help="Input dataset ID (e.g., 'imdb' or 'username/dataset')")
+    parser.add_argument("column", help="Text column to deduplicate on")
+    parser.add_argument("output_repo", help="Output dataset repository name")
+    
+    parser.add_argument(
+        "--split",
+        default="train",
+        help="Dataset split to process (default: train)",
+    )
+    parser.add_argument(
+        "--method",
+        choices=["duplicates", "outliers", "representatives"],
+        default="duplicates",
+        help="Deduplication method (default: duplicates)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.9,
+        help="Similarity threshold for duplicates (default: 0.9)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Batch size for processing (default: 64)",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        help="Maximum number of samples to process (for testing)",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Create private dataset repository",
+    )
+    parser.add_argument(
+        "--hf-token",
+        default=os.environ.get("HF_TOKEN"),
+        help="Hugging Face API token (defaults to HF_TOKEN env var)",
+    )
+    
+    return parser.parse_args()
+
+
+def create_dataset_card(
+    original_dataset: str,
+    column: str,
+    method: str,
+    threshold: float,
+    original_size: int,
+    deduped_size: int,
+) -> str:
+    """Create a dataset card with deduplication information."""
+    reduction_pct = ((original_size - deduped_size) / original_size) * 100
+    
+    return f"""---
+viewer: false
+tags:
+- deduplication
+- semhash
+- uv-script
+---
+
+# Deduplicated {original_dataset}
+
+This dataset is a deduplicated version of [{original_dataset}](https://huggingface.co/datasets/{original_dataset}).
+
+## Deduplication Details
+
+- **Method**: {method}
+- **Column**: `{column}`
+- **Threshold**: {threshold}
+- **Original size**: {original_size:,} samples
+- **Deduplicated size**: {deduped_size:,} samples
+- **Reduction**: {reduction_pct:.1f}%
+- **Date**: {datetime.now().strftime("%Y-%m-%d %H:%M UTC")}
+
+## Method Description
+
+{get_method_description(method)}
+
+## How to Use
+
+```python
+from datasets import load_dataset
+
+# Load the deduplicated dataset
+dataset = load_dataset("{os.environ.get('HF_USERNAME', 'username')}/{os.path.basename(original_dataset)}-deduped")
+```
+
+## Reproduce
+
+This dataset was created using the [uv-scripts/deduplication](https://huggingface.co/datasets/uv-scripts/deduplication) tool:
+
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/deduplication/raw/main/semantic-dedupe.py \\
+    {original_dataset} {column} {os.path.basename(original_dataset)}-deduped \\
+    --method {method} --threshold {threshold}
+```
+
+Generated with 🤖 UV Scripts
+"""
+
+
+def get_method_description(method: str) -> str:
+    """Get description for deduplication method."""
+    descriptions = {
+        "duplicates": "Removes semantic duplicates by finding samples with high similarity scores above the threshold.",
+        "outliers": "Removes outlier samples that have low similarity to other samples in the dataset.",
+        "representatives": "Keeps only representative samples, removing both duplicates and outliers.",
+    }
+    return descriptions.get(method, "Unknown method")
+
+
+def main():
+    args = parse_args()
+    
+    # Authenticate
+    if args.hf_token:
+        login(args.hf_token)
+    else:
+        print("Warning: No HF token provided. Using cached credentials or anonymous mode.")
+    
+    # Load dataset
+    print(f"Loading dataset: {args.dataset}")
+    dataset = load_dataset(args.dataset, split=args.split)
+    
+    # Apply max samples if specified
+    if args.max_samples:
+        dataset = dataset.select(range(min(args.max_samples, len(dataset))))
+        print(f"Limited to {len(dataset)} samples for testing")
+    
+    original_size = len(dataset)
+    
+    # Check if column exists
+    if args.column not in dataset.column_names:
+        print(f"Error: Column '{args.column}' not found in dataset")
+        print(f"Available columns: {', '.join(dataset.column_names)}")
+        sys.exit(1)
+    
+    # Convert dataset to records (preserves all columns)
+    print("Converting dataset to records...")
+    records = [dict(row) for row in dataset]
+    
+    # Initialize SemHash
+    print("Initializing SemHash (CPU-optimized)...")
+    semhash = SemHash.from_records(records=records, columns=[args.column])
+    
+    # Perform deduplication
+    print(f"Performing {args.method} deduplication on '{args.column}' column...")
+    
+    if args.method == "duplicates":
+        result = semhash.self_deduplicate(threshold=args.threshold)
+    elif args.method == "outliers":
+        result = semhash.self_filter_outliers()
+    elif args.method == "representatives":
+        result = semhash.self_find_representative()
+    else:
+        raise ValueError(f"Unknown method: {args.method}")
+    
+    # Get deduplicated records (all columns preserved)
+    deduplicated_records = result.selected
+    
+    # Convert back to HF Dataset
+    result_dataset = Dataset.from_list(deduplicated_records)
+    deduped_size = len(result_dataset)
+    
+    # Print statistics
+    print(f"\nDeduplication complete!")
+    print(f"Original size: {original_size:,}")
+    print(f"Deduplicated size: {deduped_size:,}")
+    print(f"Removed: {original_size - deduped_size:,} ({((original_size - deduped_size) / original_size) * 100:.1f}%)")
+    print("\nNote: SemHash processes ~20,000 sentences/second on CPU")
+    
+    # Create dataset card
+    card = create_dataset_card(
+        args.dataset,
+        args.column,
+        args.method,
+        args.threshold,
+        original_size,
+        deduped_size,
+    )
+    
+    # Push to hub
+    print(f"\nPushing to hub: {args.output_repo}")
+    result_dataset.push_to_hub(
+        args.output_repo,
+        private=args.private,
+        commit_message=f"Deduplicated using {args.method} method",
+    )
+    
+    # Create and push dataset card
+    dataset_card = DatasetCard(card)
+    dataset_card.push_to_hub(args.output_repo)
+    
+    print(f"✅ Dataset successfully pushed to: https://huggingface.co/datasets/{args.output_repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/iiif-tiles/README.md
+++ b/iiif-tiles/README.md
@@ -1,0 +1,113 @@
+---
+viewer: false
+tags:
+  - uv-script
+  - iiif
+  - glam
+  - deep-zoom
+  - static-tiles
+---
+
+# IIIF Static Tiles from HF Storage Buckets
+
+Generate [IIIF Image API 3.0](https://iiif.io/api/image/3.0/) Level 0 static tiles from images and serve them via Hugging Face Storage Buckets — no image server required.
+
+Drop images into a bucket, run one command, and get deep-zoom viewing in any IIIF viewer (Mirador, Universal Viewer, OpenSeadragon).
+
+## Demo
+
+[View in Mirador](https://projectmirador.org/embed/?iiif-content=https://huggingface.co/buckets/davanstrien/iiif-tiles-streaming/resolve/manifest.json) — 6 pages from the Wellcome Collection, served entirely from an HF Storage Bucket.
+
+## How it works
+
+```
+Source images (bucket or local)
+  → tile_iiif.py (pyvips generates tile pyramid)
+    → Output bucket (static files served via HF CDN)
+      → Any IIIF viewer (deep zoom, pan, browse)
+```
+
+The script generates a complete IIIF Level 0 tile set: a directory tree of pre-rendered JPEG tiles at multiple zoom levels, plus `info.json` descriptors and a IIIF Presentation v3 `manifest.json`. Since everything is static files, any CDN or file server works — no dynamic image server needed.
+
+In bucket-to-bucket mode, images are streamed through in small batches (download → tile → upload → cleanup) so local storage stays minimal regardless of collection size.
+
+## Quick start
+
+```bash
+# Bucket to bucket (recommended for large collections)
+uv run tile_iiif.py \
+    --source-bucket myorg/source-images \
+    --output-bucket myorg/iiif-tiles
+
+# From a local directory → HF Bucket
+uv run tile_iiif.py \
+    --source-dir ./my-scans \
+    --output-bucket myorg/iiif-tiles \
+    --collection-name "My Collection"
+
+# Local only (for testing)
+uv run tile_iiif.py \
+    --source-dir ./my-scans \
+    --output-dir ./tiles
+# Then: cd tiles && python -m http.server
+```
+
+No system dependencies — `pyvips[binary]` bundles libvips in the pip wheel.
+
+## Run on HF Jobs
+
+Process large collections without tying up your machine:
+
+```bash
+hf jobs uv run tile_iiif.py \
+    --source-bucket myorg/source-images \
+    --output-bucket myorg/iiif-tiles \
+    --collection-name "Historic Manuscripts"
+```
+
+## View the results
+
+Once tiles are in a bucket, open the manifest in any IIIF viewer:
+
+- **Mirador**: `https://projectmirador.org/embed/?iiif-content=https://huggingface.co/buckets/myorg/iiif-tiles/resolve/manifest.json`
+- **Universal Viewer**: `https://uv-v4.netlify.app/#?manifest=https://huggingface.co/buckets/myorg/iiif-tiles/resolve/manifest.json`
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--source-bucket` | — | HF bucket with source images (e.g., `org/source`) |
+| `--source-dir` | — | Local directory with source images |
+| `--output-bucket` | — | HF bucket for tiles (e.g., `org/tiles`) |
+| `--output-dir` | — | Local directory for tiles |
+| `--tile-size` | 512 | Tile size in pixels |
+| `--base-url` | auto | Base URL for IIIF ids |
+| `--collection-name` | "IIIF Collection" | Label for the manifest |
+| `--workers` | 3 | Concurrent workers for bucket-to-bucket mode |
+
+Supported image formats: JPEG, TIFF, PNG, WebP.
+
+## Performance
+
+Bucket-to-bucket with 6 images (2411x3372 each), generating 54 tiles per image:
+
+| Workers | Time | Local storage |
+|---------|------|---------------|
+| 1 | 14.3s | ~10MB (1 image + tiles) |
+| 3 | 6.7s | ~30MB (3 images + tiles) |
+
+Per image: ~0.6s download, ~0.2s tile, ~1.4s upload. The bottleneck is upload I/O, so concurrent workers overlap network time effectively.
+
+## What is IIIF Level 0?
+
+[IIIF](https://iiif.io/) (International Image Interoperability Framework) is a set of APIs for serving and annotating images, widely used by libraries, archives, and museums. Level 0 means all tiles are pre-generated static files — no dynamic image server needed. Viewers request tiles that already exist on disk (or in a bucket).
+
+This covers the primary use case: deep-zoom viewing of high-resolution scans. What you don't get (vs. a full IIIF server) is arbitrary cropping, rotation, or format conversion on the fly — but for browsing collections, Level 0 is all you need.
+
+## Why HF Storage Buckets?
+
+- **Free hosting** for public buckets
+- **Global CDN** with signed URLs
+- **CORS support** for browser-based IIIF viewers
+- **No infrastructure to maintain** — just static files
+- **Streaming processing** — handles large collections without landing everything locally

--- a/iiif-tiles/tile_iiif.py
+++ b/iiif-tiles/tile_iiif.py
@@ -1,0 +1,401 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "pyvips[binary]",
+#     "huggingface-hub",
+# ]
+# ///
+"""Generate IIIF Level 0 static tiles from images in a HF Bucket.
+
+Downloads source images from a bucket, generates IIIF Image API 3.0 tiles
+using libvips, creates a IIIF Presentation v3 manifest, and syncs everything
+to an output bucket for static serving via HF CDN.
+
+Usage:
+    uv run tile_iiif.py --source-bucket org/source --output-bucket org/tiles
+
+HF Jobs:
+    hf jobs uv run tile_iiif.py --source-bucket org/source --output-bucket org/tiles
+"""
+
+import argparse
+import json
+import shutil
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pyvips
+from huggingface_hub import HfApi, sync_bucket
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".tif", ".tiff", ".png", ".webp"}
+
+
+def generate_tiles(image_path: Path, output_dir: Path, tile_size: int) -> dict:
+    """Generate IIIF Level 0 tiles for a single image. Returns image metadata."""
+    image = pyvips.Image.new_from_file(str(image_path))
+    name = image_path.stem
+
+    # dzsave with iiif3 layout generates the full tile tree + info.json
+    image.dzsave(
+        str(output_dir / name),
+        layout="iiif3",
+        tile_size=tile_size,
+        suffix=".jpg[Q=85]",
+        overlap=0,
+    )
+
+    # libvips doesn't generate full/max — create it so the manifest body resolves
+    max_dir = output_dir / name / "full" / "max" / "0"
+    max_dir.mkdir(parents=True, exist_ok=True)
+    image.jpegsave(str(max_dir / "default.jpg"), Q=85)
+
+    return {
+        "name": name,
+        "width": image.width,
+        "height": image.height,
+    }
+
+
+def patch_info_json(tile_dir: Path, image_name: str, base_url: str):
+    """Patch the info.json id field to point to the bucket URL."""
+    info_path = tile_dir / image_name / "info.json"
+    info = json.loads(info_path.read_text())
+    info["id"] = f"{base_url}/{image_name}"
+    info_path.write_text(json.dumps(info, indent=2))
+
+
+def generate_manifest(
+    images: list[dict], base_url: str, collection_name: str
+) -> dict:
+    """Generate a minimal IIIF Presentation v3 manifest."""
+    items = []
+    for img in images:
+        canvas_id = f"{base_url}/{img['name']}/canvas"
+        image_service_id = f"{base_url}/{img['name']}"
+        full_image_id = (
+            f"{base_url}/{img['name']}/full/max/0/default.jpg"
+        )
+
+        items.append(
+            {
+                "id": canvas_id,
+                "type": "Canvas",
+                "width": img["width"],
+                "height": img["height"],
+                "label": {"en": [img["name"]]},
+                "items": [
+                    {
+                        "id": f"{canvas_id}/page",
+                        "type": "AnnotationPage",
+                        "items": [
+                            {
+                                "id": f"{canvas_id}/page/annotation",
+                                "type": "Annotation",
+                                "motivation": "painting",
+                                "body": {
+                                    "id": full_image_id,
+                                    "type": "Image",
+                                    "format": "image/jpeg",
+                                    "width": img["width"],
+                                    "height": img["height"],
+                                    "service": [
+                                        {
+                                            "id": image_service_id,
+                                            "type": "ImageService3",
+                                            "profile": "level0",
+                                        }
+                                    ],
+                                },
+                                "target": canvas_id,
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+    return {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": f"{base_url}/manifest.json",
+        "type": "Manifest",
+        "label": {"en": [collection_name]},
+        "items": items,
+    }
+
+
+def collect_tile_files(tile_dir: Path, image_name: str) -> list[tuple[str, str]]:
+    """Collect (local_path, remote_path) pairs for all tiles of an image."""
+    image_tile_dir = tile_dir / image_name
+    pairs = []
+    for f in image_tile_dir.rglob("*"):
+        if f.is_file():
+            remote = str(f.relative_to(tile_dir))
+            pairs.append((str(f), remote))
+    return pairs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate IIIF tiles from images in a HF Bucket"
+    )
+    parser.add_argument(
+        "--source-bucket",
+        default=None,
+        help="Source bucket with images (e.g., org/iiif-source)",
+    )
+    parser.add_argument(
+        "--output-bucket",
+        default=None,
+        help="Output bucket for tiles (e.g., org/iiif-tiles)",
+    )
+    parser.add_argument(
+        "--tile-size", type=int, default=512, help="Tile size in pixels (default: 512)"
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Base URL for IIIF ids (default: https://huggingface.co/buckets/{output-bucket}/resolve)",
+    )
+    parser.add_argument(
+        "--collection-name",
+        default="IIIF Collection",
+        help="Name for the IIIF manifest",
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=None,
+        help="Use a local directory as source instead of a bucket",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Write tiles to a local directory instead of a bucket",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=3,
+        help="Concurrent workers for bucket-to-bucket mode (default: 3)",
+    )
+    args = parser.parse_args()
+
+    if not args.source_dir and not args.source_bucket:
+        parser.error("Either --source-bucket or --source-dir is required")
+
+    base_url = args.base_url
+    if not base_url:
+        if args.output_bucket:
+            base_url = f"https://huggingface.co/buckets/{args.output_bucket}/resolve"
+        else:
+            base_url = "http://localhost:8000"  # for local testing
+
+    api = HfApi()
+    use_streaming = args.source_bucket and args.output_bucket and not args.source_dir
+
+    if use_streaming:
+        # Streaming mode: process one image at a time to minimize local storage
+        _run_streaming(api, args, base_url)
+    else:
+        # Batch mode: local source and/or local output
+        _run_batch(api, args, base_url)
+
+
+def _process_one_image(
+    api: HfApi,
+    source_bucket: str,
+    output_bucket: str,
+    bucket_file,
+    work_dir: Path,
+    tile_size: int,
+    base_url: str,
+    index: int,
+    total: int,
+) -> dict:
+    """Download, tile, upload, and cleanup a single image. Returns metadata."""
+    img_name = Path(bucket_file.path).name
+    # Each worker gets its own subdirectory to avoid conflicts
+    worker_dir = work_dir / f"worker_{index}"
+    worker_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download
+    t1 = time.time()
+    local_img = worker_dir / img_name
+    api.download_bucket_files(
+        source_bucket,
+        files=[(bucket_file, str(local_img))],
+    )
+    t_dl = time.time() - t1
+
+    # Tile
+    t1 = time.time()
+    tile_dir = worker_dir / "tiles"
+    tile_dir.mkdir(exist_ok=True)
+    meta = generate_tiles(local_img, tile_dir, tile_size)
+    patch_info_json(tile_dir, meta["name"], base_url)
+    for xml in tile_dir.rglob("vips-properties.xml"):
+        xml.unlink()
+    t_tile = time.time() - t1
+
+    # Upload
+    t1 = time.time()
+    tile_pairs = collect_tile_files(tile_dir, meta["name"])
+    api.batch_bucket_files(output_bucket, add=tile_pairs)
+    t_ul = time.time() - t1
+
+    print(
+        f"  [{index + 1}/{total}] {img_name}: "
+        f"download {t_dl:.1f}s, tile {t_tile:.1f}s, "
+        f"upload {len(tile_pairs)} files {t_ul:.1f}s"
+    )
+
+    # Cleanup
+    shutil.rmtree(worker_dir)
+
+    return meta
+
+
+def _run_streaming(api: HfApi, args, base_url: str):
+    """Process images with concurrent workers to overlap I/O and tiling."""
+    t0 = time.time()
+    workers = args.workers
+
+    # List source images
+    print(f"Listing images in bucket: {args.source_bucket}")
+    source_files = [
+        f
+        for f in api.list_bucket_tree(args.source_bucket)
+        if hasattr(f, "path")
+        and Path(f.path).suffix.lower() in IMAGE_EXTENSIONS
+    ]
+
+    if not source_files:
+        print("No images found in source bucket")
+        return
+
+    source_files.sort(key=lambda f: f.path)
+    total = len(source_files)
+    print(f"Found {total} images, processing with {workers} worker(s)")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        work_dir = Path(tmpdir)
+
+        if workers == 1:
+            # Sequential — simpler output
+            image_metadata = []
+            for i, bf in enumerate(source_files):
+                meta = _process_one_image(
+                    api, args.source_bucket, args.output_bucket,
+                    bf, work_dir, args.tile_size, base_url, i, total,
+                )
+                image_metadata.append(meta)
+        else:
+            # Concurrent
+            image_metadata = [None] * total
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                futures = {
+                    pool.submit(
+                        _process_one_image,
+                        api, args.source_bucket, args.output_bucket,
+                        bf, work_dir, args.tile_size, base_url, i, total,
+                    ): i
+                    for i, bf in enumerate(source_files)
+                }
+                for future in as_completed(futures):
+                    idx = futures[future]
+                    image_metadata[idx] = future.result()
+
+        # Generate and upload manifest
+        manifest = generate_manifest(image_metadata, base_url, args.collection_name)
+        manifest_json = json.dumps(manifest, indent=2)
+        api.batch_bucket_files(
+            args.output_bucket,
+            add=[(manifest_json.encode(), "manifest.json")],
+        )
+
+    t_total = time.time() - t0
+    print(f"\nDone in {t_total:.1f}s! View your manifest at:")
+    print(f"  {base_url}/manifest.json")
+    print("\nOpen in a IIIF viewer:")
+    manifest_url = f"{base_url}/manifest.json"
+    print(f"  https://projectmirador.org/embed/?iiif-content={manifest_url}")
+
+
+def _run_batch(api: HfApi, args, base_url: str):
+    """Batch mode: download all, tile all, upload all. For local sources/outputs."""
+    t0 = time.time()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        tile_dir = Path(args.output_dir) if args.output_dir else Path(tmpdir) / "tiles"
+        source_dir.mkdir(exist_ok=True)
+        tile_dir.mkdir(parents=True, exist_ok=True)
+
+        # 1. Get source images
+        if args.source_dir:
+            source_dir = Path(args.source_dir)
+            print(f"Using local source: {source_dir}")
+        else:
+            print(f"Syncing from bucket: {args.source_bucket}")
+            sync_bucket(
+                f"hf://buckets/{args.source_bucket}",
+                str(source_dir),
+            )
+
+        # 2. Find images
+        images = [
+            f
+            for f in source_dir.iterdir()
+            if f.is_file() and f.suffix.lower() in IMAGE_EXTENSIONS
+        ]
+
+        if not images:
+            print(f"No images found in {source_dir}")
+            return
+
+        print(f"Found {len(images)} images")
+
+        # 3. Generate tiles
+        image_metadata = []
+        for img_path in sorted(images):
+            print(f"  Tiling: {img_path.name}")
+            meta = generate_tiles(img_path, tile_dir, args.tile_size)
+            patch_info_json(tile_dir, meta["name"], base_url)
+            image_metadata.append(meta)
+
+        # 4. Clean up vips metadata files
+        for xml in tile_dir.rglob("vips-properties.xml"):
+            xml.unlink()
+
+        # 5. Generate manifest
+        manifest = generate_manifest(image_metadata, base_url, args.collection_name)
+        manifest_path = tile_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+        print(f"Manifest written: {manifest_path}")
+
+        # 6. Sync tiles to output bucket (or report local output)
+        if args.output_bucket:
+            print(f"Syncing tiles to bucket: {args.output_bucket}")
+            sync_bucket(
+                str(tile_dir),
+                f"hf://buckets/{args.output_bucket}",
+            )
+            print("\nDone! View your manifest at:")
+            print(f"  {base_url}/manifest.json")
+            print("\nOpen in a IIIF viewer:")
+            manifest_url = f"{base_url}/manifest.json"
+            print(f"  https://projectmirador.org/embed/?iiif-content={manifest_url}")
+        elif args.output_dir:
+            print(f"\nTiles written to: {tile_dir}")
+            print(f"To test locally: cd {tile_dir} && python -m http.server")
+            print("Then open: http://localhost:8000/manifest.json")
+        else:
+            print("\nNo --output-bucket or --output-dir specified, tiles in temp dir (will be deleted)")
+
+    t_total = time.time() - t0
+    print(f"\nTotal time: {t_total:.1f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Migrates three CPU dataset-tooling repos into the cookbook (seed-then-flip), tidying the surface ahead of launch.

## What

- **`dataset-stats/`** — dataset statistics over large datasets (Polars/streaming). 2 scripts.
- **`deduplication/`** — semantic dedup via SemHash/Model2Vec (CPU, no GPU). 1 script.
- **`iiif-tiles/`** — IIIF image tiles → dataset. 1 script.

All three are **CPU / no-vLLM**, so no #9-class FlashInfer/driver risk — pure seed-then-flip.

## Notes

- **Superset gate passes for all three** (validated locally) — the `--delete="*"` sync can't remove anything on the Hub.
- **`deduplication` had no README on the Hub** — added a minimal card (`viewer: false` + tags + a usage example pulled from the script's docstring), giving the dataset repo a proper landing page.
- Reframed the README's in-repo line to **"Most recipes now live in this repo…"** so it scales rather than enumerating ~10 folder links.
- Scripts seeded **faithfully**; any pre-existing lint is a separate additive follow-up.

## Deferred: `dataset-creation`

Held out of this PR. Its `pdf-examples/` are **5.2 MB of binaries** (a 5 MB bioRxiv PDF + a 278 KB one), already on the Hub and **not referenced by the script** — just sample inputs. Pending a blob-vs-bucket decision (committing them as blobs vs. hosting in a public `uv-scripts` bucket, the latter needing a deliberate Hub-retire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
