### PR TITLE
Migrate jobs-utils + add list-recipes.py (zero-setup recipe discovery)

### DIFF
--- a/.github/workflows/sync-jobs-utils.yml
+++ b/.github/workflows/sync-jobs-utils.yml
@@ -1,0 +1,13 @@
+name: Sync jobs-utils → HF
+on:
+  push:
+    branches: [main]
+    paths: ['jobs-utils/**', '.github/workflows/sync-jobs-utils.yml']
+
+jobs:
+  sync:
+    uses: ./.github/workflows/_sync-folder.yml
+    with:
+      folder: jobs-utils
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/jobs-utils/README.md
+++ b/jobs-utils/README.md
@@ -1,0 +1,117 @@
+---
+viewer: false
+tags:
+  - uv-script
+  - huggingface-jobs
+  - utilities
+  - benchmarking
+license: apache-2.0
+---
+
+# HF Jobs Utilities
+
+Small utility scripts for working with the [uv-scripts](https://huggingface.co/uv-scripts) collection and Hugging Face Jobs — discovering the available recipes, and testing/benchmarking your Jobs setup.
+
+## Available Scripts
+
+### list-recipes.py
+
+List every recipe (UV script) across the whole `uv-scripts` org, with a runnable URL for each. The zero-setup way to see what's available — no GPU, no token, no account; it only reads public repos.
+
+**Run locally** (nothing to install but [uv](https://docs.astral.sh/uv/getting-started/installation/)):
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/list-recipes.py
+```
+
+Add `--describe` to also print the first line of each script's docstring (slower — it fetches each file):
+```bash
+uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/list-recipes.py --describe
+```
+
+Each printed URL runs the same way: `uv run <url>` locally, or `hf jobs uv run <url>` on a GPU.
+
+### network-speed-test.py
+
+Test network download speed from within an HF Jobs environment. Useful for:
+- Verifying network connectivity
+- Comparing download speeds across different GPU flavors
+- Benchmarking before running large dataset downloads
+- Troubleshooting slow data loading issues
+
+**Features:**
+- Pure Python (no dependencies required)
+- Fast default test with small file
+- Optional `--large` flag for realistic ~100MB test
+- Clear metrics (MB/s and Mbps)
+- Works locally or on HF Jobs
+
+#### Usage
+
+**Run locally:**
+```bash
+# Quick test with small file
+uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py
+
+# More realistic test with ~100MB file
+uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py --large
+
+# Custom URL
+uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py \
+    --url https://example.com/testfile.bin
+```
+
+**Run on HF Jobs:**
+```bash
+# Test network speed on L4 GPU
+hfjobs run --flavor l4x1 \
+    -s HF_TOKEN \
+    uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py --large
+
+# Compare across different flavors
+hfjobs run --flavor a10 \
+    -s HF_TOKEN \
+    uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py --large
+
+hfjobs run --flavor h100 \
+    -s HF_TOKEN \
+    uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py --large
+```
+
+#### Example Output
+
+```
+Using large file test (~100MB)
+============================================================
+HF Jobs Network Speed Test
+============================================================
+
+Testing download speed from: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/pytorch_model.bin
+Downloading...
+
+============================================================
+Results:
+============================================================
+Downloaded: 86.68 MB
+Time: 2.79 seconds
+Speed: 31.03 MB/s (260.31 Mbps)
+============================================================
+```
+
+## Why These Utilities?
+
+HF Jobs provides different GPU flavors with varying network configurations. These utilities help you:
+
+1. **Make informed decisions** - Compare network speeds before choosing a flavor
+2. **Debug issues** - Verify network connectivity when data loading is slow
+3. **Optimize workflows** - Understand if network speed is a bottleneck
+4. **Benchmark environments** - Document baseline performance for your use case
+
+## About UV Scripts
+
+This is part of the [uv-scripts](https://huggingface.co/uv-scripts) collection - ready-to-run Python scripts that work with a single `uv run` command. No setup, no virtual environments, just instant execution.
+
+Learn more about UV: https://docs.astral.sh/uv/
+
+## License
+
+Apache 2.0

--- a/jobs-utils/list-recipes.py
+++ b/jobs-utils/list-recipes.py
@@ -1,0 +1,90 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "huggingface-hub",
+# ]
+# ///
+"""
+List every recipe (UV script) in the `uv-scripts` Hugging Face org.
+
+The zero-setup way to see what's available: this script asks the Hub for every
+dataset repo under the org, finds the `.py` scripts in each, and prints a runnable
+URL for every one. No GPU, no token, no account needed — it only reads public repos.
+
+Run it locally (nothing to install but uv itself):
+
+    uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/list-recipes.py
+
+Add --describe to also print the first line of each script's docstring (slower —
+it fetches each file):
+
+    uv run https://huggingface.co/.../list-recipes.py --describe
+"""
+
+import argparse
+import sys
+
+from huggingface_hub import HfApi, hf_hub_url
+
+ORG = "uv-scripts"
+
+
+def first_docstring_line(api: HfApi, repo_id: str, filename: str) -> str:
+    """Best-effort: read a script's module docstring's first non-empty line."""
+    try:
+        path = api.hf_hub_download(repo_id=repo_id, filename=filename, repo_type="dataset")
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except Exception:
+        return ""
+    # Find the first triple-quoted string and return its first real line.
+    for quote in ('"""', "'''"):
+        if quote in text:
+            body = text.split(quote, 2)
+            if len(body) >= 3:
+                for line in body[1].splitlines():
+                    line = line.strip()
+                    if line:
+                        return line
+    return ""
+
+
+def main(describe: bool = False) -> None:
+    api = HfApi()
+    repos = sorted(api.list_datasets(author=ORG), key=lambda d: d.id)
+
+    total = 0
+    for repo in repos:
+        repo_id = repo.id
+        try:
+            files = api.list_repo_files(repo_id, repo_type="dataset")
+        except Exception as e:
+            print(f"  (skipped {repo_id}: {e})", file=sys.stderr)
+            continue
+        scripts = sorted(f for f in files if f.endswith(".py") and "/" not in f)
+        if not scripts:
+            continue
+
+        print(f"\n## {repo_id}   →   https://huggingface.co/datasets/{repo_id}")
+        for script in scripts:
+            url = hf_hub_url(repo_id, script, repo_type="dataset")
+            if describe:
+                desc = first_docstring_line(api, repo_id, script)
+                print(f"  {script:<28} {url}")
+                if desc:
+                    print(f"  {'':<28} {desc}")
+            else:
+                print(f"  {script:<28} {url}")
+            total += 1
+
+    print(f"\n{total} recipes across {ORG}. Run any with:  uv run <url>  (or  hf jobs uv run <url>  for a GPU)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=f"List all UV-script recipes in the {ORG} org.")
+    parser.add_argument(
+        "--describe", action="store_true",
+        help="Also print each script's docstring summary (slower — fetches each file)",
+    )
+    args = parser.parse_args()
+    main(describe=args.describe)

--- a/jobs-utils/network-speed-test.py
+++ b/jobs-utils/network-speed-test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+
+"""
+Simple network speed test for HF Jobs.
+
+Tests download speed by fetching a file from Hugging Face Hub.
+Useful for verifying network performance in different HF Jobs flavors.
+
+Usage:
+    # Run locally
+    uv run network-speed-test.py
+
+    # Run on HF Jobs
+    hfjobs run --flavor l4x1 \
+        -s HF_TOKEN \
+        uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/network-speed-test.py
+
+Example output:
+    Testing download speed...
+    Downloaded 100.0 MB in 2.34 seconds
+    Download speed: 42.74 MB/s (341.89 Mbps)
+"""
+
+import sys
+import time
+import urllib.request
+import argparse
+from typing import Optional
+
+
+def format_bytes(bytes_value: int) -> str:
+    """Convert bytes to human-readable format."""
+    for unit in ["B", "KB", "MB", "GB"]:
+        if bytes_value < 1024.0:
+            return f"{bytes_value:.2f} {unit}"
+        bytes_value /= 1024.0
+    return f"{bytes_value:.2f} TB"
+
+
+def test_download_speed(url: str, size_hint: Optional[int] = None) -> tuple[float, int]:
+    """
+    Download a file and measure speed.
+
+    Returns:
+        Tuple of (duration_seconds, bytes_downloaded)
+    """
+    print(f"Testing download speed from: {url}")
+    print("Downloading...", flush=True)
+
+    start_time = time.time()
+
+    with urllib.request.urlopen(url) as response:
+        data = response.read()
+
+    duration = time.time() - start_time
+    bytes_downloaded = len(data)
+
+    return duration, bytes_downloaded
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test network speed for HF Jobs",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="https://huggingface.co/datasets/OpenWebText/resolve/main/README.md",
+        help="URL to download for testing (default: sample HF file)",
+    )
+    parser.add_argument(
+        "--large",
+        action="store_true",
+        help="Use a larger file for testing (~100MB model file)",
+    )
+
+    args = parser.parse_args()
+
+    # If --large flag is set, use a bigger file
+    test_url = args.url
+    if args.large:
+        # Use a model file that's about 100MB
+        test_url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/pytorch_model.bin"
+        print("Using large file test (~100MB)")
+
+    print("=" * 60)
+    print("HF Jobs Network Speed Test")
+    print("=" * 60)
+    print()
+
+    try:
+        duration, bytes_downloaded = test_download_speed(test_url)
+
+        # Calculate speeds
+        mb_downloaded = bytes_downloaded / (1024 * 1024)
+        speed_mbps = (bytes_downloaded * 8) / (duration * 1_000_000)  # Megabits per second
+        speed_mb_s = mb_downloaded / duration  # Megabytes per second
+
+        print()
+        print("=" * 60)
+        print("Results:")
+        print("=" * 60)
+        print(f"Downloaded: {format_bytes(bytes_downloaded)}")
+        print(f"Time: {duration:.2f} seconds")
+        print(f"Speed: {speed_mb_s:.2f} MB/s ({speed_mbps:.2f} Mbps)")
+        print("=" * 60)
+
+        # Exit successfully
+        return 0
+
+    except urllib.error.URLError as e:
+        print(f"\n❌ Error downloading file: {e}", file=sys.stderr)
+        print("\nThis could indicate network connectivity issues.", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Migrates the `jobs-utils` repo into the monorepo (seed-then-flip: `network-speed-test.py` + `README.md` downloaded from the Hub, superset gate ✅) and adds a new recipe:

### `list-recipes.py` — the zero-friction entry point
Lists **every** recipe across the `uv-scripts` org with a runnable URL for each, via `huggingface_hub`. No GPU, no token, no account — it only reads public repos, and runs locally in seconds:

```bash
uv run https://huggingface.co/datasets/uv-scripts/jobs-utils/raw/main/list-recipes.py
```

`--describe` also prints each script's docstring summary (slower — fetches each file).

**Why:** the OCR quickstart needs a token + GPU + Pro account — friction for the *very first* thing someone tries. This is the rung below: see the whole catalog with one local command, no setup. It's also the discovery entry point the org-card agent prompts point at (separate PR on `mirror-org-card`).

### Tested
- Runs locally: lists all 21 repos + their scripts with correct raw URLs (validated).
- Ruff clean.
- Superset gate ✅ (`network-speed-test.py` + `README.md` preserved; `list-recipes.py` added).

### Note — this folder is mirrored
Merging fires `sync-jobs-utils.yml` → creates/updates `uv-scripts/jobs-utils` live. The README's `list-recipes.py` section + a broadened intro are additive; the stale `hfjobs run` examples in the existing `network-speed-test` section were left untouched (out of scope).