### PR TITLE
Add demo GIF atop the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Each script carries its own dependencies, so people and agents can run one witho
 
 A **recipe** here is one such script. Most read and write the [Hugging Face Hub](https://huggingface.co/datasets), so one script's output dataset becomes the next one's input.
 
+![Demo: OCR a whole image dataset with one command — no clone, no environment, straight from a Hub URL](ocr/demo.gif)
+
 ## Quickstart
 
 **First, install [uv](https://docs.astral.sh/uv/getting-started/installation/)** — it's the only thing you install; every script brings its own Python dependencies:


### PR DESCRIPTION
Adds `ocr/demo.gif` (rendered from the existing `ocr/demo.cast`: 6× speed, 1:06, 4.9 MB — under GitHub's ~10 MB README image limit) and references it in the root README between the intro and the Quickstart.

This was the remaining 'demo GIF' item from the launch checklist — the recording assets existed but were referenced nowhere. The demo shows the funnel we want: a recipe run straight from its Hub URL.

Note: the GIF lands in `ocr/`, so merging triggers the ocr → `uv-scripts/ocr` sync (additive: one new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)