### PR TITLE
ocr: add serving-unlimited-ocr.md (serve Unlimited-OCR as a live endpoint on HF Jobs)

### DIFF
--- a/ocr/README.md
+++ b/ocr/README.md
@@ -33,7 +33,7 @@ This will:
 
 ## Serve a model as a live endpoint
 
-Want a live, OpenAI-compatible endpoint instead of a batch run — to poke at a model interactively, point an agent at it, or fan out a quick concurrent batch? [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) exposes a port on a GPU Job: a temporary endpoint that bills by the minute and self-destructs on `--timeout`. See **[serving-unlimited-ocr.md](serving-unlimited-ocr.md)** for a one-command worked example (Baidu's [Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR), served with SGLang).
+The recipes here run as batch jobs. To call a model interactively, from an agent, or with concurrent ad-hoc requests, you can instead run it as a temporary endpoint: [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) exposes a port on a GPU Job, giving an OpenAI-compatible endpoint that runs until the job is cancelled or its `--timeout` is reached. See [serving-unlimited-ocr.md](serving-unlimited-ocr.md) for a worked example serving Baidu's [Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) with SGLang.
 
 ## Models at a glance
 

--- a/ocr/README.md
+++ b/ocr/README.md
@@ -31,6 +31,10 @@ This will:
 - Push the results to a new dataset
 - View results at: `https://huggingface.co/datasets/[your-output-dataset]`
 
+## Serve a model as a live endpoint
+
+Want a live, OpenAI-compatible endpoint instead of a batch run — to poke at a model interactively, point an agent at it, or fan out a quick concurrent batch? [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) exposes a port on a GPU Job: a temporary endpoint that bills by the minute and self-destructs on `--timeout`. See **[serving-unlimited-ocr.md](serving-unlimited-ocr.md)** for a one-command worked example (Baidu's [Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR), served with SGLang).
+
 ## Models at a glance
 
 **Start here:** for a quick first run, try **`lighton-ocr2.py`** (1B, very fast) or **`paddleocr-vl-1.6.py`** (0.9B, current OmniDocBench SOTA); for the smallest footprint, **`falcon-ocr.py`** (0.3B, strong on tables). Reach for a 7–8B model only when quality demands it. Several of these models sit on the public [olmOCR-Bench](https://huggingface.co/datasets/allenai/olmOCR-bench) — pull the live ranking from your terminal in one command:

--- a/ocr/serving-unlimited-ocr.md
+++ b/ocr/serving-unlimited-ocr.md
@@ -1,17 +1,17 @@
 # Serve Unlimited-OCR as a live endpoint on HF Jobs
 
-Most recipes here run OCR as a **batch** job (dataset in → dataset out). Sometimes you'd rather
-have a **live endpoint** instead — to poke at a model interactively, point an agent at it, or fan
-out a quick concurrent batch. [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) lets
-you do that: expose a port on a GPU Job and you get a temporary, OpenAI-compatible endpoint that
-bills by the minute and disappears when the job stops.
+The OCR recipes in this folder run as batch jobs (dataset in → dataset out). To call a model
+interactively, from an agent, or with ad-hoc concurrent requests, you can instead run it as a
+temporary HTTP endpoint. [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) exposes a
+port on a GPU Job, giving an OpenAI-compatible endpoint that runs until the job is cancelled or its
+`--timeout` is reached.
 
-This is a worked example for **[baidu/Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR)**
-(3B, MIT, built on DeepSeek-OCR; one-shot long-horizon multi-page parsing). It ships its own SGLang
-build, so we serve it on the stock `lmsysorg/sglang` image and overlay the 12 MB wheel at startup —
-no custom image to build.
+This is a worked example for [baidu/Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR)
+(3B, MIT, based on DeepSeek-OCR; supports multi-page parsing in a single request). The model ships
+its own SGLang build, so it runs on the stock `lmsysorg/sglang` image with the 12 MB wheel
+installed at startup; no custom image is required.
 
-## 1. Start the server (one command)
+## 1. Start the server
 
 ```bash
 hf jobs run --detach --expose 10000 --flavor h200 -s HF_TOKEN --timeout 30m \
@@ -25,16 +25,16 @@ hf jobs run --detach --expose 10000 --flavor h200 -s HF_TOKEN --timeout 30m \
 ```
 
 Notes:
-- **`--`** before `bash` is required — otherwise the CLI parses `-lc` as its own flags.
-- **`--timeout 30m`** bounds cost: the endpoint (and billing) auto-stops at the deadline.
-  `hf jobs cancel <id>` stops it sooner.
-- **`--flavor h200`** because the model's `fa3` attention backend needs a Hopper GPU. The model is
-  small, so fa3 (not GPU memory) is what dictates the flavor. (`hf jobs hardware` lists the options.)
-- Watch it come up with `hf jobs logs -f <id>`; ready at `Application startup complete` (~3 min).
+- `--` before `bash` is required, or the CLI parses `-lc` as its own flags.
+- `--timeout` stops the endpoint (and billing) at the deadline; `hf jobs cancel <id>` stops it earlier.
+- `fa3` requires a Hopper GPU (e.g. `h200`). The model is small, so the attention backend, not GPU
+  memory, determines the flavor. Run `hf jobs hardware` for available flavors.
+- Follow startup with `hf jobs logs -f <id>`; the server is ready at `Application startup complete`
+  (about 3 minutes from a cold start).
 
-## 2. Call it (any OpenAI client; your HF token is the API key)
+## 2. Call it (OpenAI client; HF token as the API key)
 
-The exposed port is at `https://<job_id>--10000.hf.jobs` (base URL = `…/v1`).
+The exposed port is at `https://<job_id>--10000.hf.jobs`; the OpenAI base URL is that plus `/v1`.
 
 ```python
 import base64, os
@@ -55,13 +55,13 @@ r = client.chat.completions.create(
 print(r.choices[0].message.content)
 ```
 
-Output is **layout-grounded** markdown — each block tagged `<|det|>type [x1,y1,x2,y2]<|/det|> text`
-with coords normalized 0–1000. Strip the tags for plain text
-(`re.sub(r'<\|det\|>.*?<\|/det\|>', '', text)`); keep them for structure.
+Output is layout-grounded markdown: each block is tagged `<|det|>type [x1,y1,x2,y2]<|/det|> text`,
+with coordinates normalized to 0–1000. Remove the tags for plain text
+(`re.sub(r'<\|det\|>.*?<\|/det\|>', '', text)`) or keep them for structure.
 
-## 3. Multi-page / PDF (the "Unlimited" path)
+## 3. Multi-page / PDF
 
-Send several page images in **one** request with `Multi page parsing.` + `image_mode="base"`:
+Send multiple page images in one request with the `Multi page parsing.` prompt and `image_mode="base"`:
 
 ```python
 parts = [{"type": "text", "text": "Multi page parsing."}]
@@ -77,16 +77,15 @@ r = client.chat.completions.create(
 )
 ```
 
-Pages are `<PAGE>`-separated, with tables as HTML, equations as LaTeX, and reading order preserved
-across pages. Context is 32k tokens, so chunk very long documents.
+Pages are separated by `<PAGE>`; tables are returned as HTML and equations as LaTeX, with reading
+order preserved across pages. The context length is 32k tokens, so split longer documents.
 
-## 4. Batch via concurrency (point an agent at it)
+## 4. Concurrency
 
-SGLang batches concurrent requests, so an agent/script can fire many async requests at the running
-endpoint (the upstream [`infer.py`](https://github.com/baidu/Unlimited-OCR/blob/main/infer.py) runs
-a `ThreadPoolExecutor` at `concurrency=8`). For a *very* large corpus, a co-located batch job
-(compute next to the data, resumable, no network egress) is more robust — but endpoint + async is
-great for interactive and agent-driven runs.
+SGLang batches concurrent requests, so a client can send many requests in parallel to one endpoint;
+the upstream [`infer.py`](https://github.com/baidu/Unlimited-OCR/blob/main/infer.py) uses a
+`ThreadPoolExecutor` at `concurrency=8`. For a large corpus, a batch job that runs next to the data
+(resumable, no network transfer) is usually a better fit than a client-to-endpoint loop.
 
 ## 5. Stop it
 
@@ -94,6 +93,5 @@ great for interactive and agent-driven runs.
 hf jobs cancel <job_id>
 ```
 
-> Billing is per-minute on top of the GPU flavor, plus a small flat fee for the exposed port;
-> scheduling time is free. Run `hf jobs hardware` for current flavors and prices. A short session
-> is roughly the cost of a coffee.
+Billing is per-minute for the GPU flavor plus a small flat fee for the exposed port; scheduling time
+is not billed. Run `hf jobs hardware` for current flavors and prices.

--- a/ocr/serving-unlimited-ocr.md
+++ b/ocr/serving-unlimited-ocr.md
@@ -1,0 +1,98 @@
+# Serve Unlimited-OCR as a live endpoint on HF Jobs
+
+Most recipes here run OCR as a **batch** job (dataset in → dataset out). Sometimes you'd rather
+have a **live endpoint** instead — to poke at a model interactively, point an agent at it, or fan
+out a quick concurrent batch. [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) lets
+you do that: expose a port on a GPU Job and you get a temporary, OpenAI-compatible endpoint that
+bills by the minute and disappears when the job stops.
+
+This is a worked example for **[baidu/Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR)**
+(3B, MIT, built on DeepSeek-OCR; one-shot long-horizon multi-page parsing). It ships its own SGLang
+build, so we serve it on the stock `lmsysorg/sglang` image and overlay the 12 MB wheel at startup —
+no custom image to build.
+
+## 1. Start the server (one command)
+
+```bash
+hf jobs run --detach --expose 10000 --flavor h200 -s HF_TOKEN --timeout 30m \
+  lmsysorg/sglang:latest -- \
+  bash -lc 'pip install --no-deps https://github.com/baidu/Unlimited-OCR/raw/main/wheel/sglang-0.0.0.dev11416+g92e8bb79e-py3-none-any.whl \
+    && pip install -q kernels==0.11.7 \
+    && python -m sglang.launch_server --model baidu/Unlimited-OCR --served-model-name Unlimited-OCR \
+       --attention-backend fa3 --page-size 1 --mem-fraction-static 0.8 --context-length 32768 \
+       --enable-custom-logit-processor --disable-overlap-schedule --skip-server-warmup \
+       --host 0.0.0.0 --port 10000'
+```
+
+Notes:
+- **`--`** before `bash` is required — otherwise the CLI parses `-lc` as its own flags.
+- **`--timeout 30m`** bounds cost: the endpoint (and billing) auto-stops at the deadline.
+  `hf jobs cancel <id>` stops it sooner.
+- **`--flavor h200`** because the model's `fa3` attention backend needs a Hopper GPU. The model is
+  small (≈ a fraction of 141 GB) — fa3, not memory, is the constraint.
+- Watch it come up with `hf jobs logs -f <id>`; ready at `Application startup complete` (~3 min).
+
+## 2. Call it (any OpenAI client; your HF token is the API key)
+
+The exposed port is at `https://<job_id>--10000.hf.jobs` (base URL = `…/v1`).
+
+```python
+import base64, os
+from openai import OpenAI
+
+client = OpenAI(base_url="https://<job_id>--10000.hf.jobs/v1", api_key=os.environ["HF_TOKEN"])
+img = base64.b64encode(open("page.jpg", "rb").read()).decode()
+
+r = client.chat.completions.create(
+    model="Unlimited-OCR",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "document parsing."},
+        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img}"}},
+    ]}],
+    temperature=0,
+    extra_body={"images_config": {"image_mode": "gundam"}},  # "gundam" (crop-tiling) or "base"
+)
+print(r.choices[0].message.content)
+```
+
+Output is **layout-grounded** markdown — each block tagged `<|det|>type [x1,y1,x2,y2]<|/det|> text`
+with coords normalized 0–1000. Strip the tags for plain text
+(`re.sub(r'<\|det\|>.*?<\|/det\|>', '', text)`); keep them for structure.
+
+## 3. Multi-page / PDF (the "Unlimited" path)
+
+Send several page images in **one** request with `Multi page parsing.` + `image_mode="base"`:
+
+```python
+parts = [{"type": "text", "text": "Multi page parsing."}]
+for page_png in page_images:            # e.g. PDF pages rendered with pymupdf at ~150 dpi
+    b64 = base64.b64encode(open(page_png, "rb").read()).decode()
+    parts.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+
+r = client.chat.completions.create(
+    model="Unlimited-OCR",
+    messages=[{"role": "user", "content": parts}],
+    temperature=0, max_tokens=16384,
+    extra_body={"images_config": {"image_mode": "base"}},
+)
+```
+
+Pages are `<PAGE>`-separated, with tables as HTML, equations as LaTeX, and reading order preserved
+across pages. Context is 32k tokens, so chunk very long documents.
+
+## 4. Batch via concurrency (point an agent at it)
+
+SGLang batches concurrent requests, so an agent/script can fire many async requests at the running
+endpoint (the upstream [`infer.py`](https://github.com/baidu/Unlimited-OCR/blob/main/infer.py) runs
+a `ThreadPoolExecutor` at `concurrency=8`). For a *very* large corpus, a co-located batch job
+(compute next to the data, resumable, no network egress) is more robust — but endpoint + async is
+great for interactive and agent-driven runs.
+
+## 5. Stop it
+
+```bash
+hf jobs cancel <job_id>
+```
+
+> Billing: `h200` is $5.00/hr + a flat $0.01/hr for the exposed port, by the minute; scheduling
+> time is free. A short session is ~$1.

--- a/ocr/serving-unlimited-ocr.md
+++ b/ocr/serving-unlimited-ocr.md
@@ -29,7 +29,7 @@ Notes:
 - **`--timeout 30m`** bounds cost: the endpoint (and billing) auto-stops at the deadline.
   `hf jobs cancel <id>` stops it sooner.
 - **`--flavor h200`** because the model's `fa3` attention backend needs a Hopper GPU. The model is
-  small (≈ a fraction of 141 GB) — fa3, not memory, is the constraint.
+  small, so fa3 (not GPU memory) is what dictates the flavor. (`hf jobs hardware` lists the options.)
 - Watch it come up with `hf jobs logs -f <id>`; ready at `Application startup complete` (~3 min).
 
 ## 2. Call it (any OpenAI client; your HF token is the API key)
@@ -94,5 +94,6 @@ great for interactive and agent-driven runs.
 hf jobs cancel <job_id>
 ```
 
-> Billing: `h200` is $5.00/hr + a flat $0.01/hr for the exposed port, by the minute; scheduling
-> time is free. A short session is ~$1.
+> Billing is per-minute on top of the GPU flavor, plus a small flat fee for the exposed port;
+> scheduling time is free. Run `hf jobs hardware` for current flavors and prices. A short session
+> is roughly the cost of a coffee.


### PR DESCRIPTION
## What
Adds `ocr/serving-unlimited-ocr.md` — a copy-paste worked example for serving Baidu's [Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B, MIT, built on DeepSeek-OCR) as a **temporary, OpenAI-compatible GPU endpoint** via [HF Jobs serving](https://huggingface.co/docs/hub/jobs-serving) — plus a small "Serve a model as a live endpoint" pointer in `ocr/README.md` (after Quick Start).

## Why
Every recipe here runs OCR as a **batch** (dataset in → dataset out). Serving covers the other mode: poking at a model interactively, pointing an agent at a live endpoint, or fanning out a quick concurrent batch. The endpoint bills by the minute and self-destructs on `--timeout`.

## The doc covers
- one-command serve — stock `lmsysorg/sglang` image + the model's 12 MB custom SGLang wheel via `pip install --no-deps` (no custom image to build)
- calling it (OpenAI client; **HF token = API key**)
- multi-page / PDF one-shot parsing (the "Unlimited" path)
- concurrency / agent batching
- stop + cost

## Validation (2026-06-23, `h200` + fa3)
Server came up (`Application startup complete`, ~3 min cold start), then:
- OCR'd the front page of *The Commoner* (1901, from a Chronicling America mirror) in 13s — read the masthead the archive's own OCR mangled (`Vyilli&rri 4. Breugu` → **William J. Bryan**), full multi-column reading order.
- Parsed 6 PDF pages in **one** request — tables → HTML, equations → LaTeX, figures + captions, reading order preserved across pages.

~$1/session. **Additive only — no files deleted** (hub-sync safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
