### PR TITLE
Fix stale Jobs pricing claim (pay-as-you-go, no Pro subscription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
   davanstrien/ufo-ColPali your-username/ufo-ocr
 ```
 
-No `pip install`, no local setup. `--secrets HF_TOKEN` forwards your token so the job can write the output dataset back to the Hub. (Jobs needs the `hf` CLI — `uv tool install huggingface_hub` — and a [Pro, Team, or Enterprise](https://huggingface.co/pricing) account; it's pay-as-you-go, billed by the second, and a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors and prices.)
+No `pip install`, no local setup. `--secrets HF_TOKEN` forwards your token so the job can write the output dataset back to the Hub. (Jobs needs the `hf` CLI — `uv tool install huggingface_hub` — and a Hugging Face account with [pay-as-you-go credit](https://huggingface.co/pricing) — no subscription needed; it's billed by the second, and a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors and prices.)
 
 **Prefer your own machine?** A recipe is just a UV script, so on a box with the hardware it needs — most recipes here want a CUDA GPU — you can run it (or inspect it with `--help`) directly, no Jobs required:
 

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -10,7 +10,7 @@ A recipe is one self-contained Python file (a [PEP 723](https://peps.python.org/
 ## Requires
 
 - **`uv`** — `curl -LsSf https://astral.sh/uv/install.sh | sh`.
-- **The `hf` CLI** — `curl -LsSf https://hf.co/cli/install.sh | bash -s` (or `uv tool install "huggingface_hub[cli]"`). Authenticate with `hf auth login`, or set `HF_TOKEN`. Jobs needs a Pro/Team/Enterprise account.
+- **The `hf` CLI** — `curl -LsSf https://hf.co/cli/install.sh | bash -s` (or `uv tool install "huggingface_hub[cli]"`). Authenticate with `hf auth login`, or set `HF_TOKEN`. Jobs is pay-as-you-go (no subscription needed) — it just needs a Hugging Face account with credit.
 - **Strongly recommended — install the Hugging Face skills:** `hf skills add`. This installs the **`hf-cli`** skill (the full `hf` surface: jobs, auth, repos, datasets, buckets, webhooks) and stays current via `hf skills update`. The two compose: `uv-recipes` picks and runs a recipe, `hf-cli` drives everything else on the Hub.
 
 ## Run a recipe


### PR DESCRIPTION
HF Jobs no longer requires a Pro/Team/Enterprise subscription (gate removed May 2026) — it's pay-as-you-go, any account with credit. The README + uv-recipes skill still said 'Pro, Team, or Enterprise account', which overstates the barrier — bad for the launch pitch. Corrects both to 'pay-as-you-go, no subscription needed'.