### PR TITLE
ocr: add ocr-bench launch contract to olmocr2 + nanonets2

### DIFF
--- a/ocr/nanonets-ocr2.py
+++ b/ocr/nanonets-ocr2.py
@@ -277,6 +277,8 @@ def main(
     output_column: str = "markdown",
     overwrite: bool = False,
     verbose: bool = False,
+    config: str = None,
+    create_pr: bool = False,
 ):
     """Process images from HF dataset through Nanonets-OCR2-3B model."""
 
@@ -406,7 +408,15 @@ def main(
 
     # Push to hub
     logger.info(f"Pushing to {output_dataset}")
-    dataset.push_to_hub(output_dataset, private=private, token=HF_TOKEN)
+    commit_info = dataset.push_to_hub(
+        output_dataset,
+        private=private,
+        token=HF_TOKEN,
+        **({"config_name": config} if config else {}),
+        create_pr=create_pr,
+        commit_message=f"Add {model} OCR results ({len(dataset)} samples)"
+        + (f" [{config}]" if config else ""),
+    )
 
     # Calculate processing time
     end_time = datetime.now()
@@ -436,6 +446,8 @@ def main(
     logger.info(
         f"Dataset available at: https://huggingface.co/datasets/{output_dataset}"
     )
+    if create_pr and getattr(commit_info, "pr_url", None):
+        logger.info(f"Pull request created: {commit_info.pr_url}")
 
     if verbose:
         import importlib.metadata
@@ -560,6 +572,15 @@ Examples:
         "--private", action="store_true", help="Make output dataset private"
     )
     parser.add_argument(
+        "--config",
+        help="Config/subset name when pushing to Hub (for benchmarking multiple models in one repo)",
+    )
+    parser.add_argument(
+        "--create-pr",
+        action="store_true",
+        help="Create a pull request instead of pushing directly (for parallel benchmarking)",
+    )
+    parser.add_argument(
         "--shuffle",
         action="store_true",
         help="Shuffle the dataset before processing (useful for random sampling)",
@@ -607,4 +628,6 @@ Examples:
         output_column=args.output_column,
         overwrite=args.overwrite,
         verbose=args.verbose,
+        config=args.config,
+        create_pr=args.create_pr,
     )

--- a/ocr/olmocr2-vllm.py
+++ b/ocr/olmocr2-vllm.py
@@ -316,6 +316,8 @@ def main(
     private: bool = False,
     shuffle: bool = False,
     seed: int = 42,
+    config: str = None,
+    create_pr: bool = False,
 ):
     """
     Process a dataset of document images through olmOCR-2 to extract markdown.
@@ -461,36 +463,41 @@ def main(
         ds = ds.remove_columns([metadata_column_name])
     ds = ds.add_column(metadata_column_name, all_metadata)
 
-    # Add inference information
-    inference_info = json.dumps(
-        {
-            "model": model,
-            "script": "olmocr2-vllm.py",
-            "version": "1.0.0",
-            "timestamp": datetime.now().isoformat(),
-            "batch_size": batch_size,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-        }
-    )
+    # Add inference information — standard schema: a JSON-string LIST of entries, each carrying
+    # model_id (used as the leaderboard label) and column_name (the output text column). The
+    # script's own extras (version, timestamp, sampling params) ride along as extra keys.
+    inference_entry = {
+        "model_id": model,
+        "column_name": output_column,
+        "script": "olmocr2-vllm.py",
+        "version": "1.0.0",
+        "timestamp": datetime.now().isoformat(),
+        "batch_size": batch_size,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
 
-    # Handle existing inference_info column
+    # Handle existing inference_info column (append to the list; create a fresh list otherwise)
     if inference_info_column in ds.column_names:
-        # Parse existing, append new model info
+        logger.info("Updating existing inference_info column")
+
         def update_inference_info(example):
             try:
-                existing = json.loads(example[inference_info_column])
-                if not isinstance(existing, list):
-                    existing = [existing]
-            except (json.JSONDecodeError, KeyError):
-                existing = []
-
-            existing.append(json.loads(inference_info))
-            return {inference_info_column: json.dumps(existing)}
+                existing_info = (
+                    json.loads(example[inference_info_column])
+                    if example[inference_info_column]
+                    else []
+                )
+            except (json.JSONDecodeError, TypeError):
+                existing_info = []
+            existing_info.append(inference_entry)
+            return {inference_info_column: json.dumps(existing_info)}
 
         ds = ds.map(update_inference_info)
     else:
-        ds = ds.add_column(inference_info_column, [inference_info] * len(ds))
+        logger.info("Creating new inference_info column")
+        inference_list = [json.dumps([inference_entry])] * len(ds)
+        ds = ds.add_column(inference_info_column, inference_list)
 
     # Calculate processing time
     elapsed_time = time.time() - start_time
@@ -515,9 +522,13 @@ def main(
 
     # Push to hub
     logger.info(f"Pushing to HuggingFace Hub: {output_dataset}")
-    ds.push_to_hub(
+    commit_info = ds.push_to_hub(
         output_dataset,
         private=private,
+        **({"config_name": config} if config else {}),
+        create_pr=create_pr,
+        commit_message=f"Add {model} OCR results ({len(ds)} samples)"
+        + (f" [{config}]" if config else ""),
     )
 
     # Update dataset card
@@ -528,6 +539,8 @@ def main(
     logger.info(f"✓ Dataset: https://huggingface.co/datasets/{output_dataset}")
     logger.info(f"✓ Processing time: {processing_time}")
     logger.info(f"✓ Samples processed: {len(ds):,}")
+    if create_pr and getattr(commit_info, "pr_url", None):
+        logger.info(f"✓ Pull request created: {commit_info.pr_url}")
 
 
 if __name__ == "__main__":
@@ -650,6 +663,15 @@ Examples:
         help="Make output dataset private",
     )
     parser.add_argument(
+        "--config",
+        help="Config/subset name when pushing to Hub (for benchmarking multiple models in one repo)",
+    )
+    parser.add_argument(
+        "--create-pr",
+        action="store_true",
+        help="Create a pull request instead of pushing directly (for parallel benchmarking)",
+    )
+    parser.add_argument(
         "--shuffle",
         action="store_true",
         help="Shuffle dataset before processing",
@@ -681,4 +703,6 @@ Examples:
         private=args.private,
         shuffle=args.shuffle,
         seed=args.seed,
+        config=args.config,
+        create_pr=args.create_pr,
     )


### PR DESCRIPTION
Adds the `--config` / `--create-pr` launch contract (and, for olmocr2, the standard `inference_info` schema) to the two remaining current-model batch scripts that lacked it — found when olmocr2 failed to launch from the ocr-bench registry (`error: unrecognized arguments: --config olmocr-2 --create-pr`).

**olmocr2-vllm.py**: `--config`/`--create-pr` threaded to `push_to_hub` (config-tagged commit message so PR titles carry `[config]` for discovery); `inference_info` reshaped from a bare JSON dict to the standard JSON-list-of-entries with `model_id` + `column_name` (the dict shape was a pre-existing bug — ocr-bench reads first/last list entries), keeping the script's extra fields. Per-row `markdown_metadata` untouched.

**nanonets-ocr2.py**: already had correct `inference_info`; only adds `--config`/`--create-pr` with the same None-safe pattern.

Both now log the PR URL when `--create-pr` fires.

**Verified on a real Job**: olmocr2 5-sample run on bare-image l4x1 (job `6a4defa5f861d2801c569628`, 4m28s, COMPLETED — no image-mode needed) → PR config on the scratch repo loads with correct schema and genuine OCR text (incl. a German inventory note and the 1771 ownership inscription). nanonets2: arg-surface check only, no GPU spend.

Audit note: the other scripts missing the contract are superseded versions, `*-bucket.py` sinks (paradigm doesn't apply), or extract/judge tools — deliberately not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)