### PR TITLE
ocr: pin transformers<5 in dots-mocr

### DIFF
--- a/ocr/dots-mocr.py
+++ b/ocr/dots-mocr.py
@@ -8,6 +8,9 @@
 #     "tqdm",
 #     "toolz",
 #     "torch",
+#     # dots.mocr's remote code (AutoProcessor.register with a string key)
+#     # breaks on transformers v5; vllm pulls transformers unpinned.
+#     "transformers<5",
 # ]
 #
 # ///


### PR DESCRIPTION
dots.mocr's remote code (`AutoProcessor.register("dots_ocr", DotsVLProcessor)` — string key) breaks on transformers v5, which rides in unpinned via vllm. The March runs predate v5; last night's 50-sample Britannica run hit it (`AttributeError: 'str' object has no attribute '__module__'`). Same failure family as the paddleocr-vl-1.5 v5 breakage.

Pin `transformers<5` with an explaining comment. Verified on real l4x1 Jobs: 5-sample smoke + the 50-sample Britannica production run (both ran from this fix, so merging just syncs it to the Hub for future runs).

Note: commit 2269e48 also sits at the base of the concurrent `ocr/hunyuan-15` branch (parallel session branched mid-work) — merging this PR first keeps that branch's eventual diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)