### PR TITLE
ocr: pin transformers<5 in dots-ocr

### DIFF
--- a/ocr/dots-ocr.py
+++ b/ocr/dots-ocr.py
@@ -8,6 +8,10 @@
 #     "tqdm",
 #     "toolz",
 #     "torch",
+#     # dots.ocr's remote code (AutoProcessor.register with a string key)
+#     # breaks on transformers v5; vllm pulls transformers unpinned.
+#     # Same fix as dots-mocr (#76).
+#     "transformers<5",
 # ]
 #
 # ///


### PR DESCRIPTION
Same failure family as #76 (dots-mocr): dots.ocr's remote code calls `AutoProcessor.register` with a string key, which transformers v5 rejects (`AttributeError: 'str' object has no attribute '__module__'`); transformers rides in unpinned via vllm. Hit on today's MOH benchmark run — interestingly the same script succeeded on yesterday's Britannica run, so the resolution drifted within a day, which is the unpinned-transitive-dep problem in miniature.

Production MOH re-run will use this branch's local file; merging syncs the fix to the Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)