### PR TITLE
Remove deprecated hf_transfer extra and HF_HUB_ENABLE_HF_TRANSFER env var

### DIFF
--- a/build-atlas/atlas-export-remote.py
+++ b/build-atlas/atlas-export-remote.py
@@ -417,8 +417,7 @@ def deploy_space_with_remote_data(
 
 
 def main():
-    # Enable HF Transfer for faster downloads if available
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+
 
     parser = argparse.ArgumentParser(
         description="Deploy Embedding Atlas with remote data loading",

--- a/build-atlas/atlas-export.py
+++ b/build-atlas/atlas-export.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "huggingface-hub[hf_transfer]",
+#     "huggingface-hub",
 #     "torch",  # For GPU detection
 #     "datasets",  # For dataset sampling
 # ]
@@ -130,7 +130,7 @@ def build_atlas_command(args) -> tuple[list, str, Optional[Path]]:
         dataset_input = args.dataset_id
 
     # Use uvx to run embedding-atlas with required dependencies
-    # Include hf-transfer for faster downloads when HF_HUB_ENABLE_HF_TRANSFER is set
+   
     cmd = [
         "uvx",
         "--with",
@@ -302,8 +302,7 @@ def deploy_to_space(
 
 
 def main():
-    # Enable HF Transfer for faster downloads if available
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+   
 
     parser = argparse.ArgumentParser(
         description="Generate and deploy static Embedding Atlas visualizations",

--- a/deduplication/semantic-dedupe.py
+++ b/deduplication/semantic-dedupe.py
@@ -4,7 +4,7 @@
 #     "semhash",
 #     "datasets",
 #     "huggingface-hub",
-#     "hf-transfer",
+#     
 # ]
 # ///
 
@@ -42,8 +42,7 @@ from datasets import Dataset, load_dataset
 from huggingface_hub import DatasetCard, login
 from semhash import SemHash
 
-# Enable fast transfers
-os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
 
 
 def parse_args():

--- a/ocr/deepseek-ocr.py
+++ b/ocr/deepseek-ocr.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "datasets",
-#     "huggingface-hub[hf_transfer]",
+#     "huggingface-hub",
 #     "pillow",
 #     "torch",
 #     "torchvision",
@@ -252,8 +252,7 @@ def main(
     # Track processing start time
     start_time = datetime.now()
 
-    # Enable HF_TRANSFER for faster downloads
-    os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
 
     # Login to HF if token provided
     HF_TOKEN = hf_token or os.environ.get("HF_TOKEN")

--- a/sam3/segment-objects.py
+++ b/sam3/segment-objects.py
@@ -4,7 +4,7 @@
 # dependencies = [
 #     "transformers>=5.4.0",
 #     "datasets",
-#     "huggingface-hub[hf_transfer]",
+#     "huggingface-hub",
 #     "pillow",
 #     "torch",
 #     "torchvision",

--- a/transcription/easytranscriber-transcribe.py
+++ b/transcription/easytranscriber-transcribe.py
@@ -14,7 +14,7 @@
 #     "soundfile",
 #     "librosa",
 #     "static-ffmpeg",
-#     "huggingface-hub[hf_transfer]",
+#     "huggingface-hub",
 # ]
 # ///
 


### PR DESCRIPTION
Closes #32

Drops the `[hf_transfer]` extra from `huggingface-hub` dependencies and removes 
`HF_HUB_ENABLE_HF_TRANSFER` env settings that are no longer needed since the Hub handles 
fast transfer natively.

