### PR TITLE
build-atlas: make the GPU pipeline actually run (cuML, mounts, deps, portable e2e)

### DIFF
--- a/build-atlas/README.md
+++ b/build-atlas/README.md
@@ -54,8 +54,9 @@ uv run atlas-e2e.py stanfordnlp/imdb \
 
 ```bash
 # 1. Build atlas on GPU (runs as HF Job)
+# (bucket mounts at /output — Jobs reserves /data for the script artifact)
 hf jobs uv run --flavor a100-large \
-    -v hf://buckets/user/atlas-data:/data \
+    -v hf://buckets/user/atlas-data:/output \
     -s HF_TOKEN --timeout 2h \
     atlas-build-gpu.py my-org/my-dataset \
     --text text --name my-atlas --sample 1000000
@@ -78,9 +79,9 @@ hf jobs uv run --flavor cpu-upgrade \
 
 # Build: embed the prepped data
 hf jobs uv run --flavor a100-large \
-    -v hf://buckets/user/atlas-data:/data \
+    -v hf://buckets/user/atlas-data:/output \
     -s HF_TOKEN --timeout 2h \
-    atlas-build-gpu.py /data/books/books.parquet \
+    atlas-build-gpu.py /output/books/books.parquet \
     --text title --name books-atlas --sample 2000000
 
 # Deploy

--- a/build-atlas/atlas-build-gpu.py
+++ b/build-atlas/atlas-build-gpu.py
@@ -3,8 +3,15 @@
 # dependencies = [
 #     "embedding-atlas>=0.19.1",
 #     "datasets",
-#     "cuml-cu12",
+#     "cuml-cu12>=25.10",
+#     "accelerate",
+#     "torch>=2.4",
 # ]
+#
+# [tool.uv]
+# # The NVIDIA index also hosts stale torch wheels; best-match keeps torch on PyPI
+# # while cuml still resolves from the NVIDIA index.
+# index-strategy = "unsafe-best-match"
 #
 # [[tool.uv.index]]
 # url = "https://pypi.nvidia.com"

--- a/build-atlas/atlas-build-gpu.py
+++ b/build-atlas/atlas-build-gpu.py
@@ -7,7 +7,7 @@
 # ]
 #
 # [[tool.uv.index]]
-# url = "https://pypi.nvidia.com/simple"
+# url = "https://pypi.nvidia.com"
 # ///
 
 """Build an Embedding Atlas visualization with GPU-accelerated UMAP.
@@ -19,27 +19,27 @@ Examples:
 
     # From a prepped parquet in a bucket
     hf jobs uv run --flavor a100-large \\
-        -v hf://buckets/user/atlas-data:/data \\
+        -v hf://buckets/user/atlas-data:/output \\
         -s HF_TOKEN --timeout 2h \\
-        atlas-build-gpu.py /data/books.parquet \\
+        atlas-build-gpu.py /output/books.parquet \\
         --text title --sample 2000000 --name my-atlas
 
     # From an HF dataset
     hf jobs uv run --flavor a100-large \\
-        -v hf://buckets/user/atlas-data:/data \\
+        -v hf://buckets/user/atlas-data:/output \\
         -s HF_TOKEN --timeout 2h \\
         atlas-build-gpu.py stanfordnlp/imdb \\
         --text text --split train --name imdb-atlas
+
+The bucket is mounted at /output, not /data: Jobs reserves /data for the uploaded
+script artifact when you pass a local script path.
 """
 
 import argparse
 import json
 import os
-import subprocess
 import sys
 import time
-
-os.environ["CUML_ACCEL_ENABLED"] = "1"
 
 
 def main():
@@ -52,7 +52,9 @@ def main():
     parser.add_argument("--sample", type=int, default=None, help="Number of rows to sample")
     parser.add_argument("--batch-size", type=int, default=256, help="Embedding batch size")
     parser.add_argument("--model", default=None, help="Embedding model name")
-    parser.add_argument("--output-dir", default="/data", help="Base output directory")
+    parser.add_argument("--output-dir", default="/output", help="Base output directory")
+    parser.add_argument("--allow-cpu", action="store_true",
+                        help="Run without a GPU (slow: CPU embedding + CPU UMAP)")
     args = parser.parse_args()
 
     atlas_output = os.path.join(args.output_dir, args.name)
@@ -64,45 +66,65 @@ def main():
     print(f"Sample: {args.sample}")
     print(f"Batch size: {args.batch_size}")
 
-    # Report GPU/cuml status
     gpu_info = {}
     try:
-        import cuml
-        print(f"cuML: {cuml.__version__}")
-        gpu_info["cuml_version"] = cuml.__version__
-    except ImportError:
-        print("WARNING: cuml not available, falling back to CPU UMAP")
-
-    try:
         import torch
-        if torch.cuda.is_available():
-            gpu_info["gpu"] = torch.cuda.get_device_name()
-            print(f"GPU: {gpu_info['gpu']}")
+        cuda_available = torch.cuda.is_available()
     except ImportError:
-        pass
+        cuda_available = False
+    if cuda_available:
+        gpu_info["gpu"] = torch.cuda.get_device_name()
+        print(f"GPU: {gpu_info['gpu']}")
+    elif not args.allow_cpu:
+        print("ERROR: no CUDA GPU available. Run on a GPU flavor, or pass --allow-cpu "
+              "to accept a much slower CPU build.")
+        sys.exit(1)
+    else:
+        print("WARNING: no GPU — running embedding and UMAP on CPU (--allow-cpu)")
 
-    start = time.time()
+    # cuml.accel patches umap-learn so embedding-atlas's UMAP runs on GPU. It must be
+    # installed in-process *before* embedding_atlas imports umap — an env var or a plain
+    # subprocess does not engage it.
+    if cuda_available:
+        try:
+            import cuml.accel
 
-    cmd = ["embedding-atlas", args.input, "--text", args.text,
-           "--batch-size", str(args.batch_size),
-           "--export-application", atlas_output]
+            cuml.accel.install()
+            import cuml
+
+            gpu_info["cuml_version"] = cuml.__version__
+            print(f"cuml.accel installed (cuML {cuml.__version__}) — UMAP will run on GPU")
+        except Exception as e:
+            print(f"WARNING: cuml.accel unavailable ({e}) — UMAP falls back to CPU")
+
+    from embedding_atlas.cli import main as atlas_cli
+
+    cli_args = [args.input, "--text", args.text,
+                "--batch-size", str(args.batch_size),
+                "--export-application", atlas_output]
 
     if args.image:
-        cmd.extend(["--image", args.image])
+        cli_args.extend(["--image", args.image])
     if args.model:
-        cmd.extend(["--model", args.model])
+        cli_args.extend(["--model", args.model])
     if args.split:
-        cmd.extend(["--split", args.split])
+        cli_args.extend(["--split", args.split])
     if args.sample:
-        cmd.extend(["--sample", str(args.sample)])
+        cli_args.extend(["--sample", str(args.sample)])
 
-    print(f"\nRunning: {' '.join(cmd)}\n")
-    result = subprocess.run(cmd, env=os.environ)
+    print(f"\nRunning: embedding-atlas {' '.join(cli_args)}\n")
+    start = time.time()
+
+    returncode = 0
+    try:
+        atlas_cli(args=cli_args)
+    except SystemExit as e:
+        returncode = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
     elapsed = time.time() - start
 
-    if result.returncode != 0:
-        print(f"\nFailed with exit code {result.returncode} after {elapsed:.1f}s")
-        sys.exit(result.returncode)
+    if returncode != 0:
+        print(f"\nFailed with exit code {returncode} after {elapsed:.1f}s")
+        sys.exit(returncode)
 
     # Write config sidecar for atlas-deploy.py
     parquet_path = os.path.join(atlas_output, "data", "dataset.parquet")

--- a/build-atlas/atlas-e2e.py
+++ b/build-atlas/atlas-e2e.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "huggingface-hub>=1.9.0",
+#     "huggingface-hub>=1.12.0",
 # ]
 # ///
 
@@ -44,16 +44,32 @@ import sys
 import time
 from pathlib import Path
 
-from huggingface_hub import HfApi, create_bucket
+from huggingface_hub import HfApi, Volume, create_bucket, get_token, run_uv_job
+
+# Where the sibling scripts live on the Hub, so this orchestrator also works when run
+# straight from a URL (uv downloads only this one file).
+HUB_RAW = "https://huggingface.co/datasets/uv-scripts/build-atlas/raw/main"
+
+TERMINAL_STAGES = ("COMPLETED", "ERROR", "CANCELED")
+
+
+def resolve_script(name: str) -> str:
+    """Use the sibling script if it exists locally, else its Hub raw URL."""
+    local = Path(__file__).parent / name
+    if local.exists():
+        return str(local)
+    url = f"{HUB_RAW}/{name}"
+    print(f"{name} not found locally — using {url}")
+    return url
 
 
 def wait_for_job(api: HfApi, job_id: str, poll_interval: int = 30) -> str:
-    """Poll a Job until it completes. Returns the final stage."""
+    """Poll a Job until it reaches a terminal stage. Returns the final stage."""
     print(f"\nWaiting for Job {job_id}...")
     while True:
         job = api.inspect_job(job_id=job_id)
         stage = job.status.stage
-        if stage in ("COMPLETED", "ERROR"):
+        if stage in TERMINAL_STAGES:
             msg = job.status.message or ""
             print(f"Job {stage}" + (f": {msg}" if msg else ""))
             return stage
@@ -93,6 +109,9 @@ def main():
 
     args = parser.parse_args()
 
+    if args.build_only and args.deploy_only:
+        parser.error("--build-only and --deploy-only are mutually exclusive")
+
     api = HfApi()
     user = api.whoami()["name"]
 
@@ -122,60 +141,39 @@ def main():
     if not args.deploy_only:
         print(f"\n[2/3] Submitting build Job ({args.flavor})...")
 
-        build_script = Path(__file__).parent / "atlas-build-gpu.py"
-        if not build_script.exists():
-            print(f"ERROR: {build_script} not found")
-            print("atlas-build-gpu.py must be in the same directory as this script")
-            sys.exit(1)
+        build_script = resolve_script("atlas-build-gpu.py")
 
-        # Build the hf jobs command
-        cmd = [
-            "hf", "jobs", "uv", "run",
-            "--flavor", args.flavor,
-            "-v", f"hf://buckets/{args.bucket}:/data",
-            "-s", "HF_TOKEN",
-            "--timeout", args.timeout,
-            str(build_script),
+        script_args = [
             args.input,
             "--name", args.name,
             "--text", args.text,
             "--batch-size", str(args.batch_size),
         ]
-
         if args.split:
-            cmd.extend(["--split", args.split])
+            script_args.extend(["--split", args.split])
         if args.sample:
-            cmd.extend(["--sample", str(args.sample)])
+            script_args.extend(["--sample", str(args.sample)])
         if args.image:
-            cmd.extend(["--image", args.image])
+            script_args.extend(["--image", args.image])
         if args.model:
-            cmd.extend(["--model", args.model])
+            script_args.extend(["--model", args.model])
 
-        print(f"Command: {' '.join(cmd)}\n")
+        job = run_uv_job(
+            build_script,
+            script_args=script_args,
+            flavor=args.flavor,
+            timeout=args.timeout,
+            secrets={"HF_TOKEN": get_token()},
+            volumes=[Volume(type="bucket", source=args.bucket, mount_path="/data")],
+        )
 
-        # Run and capture job ID from output
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        output = result.stdout + result.stderr
-
-        # Extract job ID
-        job_id = None
-        for line in output.split("\n"):
-            if "Job started with ID:" in line:
-                job_id = line.split("Job started with ID:")[-1].strip()
-                break
-
-        if job_id is None:
-            print("ERROR: Could not extract Job ID from output:")
-            print(output)
-            sys.exit(1)
-
-        print(f"Job submitted: {job_id}")
-        print(f"View: https://huggingface.co/jobs/{user}/{job_id}")
+        print(f"Job submitted: {job.id}")
+        print(f"View: https://huggingface.co/jobs/{user}/{job.id}")
 
         # Wait for completion
-        stage = wait_for_job(api, job_id)
+        stage = wait_for_job(api, job.id)
         if stage != "COMPLETED":
-            print(f"\nJob failed. Check logs: https://huggingface.co/jobs/{user}/{job_id}")
+            print(f"\nJob did not complete ({stage}). Check logs: https://huggingface.co/jobs/{user}/{job.id}")
             sys.exit(1)
 
         print("Build complete!")
@@ -188,14 +186,11 @@ def main():
     # ── Step 3: Deploy Space ──
     print(f"\n[3/3] Deploying Space {args.space_id}...")
 
-    deploy_script = Path(__file__).parent / "atlas-deploy.py"
-    if not deploy_script.exists():
-        print(f"ERROR: {deploy_script} not found")
-        sys.exit(1)
+    deploy_script = resolve_script("atlas-deploy.py")
 
     deploy_cmd = [
         "uv", "run",
-        str(deploy_script),
+        deploy_script,
         "--name", args.name,
         "--bucket", args.bucket,
         "--space-id", args.space_id,

--- a/build-atlas/atlas-e2e.py
+++ b/build-atlas/atlas-e2e.py
@@ -143,11 +143,14 @@ def main():
 
         build_script = resolve_script("atlas-build-gpu.py")
 
+        # The bucket mounts at /output — Jobs reserves /data for the uploaded script
+        # artifact when the build script is passed as a local path.
         script_args = [
             args.input,
             "--name", args.name,
             "--text", args.text,
             "--batch-size", str(args.batch_size),
+            "--output-dir", "/output",
         ]
         if args.split:
             script_args.extend(["--split", args.split])
@@ -164,7 +167,7 @@ def main():
             flavor=args.flavor,
             timeout=args.timeout,
             secrets={"HF_TOKEN": get_token()},
-            volumes=[Volume(type="bucket", source=args.bucket, mount_path="/data")],
+            volumes=[Volume(type="bucket", source=args.bucket, mount_path="/output")],
         )
 
         print(f"Job submitted: {job.id}")


### PR DESCRIPTION
Fixes found while reviewing `build-atlas` against current Jobs and embedding-atlas 0.21.0. As published, `atlas-build-gpu.py` could not have run successfully (broken NVIDIA index URL → guaranteed install failure), and the documented `-v …:/data` mount now errors on Jobs.

**Commits (each self-contained):**
1. **atlas-e2e: portable + API-based** — sibling scripts fall back to Hub raw URLs (works via `uv run <URL>`, no clone); `run_uv_job()` + `Volume` instead of shelling out to `hf jobs` and regex-scraping the job ID; `CANCELED` treated as terminal (was an infinite poll loop); `--build-only` + `--deploy-only` rejected together.
2. **atlas-build-gpu: loud cuML activation + GPU check** — NVIDIA index URL `/simple` → root (`/simple` 404s, so uv fell back to PyPI's placeholder sdist and **the install always failed** — this script can't have run as published). Replaces the `CUML_ACCEL_ENABLED=1` env var with an explicit in-process `cuml.accel.install()`: the env var is a [documented activation mechanism](https://docs.rapids.ai/api/cuml/stable/cuml-accel/) that does cover subprocesses, but per the same docs it is **silently ignored when cuML isn't installed properly** — which is exactly the failure mode this script was in. `install()` + the success/warning print makes GPU UMAP verifiable from the job log. Also adds a hard CUDA check with `--allow-cpu`, per AGENTS.md convention.
3. **Mount `/data` → `/output`** everywhere on the Jobs side — Jobs reserves `/data` for the uploaded script artifact on local-script runs (`Mount path '/data' is reserved for Jobs artifacts`). Space-side mount in atlas-deploy is unaffected.
4. **Dependency floors** — `torch>=2.4` + `index-strategy = unsafe-best-match` (NVIDIA index hosts torch 2.3.1; first-index-wins picked it and transformers disabled torch → `NameError: nn`); `cuml-cu12>=25.10` (stops backtracking into dead PyPI placeholder versions); `accelerate`.

**Validation (l4x1):**
- `atlas-build-gpu.py` job `6a299379` **COMPLETED**: `GPU: NVIDIA L4` · `cuml.accel installed (cuML 26.02) — UMAP will run on GPU` · 2,000-row IMDB atlas built and written to the bucket in 62.6s.
- `atlas-e2e.py --build-only` run locally: bucket step → `run_uv_job` upload/submit → poll → job `6a2a8314` **COMPLETED**.

Note: the e2e URL-fallback path points at the Hub copies, so it becomes fully functional once this merges and the `build-atlas` sync runs. (Commit 2's message overstates the env-var issue — the PR body here is the corrected account; squash-merge will keep this version.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)