### PR TITLE
embeddings: fan-out across N Jobs (launcher, consolidator, --streaming, --resume)

### DIFF
--- a/embeddings/README.md
+++ b/embeddings/README.md
@@ -21,6 +21,7 @@ their dependencies (sentence-transformers vs vLLM vs Lance) are too different to
 | `generate-embeddings.py` | The default. Text or images. Simple, fast, runs anywhere. | sentence-transformers |
 | `generate-embeddings-vllm.py` | Max throughput on large *decoder* embedding models (Qwen3-Embedding). | vLLM pooling |
 | `embed-to-lance.py` | Get a **searchable vector index as a Hub dataset** (the "vector DB" path). | sentence-transformers + Lance |
+| `launch-embedding-fleet.py` | **Fan one run out across N parallel Jobs** (+ `consolidate-shards.py`). | run_uv_job + Buckets |
 
 ## Quick start
 
@@ -37,6 +38,41 @@ hf jobs uv run --flavor l4x1 -s HF_TOKEN \
 ```
 
 Always try `--max-samples 100 --private` first.
+
+## Fan-out: N Jobs in parallel
+
+One L4 does ~900 rows/s with `all-MiniLM-L6-v2`; a fleet of 8 does ~7k. `launch-embedding-fleet.py`
+splits the run into exact, non-overlapping shards (one Job each), workers stream shard parquets +
+progress heartbeats to a [Bucket](https://huggingface.co/docs/hub/storage-buckets) (object writes —
+no repo-commit contention), and a final CPU Job merges everything into the output dataset in one
+commit, with full provenance on the card.
+
+```bash
+# 8 L4s over a corpus; runs from your laptop, workers run on Jobs
+uv run https://huggingface.co/datasets/uv-scripts/embeddings/raw/main/launch-embedding-fleet.py \
+  your-name/corpus your-name/corpus-embeddings --num-shards 8 --flavor l4x1 --timeout 1h
+```
+
+Every shard is idempotent (a rank overwrites only its own files), so failures never cost you the
+run. Workers that fail are auto-retried once; past that, one command converges any run — no need
+to know which rank failed or why:
+
+```bash
+uv run launch-embedding-fleet.py <in> <out> --run-id <id> --resume   # re-runs ONLY missing shards, then merges
+```
+
+(`--retry-rank`/`--consolidate-only` remain for surgical control.) Each worker's timeout gives a
+**hard cost ceiling**: a fleet can never cost more than `N × flavor-rate × timeout`.
+
+Watch a run live — progress, ETA, live ~$ vs ceiling, GPU utilization, replica health — in the
+[fleet dashboard Space](https://huggingface.co/spaces/davanstrien/embedding-fleet-dashboard)
+(the launcher prints your run's deep link).
+
+Scale note: by default workers shard row-wise after loading the split, so each rank downloads the
+full split first — fine up to a few tens of millions of rows. Past that, add `--streaming`: workers
+then shard at the **file** level and each rank streams only its own files (text only; needs
+`num_files ≥ num_shards`). The launcher pins the input dataset revision either way, so every rank
+— including a `--retry-rank` weeks later — slices the identical snapshot.
 
 ## Which model?
 

--- a/embeddings/consolidate-shards.py
+++ b/embeddings/consolidate-shards.py
@@ -1,0 +1,216 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "huggingface-hub>=1.12",
+#     "pyarrow",
+# ]
+# ///
+"""
+Assemble the parquet shards of a fan-out embedding run (see launch-embedding-fleet.py)
+into the final Hub dataset, one file at a time, with a provenance card.
+
+Pass-through design: worker shards are ALREADY valid parquet in final order, so nothing
+is loaded or re-serialized — each file is downloaded, its footer row count read, and the
+file uploaded to the dataset repo as data/train-XXXXX-of-YYYYY.parquet. Peak disk = one
+shard, so any total run size fits on a small CPU flavor. Deliberately the ONLY step in
+the fleet that writes to a dataset repo — workers write bucket objects, so N-way commit
+contention (412s) can't happen by construction.
+
+Accepts both worker output namings: <rank>.parquet (row mode) and <rank>.partNNNN.parquet
+(streaming mode). Re-running is idempotent for same-named files; if a re-run has FEWER
+files than a previous consolidation of the same repo, stale data/ files from the earlier
+attempt are removed first.
+
+Usually spawned as a cpu Job by the launcher; can also run locally:
+    uv run consolidate-shards.py --bucket you/embedding-runs --run-id 20260709-1200-abc123
+"""
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("consolidate-shards")
+
+
+def normalize_embeddings_column(local, out_col):
+    """Rewrite the file in place if its embeddings column isn't fixed_size_list<float32>.
+
+    Shards written by different script versions can disagree (old: list<double>, new:
+    fixed_size_list<float32>); a repo with mixed parquet schemas breaks load_dataset, so
+    the consolidator is the place to unify. Returns the file's row count."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+    pf = pq.ParquetFile(local)
+    schema = pf.schema_arrow
+    if out_col not in schema.names:
+        return pf.metadata.num_rows  # nothing to normalize (unexpected, but not fatal here)
+    field = schema.field(out_col)
+    if pa.types.is_fixed_size_list(field.type) and field.type.value_type == pa.float32():
+        return pf.metadata.num_rows
+    t = pq.read_table(local)
+    col = t[out_col].combine_chunks()
+    dim = len(col[0].as_py())
+    values = pc.cast(pc.list_flatten(col), pa.float32())
+    fixed = pa.FixedSizeListArray.from_arrays(values, dim)
+    idx = t.schema.get_field_index(out_col)
+    t = t.set_column(idx, pa.field(out_col, fixed.type), fixed)
+    logger.info(f"  normalized {Path(local).name}: {field.type} → {fixed.type}")
+    pq.write_table(t, local)
+    return t.num_rows
+
+
+def upload_with_retry(api, local, repo_id, path_in_repo, max_retries=3):
+    for attempt in range(1, max_retries + 1):
+        try:
+            if attempt > 1:
+                logger.warning("Disabling XET (fallback to HTTP upload)")
+                os.environ["HF_HUB_DISABLE_XET"] = "1"
+            api.upload_file(path_or_fileobj=local, path_in_repo=path_in_repo,
+                            repo_id=repo_id, repo_type="dataset")
+            return
+        except Exception as e:
+            logger.error(f"Upload attempt {attempt}/{max_retries} for {path_in_repo} failed: {e}")
+            if attempt < max_retries:
+                delay = 30 * (2 ** (attempt - 1))
+                logger.info(f"Retrying in {delay}s...")
+                time.sleep(delay)
+            else:
+                logger.error("All upload attempts failed. Shards remain in the bucket — re-run consolidation.")
+                sys.exit(1)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--bucket", required=True, help="Run bucket, e.g. you/embedding-runs")
+    p.add_argument("--run-id", required=True)
+    p.add_argument("--private", action="store_true")
+    args = p.parse_args()
+
+    import pyarrow.parquet as pq
+    from huggingface_hub import (DatasetCard, HfApi, download_bucket_files,
+                                 list_bucket_tree, login)
+
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        login(token=token)
+    api = HfApi()
+
+    prefix = f"runs/{args.run_id}"
+    workdir = Path(tempfile.mkdtemp(prefix=f"consolidate-{args.run_id}-"))
+
+    download_bucket_files(args.bucket, [(f"{prefix}/run.json", workdir / "run.json")],
+                          raise_on_missing_files=True)
+    run = json.loads((workdir / "run.json").read_text())
+    n = run["num_shards"]
+    out_repo = run["output_dataset"]
+
+    # Collect shard files: <rank>.parquet (row mode) or <rank>.partNNNN.parquet (streaming).
+    pat = re.compile(r"^(\d{5})(?:\.part(\d{4}))?\.parquet$")
+    shard_files = []  # (rank, part, bucket_path)
+    for f in list_bucket_tree(args.bucket, prefix=f"{prefix}/data/", recursive=True):
+        name = Path(getattr(f, "path", "")).name
+        m = pat.match(name)
+        if m:
+            shard_files.append((int(m.group(1)), int(m.group(2) or 0), f.path))
+    shard_files.sort()
+    ranks_present = {r for r, _, _ in shard_files}
+    missing = sorted(set(range(n)) - ranks_present)
+    if missing:
+        logger.error(f"Missing output from {len(missing)}/{n} rank(s): {missing}")
+        logger.error("Re-run those ranks (launch-embedding-fleet.py --retry-rank), then consolidate again.")
+        sys.exit(1)
+    total_files = len(shard_files)
+    logger.info(f"{total_files} shard file(s) across {n} rank(s)")
+
+    private = args.private or run.get("private", False)
+    api.create_repo(out_repo, repo_type="dataset", private=private, exist_ok=True)
+
+    # Remove stale data/ files from any earlier consolidation with a different file count.
+    expected = {f"data/train-{i:05d}-of-{total_files:05d}.parquet" for i in range(total_files)}
+    try:
+        existing = [f for f in api.list_repo_files(out_repo, repo_type="dataset")
+                    if f.startswith("data/") and f.endswith(".parquet") and f not in expected]
+        for stale in existing:
+            logger.warning(f"Deleting stale {stale} from a previous consolidation")
+            api.delete_file(stale, repo_id=out_repo, repo_type="dataset")
+    except Exception as e:
+        logger.warning(f"stale-file check skipped: {e}")
+
+    # Embedding column name: default unless overridden via the run's embed_args.
+    ea = run.get("embed_args") or []
+    out_col = ea[ea.index("--output-column") + 1] if "--output-column" in ea else "embeddings"
+
+    # Pass each file through: download → normalize schema if needed → upload → delete local.
+    rows_total = 0
+    t0 = time.time()
+    for seq, (rank, part, bucket_path) in enumerate(shard_files):
+        local = workdir / Path(bucket_path).name
+        download_bucket_files(args.bucket, [(bucket_path, local)], raise_on_missing_files=True)
+        rows = normalize_embeddings_column(local, out_col)
+        rows_total += rows
+        dest = f"data/train-{seq:05d}-of-{total_files:05d}.parquet"
+        logger.info(f"[{seq + 1}/{total_files}] rank {rank} part {part}: {rows:,} rows → {dest}")
+        upload_with_retry(api, local, out_repo, dest)
+        local.unlink()
+
+    logger.info(f"Assembled {rows_total:,} rows in {time.time() - t0:.0f}s "
+                f"(manifest says {run.get('rows_total')})")
+    if run.get("rows_total") and rows_total != run["rows_total"]:
+        logger.warning("Row count differs from manifest — check for a re-run with different settings.")
+
+    # Timing/throughput line from final worker statuses (best effort).
+    stats_line = ""
+    try:
+        status_files = [(f"{prefix}/status/{i:05d}.json", workdir / f"status-{i:05d}.json") for i in range(n)]
+        download_bucket_files(args.bucket, status_files)
+        statuses = [json.loads(dst.read_text()) for _, dst in status_files if dst.exists()]
+        if statuses:
+            wall = max(s["updated_at"] for s in statuses) - min(s["started_at"] for s in statuses)
+            rps = sum(s.get("rows_per_sec") or 0 for s in statuses)
+            stats_line = f"- Fleet wall-clock: ~{wall / 60:.1f} min · aggregate ~{rps:,.0f} rows/s\n"
+    except Exception as e:
+        logger.info(f"status stats skipped: {e}")
+
+    script_url = "https://huggingface.co/datasets/uv-scripts/embeddings/raw/main/generate-embeddings.py"
+    launcher_url = "https://huggingface.co/datasets/uv-scripts/embeddings/raw/main/launch-embedding-fleet.py"
+    on_jobs = os.environ.get("JOB_ID") is not None
+    origin = ("Produced on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs)"
+              if on_jobs else "Generated")
+    jobs_tag = "\n- hf-jobs" if on_jobs else ""
+    mode = "streaming file-shards" if run.get("streaming") else "row shards"
+    rev_line = f"- Input revision: `{run['revision']}`\n" if run.get("revision") else ""
+    job_list = "".join(f"  - shard {i}: `{jid}`\n" for i, jid in enumerate(run.get("job_ids", [])))
+    card = DatasetCard(
+        f"---\ntags:\n- embeddings\n- uv-script\n- generated{jobs_tag}\n---\n\n"
+        f"# {out_repo}\n\n"
+        f"Embeddings of [`{run['input_dataset']}`](https://huggingface.co/datasets/{run['input_dataset']}) "
+        f"column `{run['column']}`, computed by a fleet of {n} parallel Jobs ({mode}).\n\n"
+        f"- Model: [`{run['model']}`](https://huggingface.co/{run['model']})\n"
+        f"- Rows: {rows_total:,}\n"
+        f"- Fleet: {n} × `{run['flavor']}` · run `{run['run_id']}`\n"
+        f"{rev_line}{stats_line}"
+        f"- Worker jobs:\n{job_list}\n"
+        f"## Reproduction\n\n"
+        f"{origin} with the [`generate-embeddings.py`]({script_url}) recipe from "
+        f"[uv-scripts](https://huggingface.co/uv-scripts), fanned out with "
+        f"[`launch-embedding-fleet.py`]({launcher_url}):\n\n"
+        f"```bash\nuv run {launcher_url} \\\n"
+        f"    {run['input_dataset']} <output-dataset> --column {run['column']} "
+        f"--model {run['model']} --num-shards {n} --flavor {run['flavor']}\n```\n"
+    )
+    try:
+        card.push_to_hub(out_repo, repo_type="dataset")
+    except Exception as e:
+        logger.warning(f"card push skipped: {e}")
+    logger.info(f"✅ https://huggingface.co/datasets/{out_repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/embeddings/generate-embeddings.py
+++ b/embeddings/generate-embeddings.py
@@ -7,7 +7,7 @@
 #     "numpy",
 #     "pillow",
 #     "einops",
-#     "huggingface-hub",
+#     "huggingface-hub>=1.12",
 # ]
 # ///
 """
@@ -56,6 +56,18 @@ Examples:
     # Test on a small slice first, keep the output private
     hf jobs uv run --flavor l4x1 -s HF_TOKEN generate-embeddings.py \\
         stanfordnlp/imdb  your-name/imdb-emb --max-samples 100 --private
+
+FAN-OUT (multi-job) MODE:
+    Split one embedding run across N Jobs with --num-shards/--shard-index (or the RANK /
+    NUM_SHARDS / RUN_ID / OUTPUT_BUCKET env vars, so a launcher only varies RANK per job —
+    see launch-embedding-fleet.py). Each shard takes an exact, non-overlapping contiguous
+    slice, writes its rows to the run's bucket as runs/<run-id>/data/<rank>.parquet (object
+    PUTs — no repo-commit contention), and heartbeats progress to
+    runs/<run-id>/status/<rank>.json. consolidate-shards.py merges shards into the final
+    dataset with one commit. Re-running a failed rank overwrites only its own files (resume).
+    Note: --max-samples applies BEFORE sharding, so a capped run still partitions exactly.
+    Each rank still downloads the full split before slicing — fine at few-million-row scale;
+    for larger corpora shard at the file level or stream instead.
 """
 import argparse
 import logging
@@ -204,6 +216,155 @@ def sniff_token_lengths(model, texts, max_seq_len, sample=512):
     return median
 
 
+def put_bucket_files(bucket_id, add, max_retries=3):
+    """batch_bucket_files with a short retry — bucket PUTs are cheap object writes but can
+    flake transiently; shard data must not be lost to a blip."""
+    from huggingface_hub import batch_bucket_files
+    for attempt in range(1, max_retries + 1):
+        try:
+            batch_bucket_files(bucket_id, add=add)
+            return True
+        except Exception as e:
+            if attempt == max_retries:
+                raise
+            logger.warning(f"bucket PUT attempt {attempt}/{max_retries} failed: {e}; retrying in {5 * attempt}s")
+            time.sleep(5 * attempt)
+
+
+class StatusReporter:
+    """Fan-out worker heartbeat: PUTs runs/<run-id>/status/<rank>.json to the run bucket,
+    throttled to one write per ~30s (last-writer-wins per key, so N workers never contend).
+    A failed status write must never kill a paid embedding run — errors are logged, not raised."""
+
+    def __init__(self, bucket, run_id, rank, rows_total, tokens_per_row=None):
+        self.bucket, self.run_id, self.rank = bucket, run_id, rank
+        self.rows_total, self.tokens_per_row = rows_total, tokens_per_row
+        self.started_at = time.time()
+        self.rows_done = 0
+        self._last_write = 0.0
+
+    def report(self, rows_done=None, state="running", force=False):
+        import json
+        if rows_done is not None:
+            self.rows_done = rows_done
+        now = time.time()
+        if not force and now - self._last_write < 30:
+            return
+        elapsed = max(now - self.started_at, 1e-6)
+        payload = {
+            "run_id": self.run_id,
+            "rank": self.rank,
+            "state": state,
+            "rows_done": self.rows_done,
+            "rows_total": self.rows_total,
+            "tokens_done_est": int(self.rows_done * self.tokens_per_row) if self.tokens_per_row else None,
+            "rows_per_sec": round(self.rows_done / elapsed, 1),
+            "started_at": self.started_at,
+            "updated_at": now,
+            "job_id": os.environ.get("JOB_ID"),
+        }
+        dest = f"runs/{self.run_id}/status/{self.rank:05d}.json"
+        try:
+            put_bucket_files(self.bucket, [(json.dumps(payload).encode(), dest)], max_retries=2)
+            self._last_write = now
+        except Exception as e:
+            logger.warning(f"status write skipped ({e})")
+
+
+def run_streaming_shard(ds, model, prompt_str, args):
+    """Streaming fan-out worker: iterate this rank's FILE-shard, encode in chunks, and flush
+    parquet PARTS to the bucket every ~250k rows, so memory and disk stay bounded no matter
+    how big the shard is. Output keys: runs/<run-id>/data/<rank>.part<p>.parquet — the
+    consolidator accepts both this and row mode's single <rank>.parquet naming."""
+    import itertools
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    encode_fn = model.encode_query if args.query_mode else model.encode_document
+    encode_kwargs = {"prompt": prompt_str} if prompt_str is not None else {}
+
+    def clean(t):
+        return t if isinstance(t, str) and t.strip() else " "
+
+    # Buffer a head sample for token sniffing + the auto-batch probe, then chain it back.
+    it = iter(ds)
+    head = list(itertools.islice(it, 1024))
+    if not head:
+        logger.error(f"File-shard {args.shard_index} yielded no rows.")
+        sys.exit(1)
+    if args.column not in head[0]:
+        logger.error(f"Column {args.column!r} not in rows. Available: {sorted(head[0])}")
+        sys.exit(1)
+    if args.output_column in head[0]:
+        logger.error(f"Output column {args.output_column!r} already exists — choose another --output-column.")
+        sys.exit(1)
+    head_texts = [clean(r[args.column]) for r in head]
+    median_tok = sniff_token_lengths(model, head_texts, args.max_seq_len)
+    if str(args.batch_size).lower() == "auto":
+        if median_tok is None or median_tok >= 256:
+            candidates = (32, 64, 128, 256)
+        elif median_tok >= 64:
+            candidates = (64, 128, 256, 512)
+        else:
+            candidates = (128, 256, 512, 1024)
+        batch_size = find_batch_size(model, head_texts, args.normalize, candidates=candidates)
+    else:
+        batch_size = int(args.batch_size)
+
+    reporter = StatusReporter(args.output_bucket, args.run_id, args.shard_index,
+                              rows_total=None, tokens_per_row=median_tok)
+    reporter.report(0, force=True)
+
+    chunk_rows, part_rows = 25_000, 250_000
+    prog = {"part_idx": 0, "rows_done": 0}
+    buf_rows, buf_texts, part_buf = [], [], []
+
+    def flush_part():
+        if not part_buf:
+            return
+        path = f"/tmp/part-{args.shard_index:05d}-{prog['part_idx']:04d}.parquet"
+        pq.write_table(pa.Table.from_pylist(part_buf), path)
+        dest = f"runs/{args.run_id}/data/{args.shard_index:05d}.part{prog['part_idx']:04d}.parquet"
+        logger.info(f"Uploading {len(part_buf):,}-row part → {args.output_bucket}/{dest}")
+        put_bucket_files(args.output_bucket, [(path, dest)])
+        os.remove(path)
+        part_buf.clear()
+        prog["part_idx"] += 1
+
+    def encode_chunk():
+        if not buf_rows:
+            return
+        emb = encode_fn(buf_texts, batch_size=batch_size, show_progress_bar=False,
+                        convert_to_numpy=True, normalize_embeddings=args.normalize, **encode_kwargs)
+        for r, e in zip(buf_rows, emb):
+            r[args.output_column] = e.tolist()
+        part_buf.extend(buf_rows)
+        prog["rows_done"] += len(buf_rows)
+        buf_rows.clear()
+        buf_texts.clear()
+        reporter.report(prog["rows_done"])
+        if len(part_buf) >= part_rows:
+            flush_part()
+
+    t0 = time.perf_counter()
+    try:
+        for row in itertools.chain(head, it):
+            buf_rows.append(dict(row))
+            buf_texts.append(clean(row[args.column]))
+            if len(buf_rows) >= chunk_rows:
+                encode_chunk()
+        encode_chunk()
+        flush_part()
+    except Exception:
+        reporter.report(state="error", force=True)
+        raise
+    secs = time.perf_counter() - t0
+    logger.info(f"Embedded {prog['rows_done']:,} rows in {secs:.0f}s "
+                f"({prog['rows_done'] / max(secs, 1e-6):.0f} rows/s), {prog['part_idx']} part(s)")
+    reporter.report(prog["rows_done"], state="done", force=True)
+    logger.info(f"✅ streaming shard {args.shard_index + 1}/{args.num_shards} of run {args.run_id} uploaded")
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("input_dataset", help="Input dataset ID on the Hugging Face Hub")
@@ -232,7 +393,57 @@ def main():
     p.add_argument("--normalize", action="store_true", default=True)
     p.add_argument("--no-normalize", dest="normalize", action="store_false")
     p.add_argument("--private", action="store_true", help="Make the output dataset private")
+    # Fan-out mode (see docstring). Env-defaulted so a launcher drives workers purely via env.
+    # Defaults stay raw strings; int conversion happens after parse so a malformed env var
+    # reaches p.error() instead of blowing up argparse construction.
+    p.add_argument("--num-shards", default=os.environ.get("NUM_SHARDS"),
+                   help="Fan-out: total number of shards (env NUM_SHARDS). Enables shard mode.")
+    p.add_argument("--shard-index", default=os.environ.get("RANK"),
+                   help="Fan-out: this worker's shard index, 0-based (env RANK).")
+    p.add_argument("--output-bucket", default=os.environ.get("OUTPUT_BUCKET"),
+                   help="Fan-out: bucket for shard parquets + status (env OUTPUT_BUCKET).")
+    p.add_argument("--run-id", default=os.environ.get("RUN_ID"),
+                   help="Fan-out: run identifier grouping shards under runs/<run-id>/ (env RUN_ID).")
+    p.add_argument("--streaming", action="store_true",
+                   default=os.environ.get("STREAMING") == "1",
+                   help="Fan-out: stream the dataset and shard at the FILE level (env STREAMING=1). "
+                        "Each rank downloads only its own files — use for very big datasets. "
+                        "Text modality only; incompatible with --max-samples.")
+    p.add_argument("--revision", default=os.environ.get("REVISION"),
+                   help="Input dataset revision (commit sha). Pin this in fan-out runs so every "
+                        "rank slices the identical snapshot (env REVISION).")
     args = p.parse_args()
+
+    def int_or_error(val, name):
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            p.error(f"{name} must be an integer (got {val!r}).")
+
+    args.num_shards = int_or_error(args.num_shards, "--num-shards / NUM_SHARDS")
+    args.shard_index = int_or_error(args.shard_index, "--shard-index / RANK")
+
+    sharded = args.num_shards is not None
+    if sharded:
+        if args.num_shards < 1:
+            p.error(f"--num-shards must be >= 1 (got {args.num_shards}).")
+        if args.shard_index is None or not 0 <= args.shard_index < args.num_shards:
+            p.error(f"--shard-index must be in [0, {args.num_shards}) when --num-shards is set "
+                    f"(got {args.shard_index}).")
+        if not (args.output_bucket and args.run_id):
+            p.error("fan-out mode needs --output-bucket and --run-id (env OUTPUT_BUCKET / RUN_ID).")
+    elif args.shard_index is not None:
+        p.error("--shard-index requires --num-shards.")
+
+    if args.streaming:
+        if not sharded:
+            p.error("--streaming is a fan-out mode — it needs --num-shards/--shard-index.")
+        if args.modality != "text":
+            p.error("--streaming currently supports text modality only.")
+        if args.max_samples:
+            p.error("--max-samples is incompatible with --streaming (use row mode for capped test runs).")
 
     import torch
     from datasets import load_dataset
@@ -245,18 +456,45 @@ def main():
     if not torch.cuda.is_available():
         logger.warning("No CUDA — running on CPU (much slower). Prefer a GPU flavor, e.g. --flavor l4x1.")
 
-    logger.info(f"Loading {args.input_dataset} [{args.split}]")
-    ds = (load_dataset(args.input_dataset, args.config, split=args.split) if args.config
-          else load_dataset(args.input_dataset, split=args.split))
-    if args.column not in ds.column_names:
-        logger.error(f"Column {args.column!r} not found. Available: {ds.column_names}")
-        sys.exit(1)
-    if args.output_column in ds.column_names:
-        logger.error(f"Output column {args.output_column!r} already exists — choose another --output-column.")
-        sys.exit(1)
-    if args.max_samples:
+    logger.info(f"Loading {args.input_dataset} [{args.split}]"
+                + (f" @ {args.revision[:12]}" if args.revision else "")
+                + (" (streaming)" if args.streaming else ""))
+    load_kwargs = {"split": args.split, "streaming": args.streaming}
+    if args.revision:
+        load_kwargs["revision"] = args.revision
+    ds = (load_dataset(args.input_dataset, args.config, **load_kwargs) if args.config
+          else load_dataset(args.input_dataset, **load_kwargs))
+    if ds.column_names is not None:
+        if args.column not in ds.column_names:
+            logger.error(f"Column {args.column!r} not found. Available: {ds.column_names}")
+            sys.exit(1)
+        if args.output_column in ds.column_names:
+            logger.error(f"Output column {args.output_column!r} already exists — choose another --output-column.")
+            sys.exit(1)
+    if args.max_samples and not args.streaming:
         ds = ds.select(range(min(args.max_samples, len(ds))))
-    logger.info(f"{len(ds)} rows; modality={args.modality}")
+    if sharded and args.streaming:
+        # File-level split: each rank reads ONLY its own data files. Sizes vary per rank and
+        # rows_total is unknown upfront; correctness (exact, deterministic, idempotent) holds
+        # as long as every rank pins the same --revision.
+        if ds.n_shards < args.num_shards:
+            logger.error(f"Dataset has {ds.n_shards} file shard(s) < --num-shards {args.num_shards}. "
+                         f"Lower --num-shards or use row mode.")
+            sys.exit(1)
+        ds = ds.shard(num_shards=args.num_shards, index=args.shard_index)
+        logger.info(f"Fan-out file-shard {args.shard_index + 1}/{args.num_shards} of run {args.run_id} "
+                    f"({ds.n_shards} file(s) for this rank)")
+    elif sharded:
+        # Contiguous slices keep row order reconstructable at consolidation. Note the whole
+        # split was still downloaded above — acceptable at few-M rows, not at corpus scale.
+        ds = ds.shard(num_shards=args.num_shards, index=args.shard_index, contiguous=True)
+        logger.info(f"Fan-out shard {args.shard_index + 1}/{args.num_shards} of run {args.run_id}")
+        if len(ds) == 0:
+            logger.error(f"Shard {args.shard_index} is empty — num_shards exceeds the row count. "
+                         f"Lower --num-shards (or raise --max-samples).")
+            sys.exit(1)
+    if not args.streaming:
+        logger.info(f"{len(ds)} rows; modality={args.modality}")
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = SentenceTransformer(args.model, device=device, trust_remote_code=True)
@@ -269,6 +507,9 @@ def main():
     prompt_str = None  # None = let encode_query/encode_document choose natively
     if args.modality == "text":
         prompt_str = resolve_prompt(model, args.model, is_query=args.query_mode, args=args)
+        if args.streaming:
+            run_streaming_shard(ds, model, prompt_str, args)
+            return
         items = [t if isinstance(t, str) and t.strip() else " " for t in ds[args.column]]
     else:
         if args.prompt or args.prompt_name:
@@ -302,11 +543,63 @@ def main():
     else:
         encode_fn = model.encode
         encode_kwargs = {}
+    reporter = None
+    if sharded:
+        reporter = StatusReporter(args.output_bucket, args.run_id, args.shard_index,
+                                  rows_total=len(items), tokens_per_row=median_tok)
+        reporter.report(0, force=True)
+
     t0 = time.perf_counter()
-    emb = encode_fn(items, batch_size=batch_size, show_progress_bar=True,
-                    convert_to_numpy=True, normalize_embeddings=args.normalize, **encode_kwargs)
+    try:
+        if reporter is None:
+            emb = encode_fn(items, batch_size=batch_size, show_progress_bar=True,
+                            convert_to_numpy=True, normalize_embeddings=args.normalize, **encode_kwargs)
+        else:
+            # Macro-chunks so the heartbeat can report rows_done between encode calls.
+            # Chunking doesn't change results — batching happens at batch_size regardless.
+            import numpy as np
+            chunk_rows = 25_000
+            parts = []
+            for start in range(0, len(items), chunk_rows):
+                chunk = items[start:start + chunk_rows]
+                parts.append(encode_fn(chunk, batch_size=batch_size, show_progress_bar=True,
+                                       convert_to_numpy=True, normalize_embeddings=args.normalize,
+                                       **encode_kwargs))
+                reporter.report(start + len(chunk))
+            emb = np.concatenate(parts) if len(parts) > 1 else parts[0]
+    except Exception:
+        if reporter:
+            reporter.report(state="error", force=True)
+        raise
     secs = time.perf_counter() - t0
     logger.info(f"Embedded {len(items)} in {secs:.1f}s ({len(items)/secs:.0f} rows/s), dim={dim}")
+
+    if sharded:
+        # Shard mode: no repo commit here (N workers committing → 412 contention). Write this
+        # rank's parquet to the run bucket; consolidate-shards.py makes the single final commit.
+        #
+        # Build the embedding column as zero-copy float32 Arrow — NEVER as Python floats.
+        # `[e.tolist() for e in emb]` on an 800k-row shard is ~10 GB of PyFloat objects and
+        # swap-thrashed L4 workers into multi-hour silent stalls (wiki fleet, 2026-07-09).
+        import numpy as np
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        reporter.report(len(items), state="writing", force=True)
+        try:
+            emb32 = np.ascontiguousarray(emb, dtype=np.float32)
+            emb_col = pa.FixedSizeListArray.from_arrays(pa.array(emb32.ravel()), emb32.shape[1])
+            table = ds.with_format("arrow")[:].append_column(args.output_column, emb_col)
+            out_path = f"/tmp/shard-{args.shard_index:05d}.parquet"
+            dest = f"runs/{args.run_id}/data/{args.shard_index:05d}.parquet"
+            pq.write_table(table, out_path)
+            logger.info(f"Uploading shard parquet → {args.output_bucket}/{dest}")
+            put_bucket_files(args.output_bucket, [(out_path, dest)])
+        except Exception:
+            reporter.report(state="error", force=True)
+            raise
+        reporter.report(len(items), state="done", force=True)
+        logger.info(f"✅ shard {args.shard_index + 1}/{args.num_shards} of run {args.run_id} uploaded")
+        return
 
     ds = ds.add_column(args.output_column, [e.tolist() for e in emb])
 

--- a/embeddings/launch-embedding-fleet.py
+++ b/embeddings/launch-embedding-fleet.py
@@ -1,0 +1,355 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "datasets",
+#     "huggingface-hub>=1.12",
+# ]
+# ///
+"""
+Fan one embedding run out across N Hugging Face Jobs, then consolidate.
+
+Runs generate-embeddings.py once per shard (each worker gets RANK / NUM_SHARDS /
+RUN_ID / OUTPUT_BUCKET via env), workers write parquet shards + progress heartbeats
+to the run bucket (object PUTs — no repo-commit contention), and when all workers
+finish a consolidation Job merges the shards into the final Hub dataset with one
+commit. Runs locally on your laptop; only the workers/consolidator run on Jobs.
+
+Examples:
+    # Smoke: 2 small-GPU jobs over a 20k-row slice
+    uv run launch-embedding-fleet.py stanfordnlp/imdb your-name/imdb-emb \\
+        --max-samples 20000 --num-shards 2 --flavor t4-small --timeout 20m
+
+    # Mid-size: 8 L4s over a few million rows
+    uv run launch-embedding-fleet.py your-name/corpus your-name/corpus-emb \\
+        --num-shards 8 --flavor l4x1 --timeout 1h
+
+    # Re-run one failed shard, then consolidate an existing run
+    uv run launch-embedding-fleet.py ... --run-id 20260709-1200-abc123 --retry-rank 3
+    uv run launch-embedding-fleet.py ... --run-id 20260709-1200-abc123 --consolidate-only
+
+Resume model: every worker writes only runs/<run-id>/data/<rank>.parquet and its own
+status file, so re-running a rank is idempotent. The launcher exiting early never
+orphans a run — --retry-rank / --consolidate-only pick it back up.
+"""
+import argparse
+import json
+import logging
+import os
+import secrets as pysecrets
+import sys
+import time
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("launch-embedding-fleet")
+
+SCRIPT_BASE = "https://huggingface.co/datasets/uv-scripts/embeddings/raw/main"
+
+
+def put_json(bucket, path, obj, token=None):
+    from huggingface_hub import batch_bucket_files
+    batch_bucket_files(bucket, add=[(json.dumps(obj, indent=2).encode(), path)], token=token)
+
+
+def rows_in_split(input_dataset, config, split):
+    """Row count WITHOUT downloading: builder metadata, else the dataset-viewer size API."""
+    try:
+        from datasets import load_dataset_builder
+        b = load_dataset_builder(input_dataset, config) if config else load_dataset_builder(input_dataset)
+        n = b.info.splits[split].num_examples
+        if n:
+            return n
+    except Exception as e:
+        logger.info(f"builder metadata unavailable ({e}); trying dataset-viewer size API")
+    try:
+        import huggingface_hub
+        r = huggingface_hub.get_session().get(
+            "https://datasets-server.huggingface.co/size", params={"dataset": input_dataset}
+        )
+        r.raise_for_status()
+        for s in r.json()["size"]["splits"]:
+            if s["split"] == split and (config is None or s["config"] == config):
+                return s["num_rows"]
+    except Exception as e:
+        logger.info(f"size API unavailable ({e})")
+    return None
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("input_dataset")
+    p.add_argument("output_dataset")
+    p.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    p.add_argument("--column", default="text")
+    p.add_argument("--split", default="train")
+    p.add_argument("--config", default=None)
+    p.add_argument("--max-samples", type=int, default=None)
+    p.add_argument("--num-shards", type=int, default=8)
+    p.add_argument("--flavor", default="l4x1")
+    p.add_argument("--timeout", default="1h", help="Per-worker timeout — also the hard cost ceiling")
+    p.add_argument("--bucket", default=None,
+                   help="Run bucket (default: <namespace>/embedding-runs)")
+    p.add_argument("--script", default=f"{SCRIPT_BASE}/generate-embeddings.py",
+                   help="Worker script: raw URL (default) or a local .py path for dev")
+    p.add_argument("--consolidate-script", default=f"{SCRIPT_BASE}/consolidate-shards.py",
+                   help="Consolidator script: raw URL (default) or local path for dev")
+    p.add_argument("--consolidate-flavor", default="cpu-upgrade",
+                   help="Consolidation job flavor. cpu-upgrade has 50 GB disk — use cpu-xl "
+                        "(1 TB) when total shard size approaches ~20 GB.")
+    p.add_argument("--rows-total", type=int, default=None,
+                   help="Override when the dataset has no split metadata")
+    p.add_argument("--streaming", action="store_true",
+                   help="Workers stream + shard at the FILE level (no full-split download per "
+                        "rank) — for very big datasets. Text only; incompatible with --max-samples.")
+    p.add_argument("--private", action="store_true", help="Final output dataset is private")
+    p.add_argument("--embed-args", nargs=argparse.REMAINDER, default=[],
+                   help="Everything after --embed-args is passed through to generate-embeddings.py "
+                        "verbatim — put it LAST (any launcher flags after it are swallowed too).")
+    p.add_argument("--run-id", default=None, help="Attach to an existing run (with --resume/--retry-rank/--consolidate-only)")
+    p.add_argument("--resume", action="store_true",
+                   help="Converge an existing --run-id: find ranks without a 'done' status, re-run "
+                        "exactly those, then consolidate. Idempotent — safe to run repeatedly.")
+    p.add_argument("--retry-rank", type=int, default=None, help="Re-spawn a single failed shard of --run-id")
+    p.add_argument("--consolidate-only", action="store_true", help="Just run consolidation for --run-id")
+    p.add_argument("--no-wait", action="store_true",
+                   help="Spawn workers and exit (run --consolidate-only later)")
+    args = p.parse_args()
+
+    from huggingface_hub import (JobStage, create_bucket, download_bucket_files, get_token,
+                                 run_uv_job, wait_for_job, whoami)
+
+    # Workers need a real token as a secret (bucket writes + output push); env may be empty
+    # when the user authenticated via `hf auth login` (keyring/hub cache).
+    token = os.environ.get("HF_TOKEN") or get_token()
+    if not token:
+        p.error("No HF token found — set HF_TOKEN or run `hf auth login`.")
+    namespace = whoami(token=token)["name"]
+    bucket = args.bucket or f"{namespace}/embedding-runs"
+
+    if (args.retry_rank is not None or args.consolidate_only or args.resume) and not args.run_id:
+        p.error("--resume / --retry-rank / --consolidate-only need --run-id")
+    if args.num_shards < 1:
+        p.error(f"--num-shards must be >= 1 (got {args.num_shards})")
+    if args.streaming and args.max_samples:
+        p.error("--streaming is incompatible with --max-samples (use row mode for capped tests)")
+
+    def read_manifest(run_id):
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as td:
+            dst = Path(td) / "run.json"
+            download_bucket_files(bucket, [(f"runs/{run_id}/run.json", dst)],
+                                  raise_on_missing_files=True, token=token)
+            return json.loads(dst.read_text())
+
+    # Workers are always spawned from the run manifest, never from current CLI flags —
+    # a --retry-rank months later must reproduce the original slice/model/args exactly.
+    def spawn_worker(rank, manifest):
+        script_args = [manifest["input_dataset"], manifest["output_dataset"],
+                       "--model", manifest["model"], "--column", manifest["column"],
+                       "--split", manifest["split"]]
+        if manifest.get("config"):
+            script_args += ["--config", manifest["config"]]
+        if manifest.get("max_samples"):
+            script_args += ["--max-samples", str(manifest["max_samples"])]
+        script_args += list(manifest.get("embed_args") or [])
+        env = {
+            "RANK": str(rank),
+            "NUM_SHARDS": str(manifest["num_shards"]),
+            "RUN_ID": manifest["run_id"],
+            "OUTPUT_BUCKET": bucket,
+        }
+        if manifest.get("revision"):
+            env["REVISION"] = manifest["revision"]
+        if manifest.get("streaming"):
+            env["STREAMING"] = "1"
+        job = run_uv_job(
+            args.script,
+            script_args=script_args,
+            flavor=manifest["flavor"],
+            timeout=manifest["timeout"],
+            env=env,
+            secrets={"HF_TOKEN": token},
+            labels={"embedding-fleet-run": manifest["run_id"], "rank": str(rank)},
+            token=token,
+        )
+        logger.info(f"  rank {rank} → job {job.id} ({manifest['flavor']})")
+        return job
+
+    def spawn_consolidator(run_id):
+        job = run_uv_job(
+            args.consolidate_script,
+            script_args=[
+                "--bucket", bucket, "--run-id", run_id,
+            ] + (["--private"] if args.private else []),
+            flavor=args.consolidate_flavor,
+            timeout="2h",
+            secrets={"HF_TOKEN": token},
+            labels={"embedding-fleet-run": run_id, "role": "consolidate"},
+            token=token,
+        )
+        logger.info(f"Consolidation job {job.id} ({args.consolidate_flavor}) — "
+                    f"merges shards → {args.output_dataset}")
+        return job
+
+    def execute_workers(ranks, manifest):
+        """Spawn the given ranks, wait, auto-retry failures ONCE, return still-failed ranks."""
+        for attempt in (1, 2):
+            jobs = {rank: spawn_worker(rank, manifest) for rank in ranks}
+            infos = wait_for_job([j.id for j in jobs.values()], token=token)
+            ranks = [rank for (rank, job), info in zip(jobs.items(), infos)
+                     if info.status.stage != JobStage.COMPLETED]
+            if not ranks:
+                return []
+            if attempt == 1:
+                logger.warning(f"{len(ranks)} worker(s) failed; auto-retrying once: {ranks}")
+        return ranks
+
+    def done_ranks(run_id, n):
+        """Ranks whose bucket status reports state == 'done' (works for both shard modes)."""
+        import tempfile
+        from pathlib import Path
+        done = set()
+        with tempfile.TemporaryDirectory() as td:
+            pairs = [(f"runs/{run_id}/status/{i:05d}.json", Path(td) / f"{i}.json") for i in range(n)]
+            download_bucket_files(bucket, pairs, token=token)
+            for i, (_, dst) in enumerate(pairs):
+                if dst.exists() and json.loads(dst.read_text()).get("state") == "done":
+                    done.add(i)
+        return done
+
+    # --- attach-to-existing-run paths ---
+    if args.resume:
+        manifest = read_manifest(args.run_id)
+        n = manifest["num_shards"]
+        # Don't double-spawn ranks that are still running — wait for them, then diff.
+        from huggingface_hub import list_jobs
+        try:
+            in_flight = [j for j in list_jobs(labels={"embedding-fleet-run": args.run_id},
+                                              namespace=namespace, token=token)
+                         if j.status.stage in (JobStage.RUNNING, JobStage.SCHEDULING)
+                         and (j.labels or {}).get("rank") is not None]
+        except Exception as e:
+            logger.warning(f"in-flight check skipped ({e})")
+            in_flight = []
+        if in_flight:
+            ranks = sorted({j.labels["rank"] for j in in_flight})
+            logger.info(f"{len(in_flight)} worker(s) still in flight (ranks {ranks}) — waiting before resuming.")
+            wait_for_job([j.id for j in in_flight], token=token)
+        todo = sorted(set(range(n)) - done_ranks(args.run_id, n))
+        if todo:
+            logger.info(f"Resume {args.run_id}: {n - len(todo)}/{n} shards done; re-running {todo}")
+            still_failed = execute_workers(todo, manifest)
+            if still_failed:
+                logger.error(f"Ranks still failing after retry: {still_failed} — investigate, then --resume again.")
+                sys.exit(1)
+        else:
+            logger.info(f"Resume {args.run_id}: all {n} shards already done — consolidating.")
+        job = spawn_consolidator(args.run_id)
+        info = wait_for_job(job.id, token=token)
+        if info.status.stage != JobStage.COMPLETED:
+            logger.error(f"Consolidation failed (job {job.id}); run --resume again.")
+            sys.exit(1)
+        logger.info(f"✅ https://huggingface.co/datasets/{manifest['output_dataset']}")
+        return
+
+    if args.retry_rank is not None:
+        manifest = read_manifest(args.run_id)
+        if not 0 <= args.retry_rank < manifest["num_shards"]:
+            p.error(f"--retry-rank must be in [0, {manifest['num_shards']}) for run {args.run_id}")
+        logger.info(f"Re-spawning rank {args.retry_rank} of run {args.run_id} (config from manifest)")
+        job = spawn_worker(args.retry_rank, manifest)
+        info = wait_for_job(job.id, token=token)
+        if info.status.stage != JobStage.COMPLETED:
+            logger.error(f"Retry of rank {args.retry_rank} did not complete "
+                         f"(stage={info.status.stage}, job {job.id}).")
+            sys.exit(1)
+        logger.info("Retry completed; run --consolidate-only when all shards are done.")
+        return
+
+    if args.consolidate_only:
+        job = spawn_consolidator(args.run_id)
+        info = wait_for_job(job.id, token=token)
+        sys.exit(0 if info.status.stage == JobStage.COMPLETED else 1)
+
+    # --- fresh run ---
+    rows_total = args.rows_total or rows_in_split(args.input_dataset, args.config, args.split)
+    if rows_total is None and not args.streaming:
+        p.error("Couldn't determine the split's row count — pass --rows-total.")
+    if rows_total is not None:
+        if args.max_samples:
+            rows_total = min(rows_total, args.max_samples)
+        if not args.streaming and args.num_shards > rows_total:
+            p.error(f"--num-shards {args.num_shards} exceeds the row count ({rows_total}) — "
+                    f"some shards would be empty.")
+
+    # Pin the input snapshot: every rank (and any later --retry-rank) must slice the IDENTICAL
+    # revision, or a mid-run commit to the input dataset silently breaks the exact partition.
+    from huggingface_hub import dataset_info
+    revision = dataset_info(args.input_dataset, token=token).sha
+    logger.info(f"Pinned input revision: {revision[:12]}")
+
+    run_id = time.strftime("%Y%m%d-%H%M%S") + "-" + pysecrets.token_hex(3)
+    create_bucket(bucket, private=True, exist_ok=True, token=token)
+
+    manifest = {
+        "run_id": run_id,
+        "input_dataset": args.input_dataset,
+        "output_dataset": args.output_dataset,
+        "model": args.model,
+        "column": args.column,
+        "split": args.split,
+        "config": args.config,
+        "max_samples": args.max_samples,
+        "num_shards": args.num_shards,
+        "rows_total": rows_total,
+        "flavor": args.flavor,
+        "timeout": args.timeout,
+        "private": args.private,
+        "embed_args": list(args.embed_args),
+        "streaming": args.streaming,
+        "revision": revision,
+        "started_at": time.time(),
+        "job_ids": [],
+    }
+    put_json(bucket, f"runs/{run_id}/run.json", manifest, token=token)
+    if rows_total is not None:
+        logger.info(f"Run {run_id}: {rows_total:,} rows → {args.num_shards} shards "
+                    f"(~{rows_total // args.num_shards:,} rows each) on {args.flavor}")
+    else:
+        logger.info(f"Run {run_id}: streaming file-shards × {args.num_shards} on {args.flavor} "
+                    f"(row count unknown upfront)")
+
+    jobs = [spawn_worker(rank, manifest) for rank in range(args.num_shards)]
+    manifest["job_ids"] = [j.id for j in jobs]
+    put_json(bucket, f"runs/{run_id}/run.json", manifest, token=token)
+
+    logger.info(f"Manifest: hf://buckets/{bucket}/runs/{run_id}/run.json")
+    logger.info(f"Dashboard: https://huggingface.co/spaces/davanstrien/embedding-fleet-dashboard?run={run_id}")
+
+    if args.no_wait:
+        logger.info(f"--no-wait: consolidate later with --run-id {run_id} --consolidate-only")
+        return
+
+    logger.info("Waiting for workers…")
+    infos = wait_for_job([j.id for j in jobs], token=token)
+    failed = [rank for rank, (j, i) in enumerate(zip(jobs, infos))
+              if i.status.stage != JobStage.COMPLETED]
+    if failed:
+        logger.warning(f"{len(failed)} worker(s) did not complete; auto-retrying: {failed}")
+        still_failed = execute_workers(failed, manifest)
+        if still_failed:
+            logger.error(f"Ranks still failing after retries: {still_failed}")
+            logger.error(f"Investigate (job logs / heartbeat age), then converge with: "
+                         f"--run-id {run_id} --resume")
+            sys.exit(1)
+
+    job = spawn_consolidator(run_id)
+    info = wait_for_job(job.id, token=token)
+    if info.status.stage != JobStage.COMPLETED:
+        logger.error(f"Consolidation failed (job {job.id}); retry with --consolidate-only --run-id {run_id}")
+        sys.exit(1)
+    logger.info(f"✅ https://huggingface.co/datasets/{args.output_dataset}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
One embedding run, N parallel Jobs, one output dataset.

- **Worker shard mode** in `generate-embeddings.py`: exact `ds.shard()` slices driven by env (`RANK`/`NUM_SHARDS`/`RUN_ID`/`OUTPUT_BUCKET`), 30s heartbeats + shard parquets to a Bucket (object PUTs — no repo-commit contention), zero-copy float32 Arrow writer (the old `tolist()` path = ~18GB of PyFloats at 1.2M rows → silent swap-wedge; found the hard way, twice).
- **`--streaming`**: file-level `IterableDataset.shard` for very big datasets — each rank streams only its own files, bounded-memory part writes. Text only; needs `num_files >= num_shards`.
- **`launch-embedding-fleet.py`**: run manifest (input revision pinned — every rank and any later retry slices the identical snapshot), auto-retry-once, `--resume` converges any run idempotently, `--no-wait`, `--consolidate-flavor`.
- **`consolidate-shards.py`**: passthrough per-file assembly, peak disk = ONE shard (34GB merged in 293s on cpu-xl), embeddings-column schema normalization, single commit + provenance card.

Validated on Jobs today: `davanstrien/wikipedia-en-embeddings` (6,407,814 rows) and `davanstrien/fineweb-edu-10bt-embeddings` (9,672,101 rows — 56 min end-to-end, ~$4.50 on 8× l4x1). Kill-a-worker → `--resume` → row-exact output verified. Live run dashboard: https://huggingface.co/spaces/davanstrien/embedding-fleet-dashboard

**Sync note:** the Hub repo is ahead of main (today's direct pushes, pre-PR-flow) — the superset gate is blocking `sync-embeddings` until this merges. This branch = Hub state + `--resume`; merging reconciles. The Hub-side discussion PR (uv-scripts/embeddings#1) is superseded by this and will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFBh6iF73zJLMJZ9avr8kk