### PR TITLE
embeddings: 25k-row parquet groups + page index (viewer fix)

### DIFF
--- a/embeddings/consolidate-shards.py
+++ b/embeddings/consolidate-shards.py
@@ -38,31 +38,42 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger("consolidate-shards")
 
 
+ROW_GROUP_ROWS = 25_000  # ~100MB groups with an embeddings column; viewer needs random access
+
+
 def normalize_embeddings_column(local, out_col):
-    """Rewrite the file in place if its embeddings column isn't fixed_size_list<float32>.
+    """Rewrite the file in place if its embeddings column isn't fixed_size_list<float32>
+    OR its row groups are too big for the dataset viewer.
 
     Shards written by different script versions can disagree (old: list<double>, new:
-    fixed_size_list<float32>); a repo with mixed parquet schemas breaks load_dataset, so
-    the consolidator is the place to unify. Returns the file's row count."""
+    fixed_size_list<float32>) — mixed schemas break load_dataset. And pyarrow-default
+    ~1M-row groups are multi-GB with embeddings, which the viewer rejects with
+    "Scan size limit exceeded". Returns the file's row count."""
     import pyarrow as pa
     import pyarrow.compute as pc
     import pyarrow.parquet as pq
     pf = pq.ParquetFile(local)
+    meta = pf.metadata
     schema = pf.schema_arrow
     if out_col not in schema.names:
-        return pf.metadata.num_rows  # nothing to normalize (unexpected, but not fatal here)
+        return meta.num_rows  # nothing to normalize (unexpected, but not fatal here)
     field = schema.field(out_col)
-    if pa.types.is_fixed_size_list(field.type) and field.type.value_type == pa.float32():
-        return pf.metadata.num_rows
+    schema_ok = pa.types.is_fixed_size_list(field.type) and field.type.value_type == pa.float32()
+    groups_ok = meta.num_row_groups > 0 and all(
+        meta.row_group(i).num_rows <= 4 * ROW_GROUP_ROWS for i in range(meta.num_row_groups))
+    if schema_ok and groups_ok:
+        return meta.num_rows
     t = pq.read_table(local)
-    col = t[out_col].combine_chunks()
-    dim = len(col[0].as_py())
-    values = pc.cast(pc.list_flatten(col), pa.float32())
-    fixed = pa.FixedSizeListArray.from_arrays(values, dim)
-    idx = t.schema.get_field_index(out_col)
-    t = t.set_column(idx, pa.field(out_col, fixed.type), fixed)
-    logger.info(f"  normalized {Path(local).name}: {field.type} → {fixed.type}")
-    pq.write_table(t, local)
+    if not schema_ok:
+        col = t[out_col].combine_chunks()
+        dim = len(col[0].as_py())
+        values = pc.cast(pc.list_flatten(col), pa.float32())
+        fixed = pa.FixedSizeListArray.from_arrays(values, dim)
+        idx = t.schema.get_field_index(out_col)
+        t = t.set_column(idx, pa.field(out_col, fixed.type), fixed)
+    logger.info(f"  normalized {Path(local).name}: schema_ok={schema_ok} groups_ok={groups_ok} "
+                f"→ {t.schema.field(out_col).type}, {ROW_GROUP_ROWS}-row groups + page index")
+    pq.write_table(t, local, row_group_size=ROW_GROUP_ROWS, write_page_index=True)
     return t.num_rows
 
 

--- a/embeddings/generate-embeddings.py
+++ b/embeddings/generate-embeddings.py
@@ -323,7 +323,8 @@ def run_streaming_shard(ds, model, prompt_str, args):
         if not part_buf:
             return
         path = f"/tmp/part-{args.shard_index:05d}-{prog['part_idx']:04d}.parquet"
-        pq.write_table(pa.Table.from_pylist(part_buf), path)
+        pq.write_table(pa.Table.from_pylist(part_buf), path,
+                       row_group_size=25_000, write_page_index=True)
         dest = f"runs/{args.run_id}/data/{args.shard_index:05d}.part{prog['part_idx']:04d}.parquet"
         logger.info(f"Uploading {len(part_buf):,}-row part → {args.output_bucket}/{dest}")
         put_bucket_files(args.output_bucket, [(path, dest)])
@@ -591,7 +592,10 @@ def main():
             table = ds.with_format("arrow")[:].append_column(args.output_column, emb_col)
             out_path = f"/tmp/shard-{args.shard_index:05d}.parquet"
             dest = f"runs/{args.run_id}/data/{args.shard_index:05d}.parquet"
-            pq.write_table(table, out_path)
+            # Small row groups + page index or the dataset viewer can't random-access:
+            # pyarrow's default ~1M-row groups ≈ multi-GB with an embeddings column
+            # ("Scan size limit exceeded"). ~25k rows ≈ ~100MB here.
+            pq.write_table(table, out_path, row_group_size=25_000, write_page_index=True)
             logger.info(f"Uploading shard parquet → {args.output_bucket}/{dest}")
             put_bucket_files(args.output_bucket, [(out_path, dest)])
         except Exception:


### PR DESCRIPTION
Follow-up to #87 — missed the merge by a few minutes.

The dataset viewer rejects the fan-out outputs with `Scan size limit exceeded`: pyarrow's default ~1M-row groups are ~4.6GB with an embeddings column. Both shard writers now emit 25k-row groups (~100MB) with a page index, and the consolidator normalizer rewrites any oversized-row-group file it passes through — so re-running consolidation heals existing runs (both public datasets are being re-consolidated with this now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFBh6iF73zJLMJZ9avr8kk