### PR TITLE
ocr: pin datasets>=4.0.0 in the 9 recipes that left it unpinned

### DIFF
--- a/ocr/deepseek-ocr.py
+++ b/ocr/deepseek-ocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "torch",

--- a/ocr/dots-mocr.py
+++ b/ocr/dots-mocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "vllm>=0.15.1",

--- a/ocr/dots-ocr.py
+++ b/ocr/dots-ocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "vllm>=0.15.1",

--- a/ocr/falcon-ocr.py
+++ b/ocr/falcon-ocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "torch>=2.5",

--- a/ocr/firered-ocr.py
+++ b/ocr/firered-ocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "vllm>=0.15.1",

--- a/ocr/lighton-ocr.py
+++ b/ocr/lighton-ocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "vllm",

--- a/ocr/olmocr2-vllm.py
+++ b/ocr/olmocr2-vllm.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "vllm",

--- a/ocr/paddleocr-vl-1.5.py
+++ b/ocr/paddleocr-vl-1.5.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "torch",

--- a/ocr/smoldocling-ocr.py
+++ b/ocr/smoldocling-ocr.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "datasets",
+#     "datasets>=4.0.0",
 #     "huggingface-hub",
 #     "pillow",
 #     "vllm",


### PR DESCRIPTION
Nine recipes declared a bare `"datasets"` dependency. That gives the resolver freedom to backtrack to a pre-2.15 `datasets` release that still subclasses `pa.PyExtensionType`, which modern pyarrow has removed — the job then crashes at import time, before inference starts:

```
File ".../datasets/features/features.py", line 634, in <module>
    class _ArrayXDExtensionType(pa.PyExtensionType):
AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?
```

This is the failure reported in davanstrien/ocr-bench#18 against `dots-ocr.py`.

The other 17 recipes already pin `datasets>=4.0.0`; this PR aligns the remaining nine (`deepseek-ocr`, `dots-mocr`, `dots-ocr`, `falcon-ocr`, `firered-ocr`, `lighton-ocr`, `olmocr2-vllm`, `paddleocr-vl-1.5`, `smoldocling-ocr`).

**Verification**
- `uv lock --script` resolves cleanly for all nine patched scripts (datasets 5.0.0 / pyarrow 24). `lighton-ocr.py` doesn't lock on macOS with or without this change — a local artifact of the vLLM nightly index shipping linux-only wheels, unrelated to the pin.
- End-to-end Jobs smoke run of the patched `dots-ocr.py` (a10g-small, 3 samples): https://huggingface.co/jobs/davanstrien/6a46c9eb33c08a2c0dae1c72 — completed, 3/3 rows real OCR text, no error sentinels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaJ84bsoBpgVXocRzSJ6N5
