### PR TITLE
Migrate vllm into the repo (hardened for vLLM 0.22.x)

### DIFF
--- a/.github/workflows/sync-vllm.yml
+++ b/.github/workflows/sync-vllm.yml
@@ -1,0 +1,13 @@
+name: Sync vllm → HF
+on:
+  push:
+    branches: [main]
+    paths: ['vllm/**', '.github/workflows/sync-vllm.yml']
+
+jobs:
+  sync:
+    uses: ./.github/workflows/_sync-folder.yml
+    with:
+      folder: vllm
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/vllm/.gitignore
+++ b/vllm/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+__pycache__/
+*.pyc
+.ruff_cache/
+.venv/
+*.log

--- a/vllm/CLAUDE.md
+++ b/vllm/CLAUDE.md
@@ -1,0 +1,59 @@
+# vLLM Scripts Development Notes
+
+## Repository Purpose
+This repository contains UV scripts for vLLM-based inference tasks. Focus on GPU-accelerated inference using vLLM's optimized engine.
+
+## Key Patterns
+
+### 1. GPU Requirements
+All scripts MUST check for GPU availability:
+```python
+if not torch.cuda.is_available():
+    logger.error("CUDA is not available. This script requires a GPU.")
+    sys.exit(1)
+```
+
+### 2. vLLM Docker Image
+Run on the pinned **`vllm/vllm-openai:0.22.1`** image for HF Jobs (ships vLLM + the CUDA toolkit, so FlashInfer works) with `--python /usr/bin/python3 -e PYTHONPATH=/usr/local/lib/python3.12/dist-packages`. **Pin the tag (test-then-pin), not `:latest`.** Tested 2026-06-05 on `l4x1` (vLLM 0.22.1).
+
+The custom nightly / FlashInfer `[[tool.uv.index]]` blocks (§3) are **no longer needed** — the image provides vLLM; keep a `vllm>=0.11.0` floor in the PEP 723 header for the local path.
+
+**APIs (verified):** structured outputs use `StructuredOutputsParams` (`structured_outputs=`, ≥0.11.0 — `GuidedDecodingParams`/`guided_decoding=` removed in 0.12.0); classification auto-detects the pooling runner from the model architecture (the old `LLM(..., task="classify")` arg was removed → use `LLM(model)`).
+
+### 3. Dependencies
+Include custom PyPI indexes for vLLM and FlashInfer:
+```python
+# [[tool.uv.index]]
+# url = "https://flashinfer.ai/whl/cu126/torch2.6"
+# 
+# [[tool.uv.index]]
+# url = "https://wheels.vllm.ai/nightly"
+```
+
+## Current Scripts
+
+1. **classify-dataset.py**: BERT-style text classification
+   - Uses vLLM's classify task
+   - Supports batch processing with configurable size
+   - Automatically extracts label mappings from model config
+
+## Future Scripts
+
+Potential additions:
+- Text generation with vLLM
+- Embedding generation using sentence transformers
+- Multi-modal inference
+- Structured output generation
+
+## Testing
+
+Local testing requires GPU. For scripts without local GPU access:
+1. Use HF Jobs with small test datasets
+2. Verify script runs without syntax errors: `python -m py_compile script.py`
+3. Check dependencies resolve: `uv pip compile`
+
+## Performance Considerations
+
+- Default batch size: 10,000 for local, up to 100,000 for HF Jobs
+- L4 GPUs are cost-effective for classification
+- Monitor GPU memory usage and adjust batch sizes accordingly

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -1,0 +1,249 @@
+---
+viewer: false
+tags: [uv-script, vllm, gpu, inference, hf-jobs]
+---
+
+# vLLM Inference Scripts
+
+Ready-to-run UV scripts for GPU-accelerated inference using [vLLM](https://github.com/vllm-project/vllm).
+
+These scripts use [UV's inline script metadata](https://docs.astral.sh/uv/guides/scripts/) to automatically manage dependencies - just run with `uv run` and everything installs automatically!
+
+## 📋 Available Scripts
+
+### vlm-classify.py
+
+Vision Language Model (VLM) image classification with structured output constraints.
+
+**Features:**
+
+- 🖼️ Process images through state-of-the-art VLMs (Qwen2-VL)
+- 🎯 Structured classification using vLLM's `GuidedDecodingParams`
+- 📐 Automatic image resizing to optimize token usage
+- 💾 Memory-efficient lazy batch processing
+- 🏷️ Simple CLI interface for defining classes
+- 🤗 Direct integration with Hugging Face datasets
+
+**Usage:**
+
+```bash
+# Basic classification
+uv run vlm-classify.py \
+    username/input-dataset \
+    username/output-dataset \
+    --classes "document,photo,diagram,other"
+
+# With custom prompt and image resizing
+uv run vlm-classify.py \
+    username/input-dataset \
+    username/output-dataset \
+    --classes "index-card,manuscript,title-page,other" \
+    --prompt "What type of historical document is this?" \
+    --max-size 768
+
+# Quick test with sample limit
+uv run vlm-classify.py \
+    davanstrien/sloane-index-cards \
+    username/test-output \
+    --classes "index,content,other" \
+    --max-samples 10
+```
+
+**HF Jobs execution:**
+
+```bash
+hf jobs uv run \
+    --flavor a10g \
+    --image vllm/vllm-openai \
+    -s HF_TOKEN \
+    https://huggingface.co/datasets/uv-scripts/vllm/raw/main/vlm-classify.py \
+    username/input-dataset \
+    username/output-dataset \
+    --classes "title-page,content,index,other" \
+    --max-size 768
+```
+
+**Key Parameters:**
+
+- `--classes`: Comma-separated list of classification categories (required)
+- `--prompt`: Custom classification prompt (optional, auto-generated if not provided)
+- `--max-size`: Maximum image dimension in pixels for resizing (reduces token count)
+- `--model`: VLM model to use (default: Qwen/Qwen2-VL-7B-Instruct)
+- `--batch-size`: Number of images to process at once (default: 8)
+- `--max-samples`: Limit number of samples for testing
+
+### classify-dataset.py
+
+Batch text classification using BERT-style encoder models (e.g., BERT, RoBERTa, DeBERTa, ModernBERT) with vLLM's optimized inference engine.
+
+**Note**: This script is specifically for encoder-only classification models, not generative LLMs.
+
+**Features:**
+
+- 🚀 High-throughput batch processing
+- 🏷️ Automatic label mapping from model config
+- 📊 Confidence scores for predictions
+- 🤗 Direct integration with Hugging Face Hub
+
+**Usage:**
+
+```bash
+# Local execution (requires GPU)
+uv run classify-dataset.py \
+    davanstrien/ModernBERT-base-is-new-arxiv-dataset \
+    username/input-dataset \
+    username/output-dataset \
+    --inference-column text \
+    --batch-size 10000
+```
+
+**HF Jobs execution:**
+
+```bash
+hf jobs uv run \
+    --flavor l4x1 \
+    --image vllm/vllm-openai \
+    https://huggingface.co/datasets/uv-scripts/vllm/resolve/main/classify-dataset.py \
+    davanstrien/ModernBERT-base-is-new-arxiv-dataset \
+    username/input-dataset \
+    username/output-dataset \
+    --inference-column text \
+    --batch-size 100000
+```
+
+### generate-responses.py
+
+Generate responses for prompts using generative LLMs (e.g., Llama, Qwen, Mistral) with vLLM's high-performance inference engine.
+
+**Features:**
+
+- 💬 Automatic chat template application
+- 📝 Support for both chat messages and plain text prompts
+- 🔀 Multi-GPU tensor parallelism support
+- 📏 Smart filtering for prompts exceeding context length
+- 📊 Comprehensive dataset cards with generation metadata
+- ⚡ HF Transfer enabled for fast model downloads
+- 🎛️ Full control over sampling parameters
+- 🎯 Sample limiting with `--max-samples` for testing
+
+**Usage:**
+
+```bash
+# With chat-formatted messages (default)
+uv run generate-responses.py \
+    username/input-dataset \
+    username/output-dataset \
+    --messages-column messages \
+    --max-tokens 1024
+
+# With plain text prompts (NEW!)
+uv run generate-responses.py \
+    username/input-dataset \
+    username/output-dataset \
+    --prompt-column question \
+    --max-tokens 1024 \
+    --max-samples 100
+
+# With custom model and parameters
+uv run generate-responses.py \
+    username/input-dataset \
+    username/output-dataset \
+    --model-id meta-llama/Llama-3.1-8B-Instruct \
+    --prompt-column text \
+    --temperature 0.9 \
+    --top-p 0.95 \
+    --max-model-len 8192
+```
+
+**HF Jobs execution (multi-GPU):**
+
+```bash
+hf jobs uv run \
+    --flavor l4x4 \
+    --image vllm/vllm-openai \
+    -e UV_PRERELEASE=if-necessary \
+    -s HF_TOKEN \
+    https://huggingface.co/datasets/uv-scripts/vllm/raw/main/generate-responses.py \
+    davanstrien/cards_with_prompts \
+    davanstrien/test-generated-responses \
+    --model-id Qwen/Qwen3-30B-A3B-Instruct-2507 \
+    --gpu-memory-utilization 0.9 \
+    --max-tokens 600 \
+    --max-model-len 8000
+```
+
+### Multi-GPU Tensor Parallelism
+
+- Auto-detects available GPUs by default
+- Use `--tensor-parallel-size` to manually specify
+- Required for models larger than single GPU memory (e.g., 30B+ models)
+
+### Handling Long Contexts
+
+The generate-responses.py script includes smart prompt filtering:
+
+- **Default behavior**: Skips prompts exceeding max_model_len
+- **Use `--max-model-len`**: Limit context to reduce memory usage
+- **Use `--no-skip-long-prompts`**: Fail on long prompts instead of skipping
+- Skipped prompts receive empty responses and are logged
+
+## 📚 About vLLM
+
+vLLM is a high-throughput inference engine optimized for:
+
+- Fast model serving with PagedAttention
+- Efficient batch processing
+- Support for various model architectures
+- Seamless integration with Hugging Face models
+
+## 🔧 Technical Details
+
+### UV Script Benefits
+
+- **Zero setup**: Dependencies install automatically on first run
+- **Reproducible**: Locked dependencies ensure consistent behavior
+- **Self-contained**: Everything needed is in the script file
+- **Direct execution**: Run from local files or URLs
+
+### Dependencies
+
+Scripts use UV's inline metadata for automatic dependency management:
+
+```python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "datasets",
+#     "flashinfer-python",
+#     "huggingface-hub[hf_transfer]",
+#     "torch",
+#     "transformers",
+#     "vllm",
+# ]
+# ///
+```
+
+For bleeding-edge features, use the `UV_PRERELEASE=if-necessary` environment variable to allow pre-release versions when needed.
+
+### Docker Image
+
+For HF Jobs, we recommend the official vLLM Docker image: `vllm/vllm-openai`
+
+This image includes:
+
+- Pre-installed CUDA libraries
+- vLLM and all dependencies
+- UV package manager
+- Optimized for GPU inference
+
+### Environment Variables
+
+- `HF_TOKEN`: Your Hugging Face authentication token (auto-detected if logged in)
+- `UV_PRERELEASE=if-necessary`: Allow pre-release packages when required
+- `HF_HUB_ENABLE_HF_TRANSFER=1`: Automatically enabled for faster downloads
+
+## 🔗 Resources
+
+- [vLLM Documentation](https://docs.vllm.ai/)
+- [UV Documentation](https://docs.astral.sh/uv/)
+- [UV Scripts Organization](https://huggingface.co/uv-scripts)

--- a/vllm/classify-dataset.py
+++ b/vllm/classify-dataset.py
@@ -1,0 +1,286 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "datasets",
+#     "httpx",
+#     "huggingface-hub",
+#     "setuptools",
+#     "toolz",
+#     "torch",
+#     "transformers",
+#     "vllm>=0.11.0",
+# ]
+# ///
+"""
+Batch text classification using vLLM for efficient GPU inference.
+
+This script loads a dataset from Hugging Face Hub, performs classification using
+a BERT-style model via vLLM, and saves the results back to the Hub with predicted
+labels and confidence scores.
+
+Example usage:
+    # Local execution
+    uv run classify-dataset.py \\
+        davanstrien/ModernBERT-base-is-new-arxiv-dataset \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --inference-column text \\
+        --batch-size 10000
+
+    # HF Jobs execution (see script output for full command)
+    hfjobs run --flavor l4x1 ...
+"""
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+import httpx
+import torch
+import torch.nn.functional as F
+import vllm
+from datasets import load_dataset
+from huggingface_hub import hf_hub_url, login
+from toolz import concat, keymap, partition_all
+from tqdm.auto import tqdm
+from vllm import LLM
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def check_gpu_availability():
+    """Check if CUDA is available and log GPU information."""
+    if not torch.cuda.is_available():
+        logger.error("CUDA is not available. This script requires a GPU.")
+        logger.error(
+            "Please run on a machine with NVIDIA GPU or use HF Jobs with GPU flavor."
+        )
+        sys.exit(1)
+
+    gpu_name = torch.cuda.get_device_name(0)
+    gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1024**3
+    logger.info(f"GPU detected: {gpu_name} with {gpu_memory:.1f} GB memory")
+    logger.info(f"vLLM version: {vllm.__version__}")
+
+
+def get_model_id2label(hub_model_id: str) -> Optional[dict[int, str]]:
+    """Extract label mapping from model's config.json on Hugging Face Hub."""
+    try:
+        response = httpx.get(
+            hf_hub_url(hub_model_id, filename="config.json"), follow_redirects=True
+        )
+        if response.status_code != 200:
+            logger.warning(f"Could not fetch config.json for {hub_model_id}")
+            return None
+
+        data = response.json()
+        id2label = data.get("id2label")
+
+        if id2label is None:
+            logger.info("No id2label mapping found in config.json")
+            return None
+
+        # Convert string keys to integers
+        label_map = keymap(int, id2label)
+        logger.info(f"Found label mapping: {label_map}")
+        return label_map
+
+    except Exception as e:
+        logger.warning(f"Failed to parse config.json: {e}")
+        return None
+
+
+def get_top_label(output, label_map: Optional[dict[int, str]] = None):
+    """
+    Extract the top predicted label and confidence score from vLLM output.
+
+    Args:
+        output: vLLM ClassificationRequestOutput
+        label_map: Optional mapping from label indices to label names
+
+    Returns:
+        Tuple of (label, confidence_score)
+    """
+    logits = torch.tensor(output.outputs.probs)
+    probs = F.softmax(logits, dim=0)
+    top_idx = torch.argmax(probs).item()
+    top_prob = probs[top_idx].item()
+
+    # Use label name if mapping available, otherwise use index
+    label = label_map.get(top_idx, str(top_idx)) if label_map else str(top_idx)
+    return label, top_prob
+
+
+def main(
+    hub_model_id: str,
+    src_dataset_hub_id: str,
+    output_dataset_hub_id: str,
+    inference_column: str = "text",
+    batch_size: int = 10_000,
+    hf_token: Optional[str] = None,
+):
+    """
+    Main classification pipeline.
+
+    Args:
+        hub_model_id: Hugging Face model ID for classification
+        src_dataset_hub_id: Input dataset on Hugging Face Hub
+        output_dataset_hub_id: Where to save results on Hugging Face Hub
+        inference_column: Column name containing text to classify
+        batch_size: Number of examples to process at once
+        hf_token: Hugging Face authentication token
+    """
+    # GPU check
+    check_gpu_availability()
+
+    # Authentication
+    HF_TOKEN = hf_token or os.environ.get("HF_TOKEN")
+    if HF_TOKEN:
+        login(token=HF_TOKEN)
+    else:
+        logger.error(
+            "HF_TOKEN is required. Set via --hf-token or HF_TOKEN environment variable."
+        )
+        sys.exit(1)
+
+    # vLLM auto-detects the sequence-classification runner from the model
+    # architecture (*ForSequenceClassification); the task= arg was removed in 0.12.0.
+    logger.info(f"Loading model: {hub_model_id}")
+    llm = LLM(model=hub_model_id)
+
+    # Get label mapping if available
+    id2label = get_model_id2label(hub_model_id)
+
+    # Load dataset
+    logger.info(f"Loading dataset: {src_dataset_hub_id}")
+    dataset = load_dataset(src_dataset_hub_id, split="train")
+    total_examples = len(dataset)
+    logger.info(f"Dataset loaded with {total_examples:,} examples")
+
+    # Extract text column
+    if inference_column not in dataset.column_names:
+        logger.error(
+            f"Column '{inference_column}' not found. Available columns: {dataset.column_names}"
+        )
+        sys.exit(1)
+
+    prompts = dataset[inference_column]
+
+    # Process in batches
+    logger.info(f"Starting classification with batch size {batch_size:,}")
+    all_results = []
+
+    for batch in tqdm(
+        list(partition_all(batch_size, prompts)),
+        desc="Processing batches",
+        unit="batch",
+    ):
+        batch_results = llm.classify(batch)
+        all_results.append(batch_results)
+
+    # Flatten results
+    outputs = list(concat(all_results))
+
+    # Extract labels and probabilities
+    logger.info("Extracting predictions...")
+    labels_and_probs = [get_top_label(output, id2label) for output in outputs]
+
+    # Add results to dataset
+    dataset = dataset.add_column("label", [label for label, _ in labels_and_probs])
+    dataset = dataset.add_column("prob", [prob for _, prob in labels_and_probs])
+
+    # Push to hub
+    logger.info(f"Pushing results to: {output_dataset_hub_id}")
+    dataset.push_to_hub(output_dataset_hub_id, token=HF_TOKEN)
+    logger.info("✅ Classification complete!")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        parser = argparse.ArgumentParser(
+            description="Classify text data using vLLM and save results to Hugging Face Hub",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog="""
+Examples:
+  # Basic usage
+  uv run classify-dataset.py model/name input-dataset output-dataset
+  
+  # With custom column and batch size
+  uv run classify-dataset.py model/name input-dataset output-dataset \\
+    --inference-column prompt \\
+    --batch-size 50000
+  
+  # Using environment variable for token
+  HF_TOKEN=hf_xxx uv run classify-dataset.py model/name input-dataset output-dataset
+            """,
+        )
+
+        parser.add_argument(
+            "hub_model_id",
+            help="Hugging Face model ID for classification (e.g., bert-base-uncased)",
+        )
+        parser.add_argument(
+            "src_dataset_hub_id",
+            help="Input dataset on Hugging Face Hub (e.g., username/dataset-name)",
+        )
+        parser.add_argument(
+            "output_dataset_hub_id", help="Output dataset name on Hugging Face Hub"
+        )
+        parser.add_argument(
+            "--inference-column",
+            type=str,
+            default="text",
+            help="Column containing text to classify (default: text)",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=10_000,
+            help="Batch size for inference (default: 10,000)",
+        )
+        parser.add_argument(
+            "--hf-token",
+            type=str,
+            help="Hugging Face token (can also use HF_TOKEN env var)",
+        )
+
+        args = parser.parse_args()
+
+        main(
+            hub_model_id=args.hub_model_id,
+            src_dataset_hub_id=args.src_dataset_hub_id,
+            output_dataset_hub_id=args.output_dataset_hub_id,
+            inference_column=args.inference_column,
+            batch_size=args.batch_size,
+            hf_token=args.hf_token,
+        )
+    else:
+        # Show HF Jobs example when run without arguments
+        print("""
+vLLM Classification Script
+=========================
+
+This script requires arguments. For usage information:
+    uv run classify-dataset.py --help
+
+Example HF Jobs command:
+    hfjobs run \\
+        --flavor l4x1 \\
+        --secret HF_TOKEN=$(python -c "from huggingface_hub import HfFolder; print(HfFolder.get_token())") \\
+        vllm/vllm-openai:latest \\
+        /bin/bash -c '
+            uv run https://huggingface.co/datasets/uv-scripts/vllm/resolve/main/classify-dataset.py \\
+                davanstrien/ModernBERT-base-is-new-arxiv-dataset \\
+                username/input-dataset \\
+                username/output-dataset \\
+                --inference-column text \\
+                --batch-size 100000
+        ' \\
+        --project vllm-classify \\
+        --name my-classification-job
+        """)

--- a/vllm/generate-responses.py
+++ b/vllm/generate-responses.py
@@ -1,0 +1,584 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "datasets",
+#     "flashinfer-python",
+#     "huggingface-hub",
+#     "hf-xet>= 1.1.7",
+#     "torch",
+#     "transformers",
+#     "vllm>=0.11.0",
+# ]
+#
+# ///
+"""
+Generate responses for prompts in a dataset using vLLM for efficient GPU inference.
+
+This script loads a dataset from Hugging Face Hub containing chat-formatted messages,
+applies the model's chat template, generates responses using vLLM, and saves the
+results back to the Hub with a comprehensive dataset card.
+
+Example usage:
+    # Local execution with auto GPU detection
+    uv run generate-responses.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --messages-column messages
+
+    # With custom model and sampling parameters
+    uv run generate-responses.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --model-id meta-llama/Llama-3.1-8B-Instruct \\
+        --temperature 0.9 \\
+        --top-p 0.95 \\
+        --max-tokens 2048
+
+    # HF Jobs execution (see script output for full command)
+    hf jobs uv run --flavor a100x4 ...
+"""
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+from typing import Optional
+
+from datasets import load_dataset
+from huggingface_hub import DatasetCard, get_token, login
+from torch import cuda
+from tqdm.auto import tqdm
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def check_gpu_availability() -> int:
+    """Check if CUDA is available and return the number of GPUs."""
+    if not cuda.is_available():
+        logger.error("CUDA is not available. This script requires a GPU.")
+        logger.error(
+            "Please run on a machine with NVIDIA GPU or use HF Jobs with GPU flavor."
+        )
+        sys.exit(1)
+
+    num_gpus = cuda.device_count()
+    for i in range(num_gpus):
+        gpu_name = cuda.get_device_name(i)
+        gpu_memory = cuda.get_device_properties(i).total_memory / 1024**3
+        logger.info(f"GPU {i}: {gpu_name} with {gpu_memory:.1f} GB memory")
+
+    return num_gpus
+
+
+def create_dataset_card(
+    source_dataset: str,
+    model_id: str,
+    messages_column: str,
+    prompt_column: Optional[str],
+    sampling_params: SamplingParams,
+    tensor_parallel_size: int,
+    num_examples: int,
+    generation_time: str,
+    num_skipped: int = 0,
+    max_model_len_used: Optional[int] = None,
+) -> str:
+    """Create a comprehensive dataset card documenting the generation process."""
+    filtering_section = ""
+    if num_skipped > 0:
+        skip_percentage = (num_skipped / num_examples) * 100
+        processed = num_examples - num_skipped
+        filtering_section = f"""
+
+### Filtering Statistics
+
+- **Total Examples**: {num_examples:,}
+- **Processed**: {processed:,} ({100 - skip_percentage:.1f}%)
+- **Skipped (too long)**: {num_skipped:,} ({skip_percentage:.1f}%)
+- **Max Model Length Used**: {max_model_len_used:,} tokens
+
+Note: Prompts exceeding the maximum model length were skipped and have empty responses."""
+
+    return f"""---
+tags:
+- generated
+- vllm
+- uv-script
+---
+
+# Generated Responses Dataset
+
+This dataset contains generated responses for prompts from [{source_dataset}](https://huggingface.co/datasets/{source_dataset}).
+
+## Generation Details
+
+- **Source Dataset**: [{source_dataset}](https://huggingface.co/datasets/{source_dataset})
+- **Input Column**: `{prompt_column if prompt_column else messages_column}` ({"plain text prompts" if prompt_column else "chat messages"})
+- **Model**: [{model_id}](https://huggingface.co/{model_id})
+- **Number of Examples**: {num_examples:,}
+- **Generation Date**: {generation_time}{filtering_section}
+
+### Sampling Parameters
+
+- **Temperature**: {sampling_params.temperature}
+- **Top P**: {sampling_params.top_p}
+- **Top K**: {sampling_params.top_k}
+- **Min P**: {sampling_params.min_p}
+- **Max Tokens**: {sampling_params.max_tokens}
+- **Repetition Penalty**: {sampling_params.repetition_penalty}
+
+### Hardware Configuration
+
+- **Tensor Parallel Size**: {tensor_parallel_size}
+- **GPU Configuration**: {tensor_parallel_size} GPU(s)
+
+## Dataset Structure
+
+The dataset contains all columns from the source dataset plus:
+- `response`: The generated response from the model
+
+## Generation Script
+
+Generated using the vLLM inference script from [uv-scripts/vllm](https://huggingface.co/datasets/uv-scripts/vllm).
+
+To reproduce this generation:
+
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/vllm/raw/main/generate-responses.py \\
+    {source_dataset} \\
+    <output-dataset> \\
+    --model-id {model_id} \\
+    {"--prompt-column " + prompt_column if prompt_column else "--messages-column " + messages_column} \\
+    --temperature {sampling_params.temperature} \\
+    --top-p {sampling_params.top_p} \\
+    --top-k {sampling_params.top_k} \\
+    --max-tokens {sampling_params.max_tokens}{f" \\\\\\n    --max-model-len {max_model_len_used}" if max_model_len_used else ""}
+```
+"""
+
+
+def main(
+    src_dataset_hub_id: str,
+    output_dataset_hub_id: str,
+    model_id: str = "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    messages_column: str = "messages",
+    prompt_column: Optional[str] = None,
+    output_column: str = "response",
+    temperature: float = 0.7,
+    top_p: float = 0.8,
+    top_k: int = 20,
+    min_p: float = 0.0,
+    max_tokens: int = 16384,
+    repetition_penalty: float = 1.0,
+    gpu_memory_utilization: float = 0.90,
+    max_model_len: Optional[int] = None,
+    tensor_parallel_size: Optional[int] = None,
+    skip_long_prompts: bool = True,
+    max_samples: Optional[int] = None,
+    hf_token: Optional[str] = None,
+):
+    """
+    Main generation pipeline.
+
+    Args:
+        src_dataset_hub_id: Input dataset on Hugging Face Hub
+        output_dataset_hub_id: Where to save results on Hugging Face Hub
+        model_id: Hugging Face model ID for generation
+        messages_column: Column name containing chat messages
+        prompt_column: Column name containing plain text prompts (alternative to messages_column)
+        output_column: Column name for generated responses
+        temperature: Sampling temperature
+        top_p: Top-p sampling parameter
+        top_k: Top-k sampling parameter
+        min_p: Minimum probability threshold
+        max_tokens: Maximum tokens to generate
+        repetition_penalty: Repetition penalty parameter
+        gpu_memory_utilization: GPU memory utilization factor
+        max_model_len: Maximum model context length (None uses model default)
+        tensor_parallel_size: Number of GPUs to use (auto-detect if None)
+        skip_long_prompts: Skip prompts exceeding max_model_len instead of failing
+        max_samples: Maximum number of samples to process (None for all)
+        hf_token: Hugging Face authentication token
+    """
+    generation_start_time = datetime.now().isoformat()
+
+    # GPU check and configuration
+    num_gpus = check_gpu_availability()
+    if tensor_parallel_size is None:
+        tensor_parallel_size = num_gpus
+        logger.info(
+            f"Auto-detected {num_gpus} GPU(s), using tensor_parallel_size={tensor_parallel_size}"
+        )
+    else:
+        logger.info(f"Using specified tensor_parallel_size={tensor_parallel_size}")
+        if tensor_parallel_size > num_gpus:
+            logger.warning(
+                f"Requested {tensor_parallel_size} GPUs but only {num_gpus} available"
+            )
+
+    # Authentication - try multiple methods
+    HF_TOKEN = hf_token or os.environ.get("HF_TOKEN") or get_token()
+
+    if not HF_TOKEN:
+        logger.error("No HuggingFace token found. Please provide token via:")
+        logger.error("  1. --hf-token argument")
+        logger.error("  2. HF_TOKEN environment variable")
+        logger.error("  3. Run 'huggingface-cli login' or use login() in Python")
+        sys.exit(1)
+
+    logger.info("HuggingFace token found, authenticating...")
+    login(token=HF_TOKEN)
+
+    # Initialize vLLM
+    logger.info(f"Loading model: {model_id}")
+    vllm_kwargs = {
+        "model": model_id,
+        "tensor_parallel_size": tensor_parallel_size,
+        "gpu_memory_utilization": gpu_memory_utilization,
+    }
+    if max_model_len is not None:
+        vllm_kwargs["max_model_len"] = max_model_len
+        logger.info(f"Using max_model_len={max_model_len}")
+
+    llm = LLM(**vllm_kwargs)
+
+    # Load tokenizer for chat template
+    logger.info("Loading tokenizer...")
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    # Create sampling parameters
+    sampling_params = SamplingParams(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        min_p=min_p,
+        max_tokens=max_tokens,
+        repetition_penalty=repetition_penalty,
+    )
+
+    # Load dataset
+    logger.info(f"Loading dataset: {src_dataset_hub_id}")
+    dataset = load_dataset(src_dataset_hub_id, split="train")
+
+    # Apply max_samples if specified
+    if max_samples is not None and max_samples < len(dataset):
+        logger.info(f"Limiting dataset to {max_samples} samples")
+        dataset = dataset.select(range(max_samples))
+
+    total_examples = len(dataset)
+    logger.info(f"Dataset loaded with {total_examples:,} examples")
+
+    # Determine which column to use and validate
+    if prompt_column:
+        # Use prompt column mode
+        if prompt_column not in dataset.column_names:
+            logger.error(
+                f"Column '{prompt_column}' not found. Available columns: {dataset.column_names}"
+            )
+            sys.exit(1)
+        logger.info(f"Using prompt column mode with column: '{prompt_column}'")
+        use_messages = False
+    else:
+        # Use messages column mode
+        if messages_column not in dataset.column_names:
+            logger.error(
+                f"Column '{messages_column}' not found. Available columns: {dataset.column_names}"
+            )
+            sys.exit(1)
+        logger.info(f"Using messages column mode with column: '{messages_column}'")
+        use_messages = True
+
+    # Get effective max length for filtering
+    if max_model_len is not None:
+        effective_max_len = max_model_len
+    else:
+        # Get model's default max length
+        effective_max_len = llm.llm_engine.model_config.max_model_len
+    logger.info(f"Using effective max model length: {effective_max_len}")
+
+    # Process messages and apply chat template
+    logger.info("Preparing prompts...")
+    all_prompts = []
+    valid_prompts = []
+    valid_indices = []
+    skipped_info = []
+
+    for i, example in enumerate(tqdm(dataset, desc="Processing prompts")):
+        if use_messages:
+            # Messages mode: use existing chat messages
+            messages = example[messages_column]
+            # Apply chat template
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        else:
+            # Prompt mode: convert plain text to messages format
+            user_prompt = example[prompt_column]
+            messages = [{"role": "user", "content": user_prompt}]
+            # Apply chat template
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+
+        all_prompts.append(prompt)
+
+        # Count tokens if filtering is enabled
+        if skip_long_prompts:
+            tokens = tokenizer.encode(prompt)
+            if len(tokens) <= effective_max_len:
+                valid_prompts.append(prompt)
+                valid_indices.append(i)
+            else:
+                skipped_info.append((i, len(tokens)))
+        else:
+            valid_prompts.append(prompt)
+            valid_indices.append(i)
+
+    # Log filtering results
+    if skip_long_prompts and skipped_info:
+        logger.warning(
+            f"Skipped {len(skipped_info)} prompts that exceed max_model_len ({effective_max_len} tokens)"
+        )
+        logger.info("Skipped prompt details (first 10):")
+        for idx, (prompt_idx, token_count) in enumerate(skipped_info[:10]):
+            logger.info(
+                f"  - Example {prompt_idx}: {token_count} tokens (exceeds by {token_count - effective_max_len})"
+            )
+        if len(skipped_info) > 10:
+            logger.info(f"  ... and {len(skipped_info) - 10} more")
+
+        skip_percentage = (len(skipped_info) / total_examples) * 100
+        if skip_percentage > 10:
+            logger.warning(f"WARNING: {skip_percentage:.1f}% of prompts were skipped!")
+
+    if not valid_prompts:
+        logger.error("No valid prompts to process after filtering!")
+        sys.exit(1)
+
+    # Generate responses - vLLM handles batching internally
+    logger.info(f"Starting generation for {len(valid_prompts):,} valid prompts...")
+    logger.info("vLLM will handle batching and scheduling automatically")
+
+    outputs = llm.generate(valid_prompts, sampling_params)
+
+    # Extract generated text and create full response list
+    logger.info("Extracting generated responses...")
+    responses = [""] * total_examples  # Initialize with empty strings
+
+    for idx, output in enumerate(outputs):
+        original_idx = valid_indices[idx]
+        response = output.outputs[0].text.strip()
+        responses[original_idx] = response
+
+    # Add responses to dataset
+    logger.info("Adding responses to dataset...")
+    dataset = dataset.add_column(output_column, responses)
+
+    # Create dataset card
+    logger.info("Creating dataset card...")
+    card_content = create_dataset_card(
+        source_dataset=src_dataset_hub_id,
+        model_id=model_id,
+        messages_column=messages_column,
+        prompt_column=prompt_column,
+        sampling_params=sampling_params,
+        tensor_parallel_size=tensor_parallel_size,
+        num_examples=total_examples,
+        generation_time=generation_start_time,
+        num_skipped=len(skipped_info) if skip_long_prompts else 0,
+        max_model_len_used=effective_max_len if skip_long_prompts else None,
+    )
+
+    # Push dataset to hub
+    logger.info(f"Pushing dataset to: {output_dataset_hub_id}")
+    dataset.push_to_hub(output_dataset_hub_id, token=HF_TOKEN)
+
+    # Push dataset card
+    card = DatasetCard(card_content)
+    card.push_to_hub(output_dataset_hub_id, token=HF_TOKEN)
+
+    logger.info("✅ Generation complete!")
+    logger.info(
+        f"Dataset available at: https://huggingface.co/datasets/{output_dataset_hub_id}"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        parser = argparse.ArgumentParser(
+            description="Generate responses for dataset prompts using vLLM",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog="""
+Examples:
+  # Basic usage with default Qwen model
+  uv run generate-responses.py input-dataset output-dataset
+  
+  # With custom model and parameters
+  uv run generate-responses.py input-dataset output-dataset \\
+    --model-id meta-llama/Llama-3.1-8B-Instruct \\
+    --temperature 0.9 \\
+    --max-tokens 2048
+  
+  # Force specific GPU configuration
+  uv run generate-responses.py input-dataset output-dataset \\
+    --tensor-parallel-size 2 \\
+    --gpu-memory-utilization 0.95
+  
+  # Using environment variable for token
+  HF_TOKEN=hf_xxx uv run generate-responses.py input-dataset output-dataset
+            """,
+        )
+
+        parser.add_argument(
+            "src_dataset_hub_id",
+            help="Input dataset on Hugging Face Hub (e.g., username/dataset-name)",
+        )
+        parser.add_argument(
+            "output_dataset_hub_id", help="Output dataset name on Hugging Face Hub"
+        )
+        parser.add_argument(
+            "--model-id",
+            type=str,
+            default="Qwen/Qwen3-30B-A3B-Instruct-2507",
+            help="Model to use for generation (default: Qwen3-30B-A3B-Instruct-2507)",
+        )
+        parser.add_argument(
+            "--messages-column",
+            type=str,
+            default="messages",
+            help="Column containing chat messages (default: messages)",
+        )
+        parser.add_argument(
+            "--prompt-column",
+            type=str,
+            help="Column containing plain text prompts (alternative to --messages-column)",
+        )
+        parser.add_argument(
+            "--output-column",
+            type=str,
+            default="response",
+            help="Column name for generated responses (default: response)",
+        )
+        parser.add_argument(
+            "--max-samples",
+            type=int,
+            help="Maximum number of samples to process (default: all)",
+        )
+        parser.add_argument(
+            "--temperature",
+            type=float,
+            default=0.7,
+            help="Sampling temperature (default: 0.7)",
+        )
+        parser.add_argument(
+            "--top-p",
+            type=float,
+            default=0.8,
+            help="Top-p sampling parameter (default: 0.8)",
+        )
+        parser.add_argument(
+            "--top-k",
+            type=int,
+            default=20,
+            help="Top-k sampling parameter (default: 20)",
+        )
+        parser.add_argument(
+            "--min-p",
+            type=float,
+            default=0.0,
+            help="Minimum probability threshold (default: 0.0)",
+        )
+        parser.add_argument(
+            "--max-tokens",
+            type=int,
+            default=16384,
+            help="Maximum tokens to generate (default: 16384)",
+        )
+        parser.add_argument(
+            "--repetition-penalty",
+            type=float,
+            default=1.0,
+            help="Repetition penalty (default: 1.0)",
+        )
+        parser.add_argument(
+            "--gpu-memory-utilization",
+            type=float,
+            default=0.90,
+            help="GPU memory utilization factor (default: 0.90)",
+        )
+        parser.add_argument(
+            "--max-model-len",
+            type=int,
+            help="Maximum model context length (default: model's default)",
+        )
+        parser.add_argument(
+            "--tensor-parallel-size",
+            type=int,
+            help="Number of GPUs to use (default: auto-detect)",
+        )
+        parser.add_argument(
+            "--hf-token",
+            type=str,
+            help="Hugging Face token (can also use HF_TOKEN env var)",
+        )
+        parser.add_argument(
+            "--skip-long-prompts",
+            action="store_true",
+            default=True,
+            help="Skip prompts that exceed max_model_len instead of failing (default: True)",
+        )
+        parser.add_argument(
+            "--no-skip-long-prompts",
+            dest="skip_long_prompts",
+            action="store_false",
+            help="Fail on prompts that exceed max_model_len",
+        )
+
+        args = parser.parse_args()
+
+        main(
+            src_dataset_hub_id=args.src_dataset_hub_id,
+            output_dataset_hub_id=args.output_dataset_hub_id,
+            model_id=args.model_id,
+            messages_column=args.messages_column,
+            prompt_column=args.prompt_column,
+            output_column=args.output_column,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            top_k=args.top_k,
+            min_p=args.min_p,
+            max_tokens=args.max_tokens,
+            repetition_penalty=args.repetition_penalty,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            max_model_len=args.max_model_len,
+            tensor_parallel_size=args.tensor_parallel_size,
+            skip_long_prompts=args.skip_long_prompts,
+            max_samples=args.max_samples,
+            hf_token=args.hf_token,
+        )
+    else:
+        # Show HF Jobs example when run without arguments
+        print("""
+vLLM Response Generation Script
+==============================
+
+This script requires arguments. For usage information:
+    uv run generate-responses.py --help
+
+Example HF Jobs command with multi-GPU:
+    # If you're logged in with huggingface-cli, token will be auto-detected
+    hf jobs uv run \\
+        --flavor l4x4 \\
+        https://huggingface.co/datasets/uv-scripts/vllm/raw/main/generate-responses.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --messages-column messages \\
+        --model-id Qwen/Qwen3-30B-A3B-Instruct-2507 \\
+        --temperature 0.7 \\
+        --max-tokens 16384
+        """)

--- a/vllm/vlm-classify.py
+++ b/vllm/vlm-classify.py
@@ -1,0 +1,438 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub",
+#     "pillow",
+#     "toolz",
+#     "torch",
+#     "tqdm",
+#     "transformers",
+#     "vllm>=0.11.0",  # StructuredOutputsParams API (guided_decoding removed in 0.12.0)
+# ]
+# ///
+
+"""
+Classify images using Vision Language Models with vLLM.
+
+This script processes images through VLMs to classify them into user-defined categories,
+using vLLM's GuidedDecodingParams for structured output.
+
+Examples:
+    # Basic classification
+    uv run vlm-classify.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --classes "document,photo,diagram,other"
+    
+    # With custom prompt and model
+    uv run vlm-classify.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --classes "index-card,manuscript,title-page,other" \\
+        --prompt "What type of historical document is this?" \\
+        --model Qwen/Qwen2-VL-7B-Instruct
+    
+    # Quick test with sample limit
+    uv run vlm-classify.py \\
+        davanstrien/sloane-index-cards \\
+        username/test-output \\
+        --classes "index,content,other" \\
+        --max-samples 10
+"""
+
+import argparse
+import base64
+import io
+import logging
+import os
+import sys
+from collections import Counter
+from typing import List, Optional, Union, Dict, Any
+
+import torch
+from PIL import Image
+from datasets import load_dataset
+from huggingface_hub import login
+from toolz import partition_all
+from tqdm.auto import tqdm
+from vllm import LLM, SamplingParams
+from vllm.sampling_params import StructuredOutputsParams
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def image_to_data_uri(
+    image: Union[Image.Image, Dict[str, Any]], max_size: Optional[int] = None
+) -> str:
+    """Convert image to base64 data URI for VLM processing.
+
+    Args:
+        image: PIL Image or dict with image bytes
+        max_size: Optional maximum dimension (width or height) to resize to.
+                 Preserves aspect ratio using thumbnail method.
+    """
+    if isinstance(image, Image.Image):
+        pil_img = image
+    elif isinstance(image, dict) and "bytes" in image:
+        pil_img = Image.open(io.BytesIO(image["bytes"]))
+    else:
+        raise ValueError(f"Unsupported image type: {type(image)}")
+
+    # Resize if max_size is specified and image exceeds it
+    if max_size and (pil_img.width > max_size or pil_img.height > max_size):
+        # Use thumbnail to preserve aspect ratio
+        pil_img = pil_img.copy()  # Don't modify original
+        pil_img.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
+
+    # Convert to RGB if necessary (handle RGBA, grayscale, etc.)
+    if pil_img.mode not in ("RGB", "L"):
+        pil_img = pil_img.convert("RGB")
+
+    # Convert to base64
+    buf = io.BytesIO()
+    pil_img.save(buf, format="JPEG", quality=95)
+    base64_str = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/jpeg;base64,{base64_str}"
+
+
+def create_classification_messages(
+    image: Union[Image.Image, Dict[str, Any]],
+    prompt: str,
+    max_size: Optional[int] = None,
+) -> List[Dict]:
+    """Create chat messages for VLM classification."""
+    image_uri = image_to_data_uri(image, max_size=max_size)
+
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": image_uri}},
+                {"type": "text", "text": prompt},
+            ],
+        }
+    ]
+
+
+def main(
+    input_dataset: str,
+    output_dataset: str,
+    classes: str,
+    prompt: Optional[str] = None,
+    image_column: str = "image",
+    model: str = "Qwen/Qwen2-VL-7B-Instruct",
+    batch_size: int = 8,
+    max_samples: Optional[int] = None,
+    max_size: Optional[int] = None,
+    gpu_memory_utilization: float = 0.9,
+    max_model_len: Optional[int] = None,
+    tensor_parallel_size: Optional[int] = None,
+    split: str = "train",
+    hf_token: Optional[str] = None,
+    private: bool = False,
+):
+    """Classify images from a dataset using a Vision Language Model."""
+
+    # Check GPU availability
+    if not torch.cuda.is_available():
+        logger.error("CUDA is not available. This script requires a GPU.")
+        logger.error("If running locally, ensure you have a CUDA-capable GPU.")
+        logger.error("For cloud execution, use: hf jobs uv run --flavor a10g ...")
+        sys.exit(1)
+
+    # Parse classes
+    class_list = [c.strip() for c in classes.split(",")]
+    logger.info(f"Classes: {class_list}")
+
+    # Create default prompt if not provided
+    if prompt is None:
+        prompt = f"Classify this image into one of the following categories: {', '.join(class_list)}"
+    logger.info(f"Prompt template: {prompt}")
+
+    # Login to HF if token provided
+    HF_TOKEN = hf_token or os.environ.get("HF_TOKEN")
+    if HF_TOKEN:
+        login(token=HF_TOKEN)
+
+    # Load dataset
+    logger.info(f"Loading dataset: {input_dataset}")
+    dataset = load_dataset(input_dataset, split=split)
+
+    # Validate image column
+    if image_column not in dataset.column_names:
+        raise ValueError(
+            f"Column '{image_column}' not found. Available: {dataset.column_names}"
+        )
+
+    # Limit samples if requested
+    if max_samples:
+        dataset = dataset.select(range(min(max_samples, len(dataset))))
+        logger.info(f"Limited to {len(dataset)} samples")
+
+    # Log resizing configuration
+    if max_size:
+        logger.info(f"Image resizing enabled: max dimension = {max_size}px")
+
+    # Auto-detect tensor parallel size if not specified
+    if tensor_parallel_size is None:
+        tensor_parallel_size = torch.cuda.device_count()
+        logger.info(f"Auto-detected {tensor_parallel_size} GPUs for tensor parallelism")
+
+    # Initialize vLLM
+    logger.info(f"Loading model: {model}")
+    llm_kwargs = {
+        "model": model,
+        "gpu_memory_utilization": gpu_memory_utilization,
+        "tensor_parallel_size": tensor_parallel_size,
+        "trust_remote_code": True,  # Required for some VLMs
+    }
+
+    if max_model_len:
+        llm_kwargs["max_model_len"] = max_model_len
+
+    llm = LLM(**llm_kwargs)
+
+    # Constrain output to one of the class labels (vLLM structured outputs).
+    # StructuredOutputsParams + structured_outputs= is the API from vLLM 0.11.0+;
+    # the old GuidedDecodingParams/guided_decoding= was removed in 0.12.0.
+    structured = StructuredOutputsParams(choice=class_list)
+    sampling_params = SamplingParams(
+        temperature=0.1,  # Low temperature for consistent classification
+        max_tokens=50,  # Classifications are short
+        structured_outputs=structured,
+    )
+
+    # Process images in batches to avoid memory issues
+    logger.info(f"Processing {len(dataset)} images in batches of {batch_size}")
+
+    all_classifications = []
+
+    # Process in batches using lazy loading
+    for batch_indices in tqdm(
+        partition_all(batch_size, range(len(dataset))),
+        total=(len(dataset) + batch_size - 1) // batch_size,
+        desc="Classifying images",
+    ):
+        batch_indices = list(batch_indices)
+
+        # Load only this batch's images
+        batch_images = []
+        valid_batch_indices = []
+
+        for idx in batch_indices:
+            try:
+                image = dataset[idx][image_column]
+                batch_images.append(image)
+                valid_batch_indices.append(idx)
+            except Exception as e:
+                logger.warning(f"Skipping image at index {idx}: {e}")
+                all_classifications.append(None)
+
+        if not batch_images:
+            continue
+
+        try:
+            # Create messages for just this batch
+            batch_messages = [
+                create_classification_messages(img, prompt, max_size=max_size)
+                for img in batch_images
+            ]
+
+            # Process with vLLM
+            outputs = llm.chat(
+                messages=batch_messages,
+                sampling_params=sampling_params,
+                use_tqdm=False,  # Already have outer progress bar
+            )
+
+            # Extract classifications
+            for output in outputs:
+                if output.outputs:
+                    label = output.outputs[0].text.strip()
+                    all_classifications.append(label)
+                else:
+                    all_classifications.append(None)
+                    logger.warning("Empty output for an image")
+
+        except Exception as e:
+            logger.error(f"Error processing batch: {e}")
+            # Add None for failed batch
+            all_classifications.extend([None] * len(batch_images))
+
+    # Ensure we have the right number of classifications
+    while len(all_classifications) < len(dataset):
+        all_classifications.append(None)
+
+    # Add classifications to dataset
+    logger.info("Adding classifications to dataset...")
+    dataset = dataset.add_column("label", all_classifications[: len(dataset)])
+
+    # Push to hub
+    logger.info(f"Pushing to {output_dataset}...")
+    dataset.push_to_hub(output_dataset, private=private, token=HF_TOKEN)
+
+    # Print summary
+    logger.info("Classification complete!")
+    logger.info(f"Processed {len(all_classifications)} images")
+    logger.info(f"Output dataset: {output_dataset}")
+
+    # Show distribution of classifications
+    label_counts = Counter(all_classifications)
+    logger.info("Classification distribution:")
+    for label, count in sorted(label_counts.items()):
+        if label is not None:  # Skip None values in summary
+            percentage = (
+                (count / len(all_classifications)) * 100 if all_classifications else 0
+            )
+            logger.info(f"  {label}: {count} ({percentage:.1f}%)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Classify images using Vision Language Models",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Basic classification
+    uv run vlm-classify.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --classes "document,photo,diagram,other"
+    
+    # With custom prompt
+    uv run vlm-classify.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --classes "index-card,manuscript,other" \\
+        --prompt "What type of historical document is this?"
+    
+    # HF Jobs execution
+    hf jobs uv run \\
+        --flavor a10g \\
+        https://huggingface.co/datasets/uv-scripts/vllm/raw/main/vlm-classify.py \\
+        username/input-dataset \\
+        username/output-dataset \\
+        --classes "title-page,content,index,other"
+        """,
+    )
+
+    parser.add_argument(
+        "input_dataset",
+        help="Input dataset ID on Hugging Face Hub",
+    )
+    parser.add_argument(
+        "output_dataset",
+        help="Output dataset ID on Hugging Face Hub",
+    )
+    parser.add_argument(
+        "--classes",
+        required=True,
+        help='Comma-separated list of classes (e.g., "cat,dog,other")',
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Custom classification prompt (default: auto-generated)",
+    )
+    parser.add_argument(
+        "--image-column",
+        default="image",
+        help="Column name containing images (default: image)",
+    )
+    parser.add_argument(
+        "--model",
+        default="Qwen/Qwen2-VL-7B-Instruct",
+        help="Vision Language Model to use (default: Qwen/Qwen2-VL-7B-Instruct)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=8,
+        help="Batch size for inference (default: 8)",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Maximum number of samples to process (for testing)",
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=None,
+        help="Maximum image dimension in pixels. Images larger than this will be resized while preserving aspect ratio (e.g., 768, 1024)",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.9,
+        help="GPU memory utilization (default: 0.9)",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="Maximum model context length",
+    )
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=None,
+        help="Number of GPUs for tensor parallelism (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--split",
+        default="train",
+        help="Dataset split to use (default: train)",
+    )
+    parser.add_argument(
+        "--hf-token",
+        default=None,
+        help="Hugging Face API token (or set HF_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Make output dataset private",
+    )
+
+    args = parser.parse_args()
+
+    # Show example command if no arguments
+    if len(sys.argv) == 1:
+        parser.print_help()
+        print("\n" + "=" * 60)
+        print("Example HF Jobs command:")
+        print("=" * 60)
+        print("""
+hf jobs uv run \\
+    --flavor a10g \\
+    -e HF_TOKEN=$(python3 -c "from huggingface_hub import get_token; print(get_token())") \\
+    https://huggingface.co/datasets/uv-scripts/vllm/raw/main/vlm-classify.py \\
+    davanstrien/sloane-index-cards \\
+    username/classified-cards \\
+    --classes "index-card,manuscript,title-page,other" \\
+    --max-size 768 \\
+    --max-samples 100
+        """)
+        sys.exit(0)
+
+    main(
+        input_dataset=args.input_dataset,
+        output_dataset=args.output_dataset,
+        classes=args.classes,
+        prompt=args.prompt,
+        image_column=args.image_column,
+        model=args.model,
+        batch_size=args.batch_size,
+        max_samples=args.max_samples,
+        max_size=args.max_size,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+        tensor_parallel_size=args.tensor_parallel_size,
+        split=args.split,
+        hf_token=args.hf_token,
+        private=args.private,
+    )


### PR DESCRIPTION
Migrates `uv-scripts/vllm` into the repo (seed-then-flip), hardened for current vLLM and smoke-tested on `l4x1` + the `vllm/vllm-openai` image (**vLLM 0.22.1**). The worked template for the rest of the vLLM family (#29).

## All three scripts hardened + smoke-tested green

| Script | Fix | Smoke-test (l4x1, image, 0.22.1) |
|---|---|---|
| `vlm-classify.py` | `GuidedDecodingParams`→`StructuredOutputsParams` (`structured_outputs=`) | ✅ classified + pushed |
| `generate-responses.py` | dropped `HF_HUB_ENABLE_HF_TRANSFER` | ✅ generated + pushed |
| `classify-dataset.py` | de-nightly'd (dropped nightly + FlashInfer indexes); `LLM(task="classify")` → auto-detect runner | ✅ classified + pushed |

All three: dropped the dead `huggingface-hub[hf_transfer]` extra (#32) and floored `vllm>=0.11.0`. `CLAUDE.md` pins the tested **`vllm/vllm-openai:0.22.1`** image and records the verified APIs (StructuredOutputsParams ≥0.11.0; classify runner auto-detect).

## Safety
Superset gate passes (5 Hub files present) → the `--delete="*"` sync can't remove anything. Uses the existing dataset-typed reusable workflow (folder == repo). No README change (the "Most recipes…" line is non-enumerated).

## Follow-ups (not in this PR)
- **`classify-dataset.py` column collision** — crashes if the input already has a `label`/`prob` column (most classification datasets do). Orthogonal to the vLLM hardening; a design call on output naming. (Surfaced on rotten-tomatoes during testing.)
- **Docstring examples** — the in-docstring HF-Jobs examples still show older/varied invocations (`a10g`/`a100x4`/`l4x4`, old `hfjobs`). Modernize to the tested `--image vllm/vllm-openai:0.22.1 --python /usr/bin/python3 -e PYTHONPATH=…` form — deferred to avoid an untested bulk rewrite.

Largely completes #28. The `bump-vllm-pins` skill (#35) keeps these pins current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
