### PR TITLE
agent-traces: add claude-code-agree-rate.py (local-introspection)

### DIFF
--- a/agent-traces/README.md
+++ b/agent-traces/README.md
@@ -1,0 +1,63 @@
+---
+viewer: false
+tags:
+  - uv-script
+  - agent-traces
+  - claude-code
+  - introspection
+license: apache-2.0
+---
+
+# Agent Traces
+
+Tools for working with **agent traces** — the logs coding agents leave behind. (`agent-traces` is also a [Hugging Face dataset format](https://huggingface.co/datasets?format=format:agent-traces); the scripts here analyse your *local* traces today and can grow toward converting them to that Hub format.)
+
+Unlike the rest of this repo, these are **local-introspection** scripts: they read logs on your own machine, not the Hub, so they run with plain `uv run` — no Jobs, no GPU, no token.
+
+## Available scripts
+
+### claude-code-agree-rate.py
+
+**How often do you take your coding agent's recommendation?**
+
+Claude Code can pause mid-task and ask you a multiple-choice question (the `AskUserQuestion` tool), often marking one option **"(Recommended)"**. This script scans your local Claude Code logs (`~/.claude/projects`) and reports how often you picked the recommended option when one was offered.
+
+Specific to Claude Code's log format — other coding agents record sessions differently, so an equivalent for another tool would be its own script in this folder.
+
+Run it (nothing to install but [uv](https://docs.astral.sh/uv/getting-started/installation/)):
+
+```bash
+uv run https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/main/agent-traces/claude-code-agree-rate.py
+```
+
+Example output:
+
+```
+You took the recommended option 72% of the time (33/46).
+
+files scanned                         : 485
+AskUserQuestion calls                 : 238  (207 answered)
+--------------------------------------------------------
+questions with a (Recommended) option : 53
+  answered                            : 46
+  skipped / rejected                  : 7
+    -> followed recommendation        : 33
+    -> chose a different listed option: 4
+    -> free-text / Other              : 9
+```
+
+The breakdown matters more than the headline: "didn't follow" splits into *picked a different option* (a real override) and *answered in free text* (often just asking a follow-up question, not overriding).
+
+Flags:
+
+- `--examples N` — show N answered cases (recommended option → what you chose)
+- `--json` — machine-readable output
+- `--path DIR` — scan a different log directory (default `~/.claude/projects`)
+
+**Privacy:** the default output is aggregate counts only and is safe to share. `--examples` prints the text of your questions and answers, which can include private project details — don't paste that publicly.
+
+### Notes / caveats
+
+- Relies on the `(Recommended)` label convention — a soft string, not a structured field — so it only catches recommendations marked that way.
+- Counts only questions you actually answered; skipped or clarified prompts are reported separately, not in the rate.
+- Stdlib only — no dependencies, no network. A raw-bytes pre-filter skips sessions that never call the tool, so it stays fast even over gigabytes of logs.

--- a/agent-traces/claude-code-agree-rate.py
+++ b/agent-traces/claude-code-agree-rate.py
@@ -1,0 +1,176 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""How often do you take your coding agent's recommendation?
+
+Claude Code can pause mid-task and ask you a multiple-choice question (the
+AskUserQuestion tool), often marking one option "(Recommended)". This script
+scans your local Claude Code logs and reports how often you picked the
+recommended option when one was offered.
+
+Runs on your own machine over ~/.claude/projects — no Hub, no GPU, no network.
+Read-only; the default output is aggregate counts only.
+
+Specific to Claude Code logs (the AskUserQuestion tool + ~/.claude/projects
+JSONL format). Other coding agents record sessions differently.
+
+Run it (nothing to install but uv):
+    uv run https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/main/agent-traces/claude-code-agree-rate.py
+    uv run claude-code-agree-rate.py --examples 20      # show each answered case
+    uv run claude-code-agree-rate.py --json             # machine-readable
+    uv run claude-code-agree-rate.py --path ~/some/dir  # scan a different log dir
+
+Privacy: --examples prints the text of your questions and answers, which can
+include private project details. The default (aggregate) output is safe to
+share; --examples output is not.
+"""
+import argparse
+import glob
+import hashlib
+import json
+import os
+import re
+
+PAIR = re.compile(r'"([^"]*?)"\s*=\s*"([^"]*?)"')  # "question"="answer"
+ANSWERED = "have been answered"
+
+# Only these lines can matter: the AskUserQuestion tool_use and its answered
+# tool_result. Gating on raw bytes before json.loads skips the ~99% of lines
+# (and whole sessions) that never touch the tool — a >2x speedup on large logs.
+_FILE_GATE = b"AskUserQuestion"
+_LINE_GATE = (b"AskUserQuestion", b"have been answered", b"doesn't want to proceed")
+
+
+def norm(s):
+    return re.sub(r"\s+", " ", (s or "").lower().replace("(recommended)", "")).strip()
+
+
+def iter_objs(path):
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return
+    if _FILE_GATE not in raw:  # whole file irrelevant — skip without parsing
+        return
+    for line in raw.splitlines():
+        if not any(g in line for g in _LINE_GATE):
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def blocks(obj):
+    content = (obj.get("message") or {}).get("content")
+    return content if isinstance(content, list) else []
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--path", default=os.path.expanduser("~/.claude/projects"),
+                        help="directory of Claude Code .jsonl logs (default: ~/.claude/projects)")
+    parser.add_argument("--examples", type=int, default=0,
+                        help="show N answered cases. WARNING: prints your question/answer text — do not share")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    files = glob.glob(os.path.join(args.path, "**", "*.jsonl"), recursive=True)
+
+    seen = set()
+    followed = other_listed = free_text = skipped = 0
+    total_calls = answered_calls = 0
+    examples = []
+
+    for f in files:
+        objs = list(iter_objs(f))
+        # map AskUserQuestion tool_use id -> its questions
+        questions_by_id = {}
+        for o in objs:
+            for b in blocks(o):
+                if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") == "AskUserQuestion":
+                    questions_by_id[b.get("id")] = (b.get("input") or {}).get("questions", [])
+        # map tool_use id -> answer string
+        result_by_id = {}
+        for o in objs:
+            for b in blocks(o):
+                if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id") in questions_by_id:
+                    c = b.get("content")
+                    result_by_id[b["tool_use_id"]] = c if isinstance(c, str) else json.dumps(c)
+
+        for tid, questions in questions_by_id.items():
+            total_calls += 1
+            result = result_by_id.get(tid, "")
+            is_answered = ANSWERED in result and bool(PAIR.search(result))
+            if is_answered:
+                answered_calls += 1
+            ans = {norm(q): a for q, a in PAIR.findall(result)} if is_answered else {}
+            for q in questions:
+                rec = next((o["label"] for o in q.get("options", [])
+                            if "(recommended)" in (o.get("label") or "").lower()), None)
+                if not rec:
+                    continue
+                qtext = q.get("question", "")
+                chosen = ans.get(norm(qtext))
+                key = hashlib.md5((norm(qtext) + "|" + norm(rec) + "|" + norm(str(chosen))).encode()).hexdigest()
+                if key in seen:  # dedup resumed-session duplicates
+                    continue
+                seen.add(key)
+                if not is_answered or chosen is None:
+                    skipped += 1
+                    continue
+                labels = {norm(o.get("label", "")) for o in q.get("options", [])}
+                multi = q.get("multiSelect")
+                if norm(chosen) == norm(rec) or (multi and norm(rec) and norm(rec) in norm(chosen)):
+                    followed += 1
+                    tag = "followed-rec"
+                elif norm(chosen) in labels:
+                    other_listed += 1
+                    tag = "other-listed"
+                else:
+                    free_text += 1
+                    tag = "free-text"
+                examples.append({"tag": tag, "recommended": rec, "chosen": chosen, "question": qtext})
+
+    answered = followed + other_listed + free_text
+    summary = {
+        "files_scanned": len(files),
+        "askuserquestion_calls": total_calls,
+        "answered_calls": answered_calls,
+        "rec_questions_answered": answered,
+        "rec_questions_skipped": skipped,
+        "followed_recommendation": followed,
+        "chose_other_listed": other_listed,
+        "free_text_other": free_text,
+        "rate": round(followed / answered, 3) if answered else None,
+    }
+
+    if args.json:
+        print(json.dumps({"summary": summary, "examples": examples}, indent=2))
+        return
+
+    if answered:
+        print(f"You took the recommended option {followed / answered:.0%} of the time ({followed}/{answered}).\n")
+    else:
+        print("No answered questions with a (Recommended) option found.\n")
+    print(f"files scanned                         : {summary['files_scanned']}")
+    print(f"AskUserQuestion calls                 : {total_calls}  ({answered_calls} answered)")
+    print("-" * 56)
+    print(f"questions with a (Recommended) option : {answered + skipped}")
+    print(f"  answered                            : {answered}")
+    print(f"  skipped / rejected                  : {skipped}")
+    print(f"    -> followed recommendation        : {followed}")
+    print(f"    -> chose a different listed option: {other_listed}")
+    print(f"    -> free-text / Other              : {free_text}")
+    if args.examples:
+        print("\nexamples (your text — do not share):")
+        for e in examples[: args.examples]:
+            mark = "Y" if e["tag"] == "followed-rec" else "n"
+            print(f"  [{mark}] {e['recommended'][:34]!r} -> {str(e['chosen'])[:34]!r}")
+            print(f"      {e['question'][:90]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new **agent-traces** folder for local agent-trace introspection tools, and a first script.

## `claude-code-agree-rate.py`

How often do you take your coding agent's recommendation? Claude Code can pause mid-task and ask a multiple-choice question (the `AskUserQuestion` tool), often marking one option `(Recommended)`. This stdlib UV script scans your local Claude Code logs (`~/.claude/projects`) and reports how often you picked the recommended option when one was offered.

```
You took the recommended option 72% of the time (33/46).

questions with a (Recommended) option : 53
  answered                            : 46
  skipped / rejected                  : 7
    -> followed recommendation        : 33
    -> chose a different listed option: 4
    -> free-text / Other              : 9
```

The breakdown is the point: "didn't follow" splits into a real override (picked a different option) vs. answering in free text (usually asking a follow-up, not overriding).

## Notes

- **Different category from the rest of the repo:** local-introspection, not a Jobs recipe. Reads logs on your own machine — no Hub I/O, no GPU — so it runs with plain `uv run` (precedent: `jobs-utils/`).
- **No sync workflow** — stays GitHub-only for now, not mirrored to the Hub.
- **Claude-Code-specific** by design (the `AskUserQuestion` + `~/.claude/projects` format); other agents log differently, so an equivalent for another tool would be its own script in this folder.
- Stdlib only, zero deps; a raw-bytes pre-filter keeps it fast over gigabytes of logs.
- Privacy: default output is aggregate only (safe to share); `--examples` prints question/answer text and is documented as not-for-sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)