### PR TITLE
ci: bump hub-sync to v0.2.0 (drops deprecated 'hf repo' warning)

### DIFF
--- a/.github/workflows/_sync-folder.yml
+++ b/.github/workflows/_sync-folder.yml
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
 
-      - uses: huggingface/hub-sync@v0.1.0
+      - uses: huggingface/hub-sync@v0.2.0
         with:
           github_repo_id: ${{ github.repository }}
           huggingface_repo_id: ${{ env.REPO_ID }}


### PR DESCRIPTION
The pinned `huggingface/hub-sync@v0.1.0` runs `hf repo create`, which the hf CLI now flags: `Warning: 'hf repo' is deprecated in favor of 'hf repos'.`

Upstream already fixed this — [v0.2.0](https://github.com/huggingface/hub-sync/compare/v0.1.0...v0.2.0) uses `hf repos create` (and pins setup-uv to a SHA). Inputs are backward-compatible; v0.2.0 only adds an optional `hf_version`. One-line bump in the shared `_sync-folder.yml`, which all sync-*.yml workflows call.

No sync-semantics changes (same `hf upload --delete="*"` mirror behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)