### PR TITLE
pp-doclayout: keep dataset rows aligned when an image is unreadable

### DIFF
--- a/ocr/pp-doclayout.py
+++ b/ocr/pp-doclayout.py
@@ -195,7 +195,7 @@ def extract_detections(result: Any) -> List[Dict[str, Any]]:
 @dataclass
 class SourceItem:
     key: str  # stable identifier per image (used for dedup/resume)
-    image: Image.Image
+    image: Optional[Image.Image]  # None for an unreadable row (placeholder)
     extras: Dict[str, Any]  # original row fields (only populated for dataset source)
 
 
@@ -234,16 +234,23 @@ def iter_dataset_images(
     total = len(ds)
 
     def gen() -> Iterator[SourceItem]:
-        skipped = 0
+        failed = 0
         for i in range(total):
             try:
                 row = ds[i]
                 image = to_pil(row[image_column])
             except (UnidentifiedImageError, OSError) as e:
-                skipped += 1
+                # Still yield a placeholder so the output row stays aligned with
+                # the source row (the dataset sink writes layouts positionally).
+                failed += 1
                 logger.warning(
-                    f"Skipping unreadable image at row {i}: "
-                    f"{type(e).__name__}: {e}"
+                    f"Unreadable image at row {i}: "
+                    f"{type(e).__name__}: {e} — writing empty layout"
+                )
+                yield SourceItem(
+                    key=f"row-{i:08d}",
+                    image=None,
+                    extras={"failed": True},
                 )
                 continue
             yield SourceItem(
@@ -251,8 +258,8 @@ def iter_dataset_images(
                 image=image,
                 extras={},  # original schema is preserved by the sink via the dataset ref
             )
-        if skipped:
-            logger.info(f"Skipped {skipped} unreadable image(s) total")
+        if failed:
+            logger.info(f"{failed} unreadable image(s) written as empty layouts")
 
     return gen(), total, ds
 
@@ -952,6 +959,13 @@ def main(args: argparse.Namespace) -> None:
     for item in pbar:
         if item.key in completed:
             skipped += 1
+            continue
+        if item.extras.get("failed") or item.image is None:
+            # Unreadable source image — write an empty layout in position so the
+            # output stays row-aligned with the source dataset.
+            sink.write(item.key, [], {})
+            errors += 1
+            processed += 1
             continue
         try:
             arr = pil_to_array(item.image)


### PR DESCRIPTION
## Problem

`pp-doclayout.py` has the same latent row-alignment bug that #60 fixed in `pp-ocrv6.py`. In the **dataset-sink path**:

- the dataset-source generator *drops* unreadable images (`continue`, no yield);
- `finalize()` then pads empty layouts onto the **end** when `len(_layouts) != len(original_dataset)`, and does `original_dataset.add_column("layout", _layouts)`.

So if row *N* is corrupt, every row after *N* gets its `layout` shifted by one and the empty `"[]"` lands on the last row. It's silent — no crash, just a misaligned `layout` column. (The bucket sink is keyed by path, not position, so it's unaffected.)

This matters because `layout` is the structured-region output downstream consumers rely on (e.g. routing pages by table/figure presence) — a silent shift mislabels which pages have what.

## Fix

Mirror of #60 — three small edits, dataset-source path only:

1. `SourceItem.image` → `Optional[Image.Image]`.
2. Dataset generator: on an unreadable image, yield an in-position placeholder (`image=None, extras={"failed": True}`) instead of dropping it.
3. Main loop: for a placeholder, write an empty layout in position and skip the model call.

The bucket-source generator still drops unreadable images (correct — keyed by path).

## Verification

`ruff check` clean, compiles. Verified end-to-end on a `t4-small` Job (`PP-DocLayout-L`) against a 5-row dataset with a deliberately corrupt image at **idx 2**:

| idx | layout regions |
|---|---|
| 0 | 0 (genuine model-empty — handwritten page) |
| 1 | 18 |
| **2** | **0 — corrupt row, empty in position** |
| 3 | 14 |
| 4 | 20 |

Discriminator: under the old bug the empty would land at idx 4 (idx 2 would show idx 3's regions); observed is idx 2 empty / idx 4 populated — i.e. the fix holds. Job log: `Unreadable image at row 2 … writing empty layout` -> `Processed 5 (errors 1)`.

Follows #60.