### PR TITLE
ocr/README: slim the lift-extract.py blurb to match siblings

### DIFF
--- a/ocr/README.md
+++ b/ocr/README.md
@@ -84,15 +84,7 @@ Most scripts here output markdown. These take a **schema** and return **structur
 
 Pass `--schema` (inline JSON, a URL, or a file path). The LFM models are small and fast; run them on the `vllm/vllm-openai` image so the CUDA toolkit is present (each script's docstring has the exact command). Because `lfm2-extract.py` works on a **text** column, you can **chain it after OCR**: a recipe above turns a page into `markdown`, then `lfm2-extract.py` turns that markdown into fields.
 
-`lift-extract.py` is the heavyweight of the group: Datalab's 9B model does **schema-constrained** decoding (output is guaranteed valid against your JSON Schema) and is the only recipe here that takes **multi-page PDFs** directly — a whole document (`--pdf-column`, `--page-range`) collapses into one extraction. It runs in-process two ways — `--method hf` (Transformers, default image, best for small jobs) or `--method vllm` (vLLM's offline engine on the `vllm/vllm-openai` image, faster at scale via continuous batching) — both single-command, no server. The vLLM path mirrors lift's own structured-output recipe (schema-constrained JSON decoding); benchmark the two by pushing each to one repo with `--config hf` / `--config vllm`. **License:** the code is Apache-2.0 but the weights are a modified OpenRAIL-M (free for research, personal use, and startups under $5M funding/revenue; no competitive use against Datalab's API) — confirm you're within those terms.
-
-```bash
-# images or multi-page PDFs → schema-constrained JSON (9B, runs on the default image)
-hf jobs uv run --flavor a100-large --secrets HF_TOKEN \
-    https://huggingface.co/datasets/uv-scripts/ocr/raw/main/lift-extract.py \
-    your-input-dataset your-output-dataset \
-    --schema '{"type":"object","properties":{"title":{"type":"string"}}}' --max-samples 5
-```
+`lift-extract.py` is the one outlier: a 9B model that also reads **multi-page PDFs** (`--pdf-column`, `--page-range`) and runs on either Transformers (`--method hf`) or vLLM (`--method vllm`). Its weights are **modified OpenRAIL-M** (free for research, personal use, and startups under $5M; no competitive use against Datalab's API) — the only non-permissive license here, so check the terms.
 
 ```bash
 # image → JSON directly


### PR DESCRIPTION
Follow-up to #51 — trims the `lift-extract.py` entry in `ocr/README.md`.

It had a 5-sentence dedicated paragraph **and** its own code block, while every other recipe in the *Structured extraction* section is just a table row served by the shared paragraph + single example. This replaces it with one short note covering only what's genuinely lift-specific:

- multi-page PDF input (`--pdf-column`, `--page-range`),
- the two backends (`--method hf` / `--method vllm`),
- the **modified OpenRAIL-M** license (the only non-permissive model in the group).

Net −8 lines; drops the redundant second code block. Table row unchanged. The backend/benchmarking detail still lives in the script's `--help` and docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
