### PR TITLE
transcription: MOSS-Transcribe-Diarize recipes (joint ASR + speaker diarization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 |---|---|---|
 | **ocr** ⭐ | OCR / document → text & structured data — GLM, PaddleOCR-VL, Nanonets, olmOCR, dots, … (30+ models) | [`uv-scripts/ocr`](https://huggingface.co/datasets/uv-scripts/ocr) |
 | **vision** | Zero-shot detection & segmentation over image datasets | [`sam3`](https://huggingface.co/datasets/uv-scripts/sam3) · [`object-detection`](https://huggingface.co/datasets/uv-scripts/object-detection) · [`vlm-object-detection`](https://huggingface.co/datasets/uv-scripts/vlm-object-detection) |
-| **audio** | Transcription & speech translation | [`transcription`](https://huggingface.co/datasets/uv-scripts/transcription) |
+| **audio** | Transcription, speaker diarization & speech translation | [`transcription`](https://huggingface.co/datasets/uv-scripts/transcription) |
 | **embeddings** | Embed text/images (auto-batch, prompt-aware); build a searchable Lance vector DB on the Hub | [`embeddings`](https://huggingface.co/datasets/uv-scripts/embeddings) |
 | **embeddings & atlas** | Embed a dataset; build an interactive map | [`build-atlas`](https://huggingface.co/datasets/uv-scripts/build-atlas) |
 | **data processing** | Filter / dedup / stats over large datasets | [`dataset-stats`](https://huggingface.co/datasets/uv-scripts/dataset-stats) · [`deduplication`](https://huggingface.co/datasets/uv-scripts/deduplication) · [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -54,7 +54,7 @@ No download/upload step. Buckets are mounted directly as volumes via [hf-mount](
 | `cohere-transcribe-vllm.py` | Cohere Transcribe (2B) | vLLM nightly | `.txt` | 214x RT (A100) |
 | `easytranscriber-transcribe.py` | Cohere Transcribe 2B (default) or Whisper variants | [easytranscriber](https://github.com/kb-labb/easytranscriber) | JSON word timestamps (+ optional `.txt` / `.srt`) | 42.9x RT (L4) |
 | `moss-transcribe-diarize.py` | [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B) | transformers (remote code) | JSON speaker segments `{start, end, speaker, text}` (+ optional `.txt` / `.srt`) | 3.2x RT (A10G, 74-min file) |
-| `moss-transcribe-diarize-server.py` | [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B) | in-job sgl-omni server | JSON speaker segments (+ optional `.txt`) | 37.8x RT aggregate (A100, 4 streams) |
+| `moss-transcribe-diarize-server.py` | [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B) | in-job sgl-omni server | JSON speaker segments (+ optional `.txt`) | 47.4x RT aggregate (A100, 6 streams) |
 
 **`cohere-transcribe.py`** (recommended for plain text) — uses `model.transcribe()` with automatic long-form chunking, overlap, and reassembly. Stable dependencies.
 
@@ -138,11 +138,13 @@ CBS Suspense (1940s radio drama), 66 episodes, 33 hours of audio.
 
 Long files are generation-bound (the whole diarized transcript is decoded in one pass), so RTFx drops as recordings grow; short clips run far faster. `l4x1` also works — same class of GPU.
 
-**`moss-transcribe-diarize-server.py`** (Apollo 11 mission audio, 3 tapes / 2.7 h, concurrency 4):
+**`moss-transcribe-diarize-server.py`** (Apollo 11 mission audio from the [Internet Archive](https://archive.org/details/Apollo11Audio) — the full collection in one job):
 
-| GPU | Time | RTFx | Output |
-|-----|------|------|--------|
-| A100 | 4.3 min | 37.8x realtime aggregate | 1,697 segments, 96–99% coverage per tape |
+| GPU | Audio | Time | RTFx | Cost | Output |
+|-----|-------|------|------|------|--------|
+| A100 | 174.5 h (103 tapes) | 3.8 h | 47.4x realtime aggregate | $9.46 | 45k speaker segments, 97% coverage |
+
+Result published as [`davanstrien/apollo-11-diarized`](https://huggingface.co/datasets/davanstrien/apollo-11-diarized) with a searchable demo at [`davanstrien/apollo-11-search`](https://huggingface.co/spaces/davanstrien/apollo-11-search).
 
 ### Data
 

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -45,12 +45,15 @@ No download/upload step. Buckets are mounted directly as volumes via [hf-mount](
 | `cohere-transcribe.py` | Cohere Transcribe (2B) | transformers | `.txt` | 161x RT (A100) |
 | `cohere-transcribe-vllm.py` | Cohere Transcribe (2B) | vLLM nightly | `.txt` | 214x RT (A100) |
 | `easytranscriber-transcribe.py` | Cohere Transcribe 2B (default) or Whisper variants | [easytranscriber](https://github.com/kb-labb/easytranscriber) | JSON word timestamps (+ optional `.txt` / `.srt`) | 42.9x RT (L4) |
+| `moss-transcribe-diarize.py` | [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B) | transformers (remote code) | JSON speaker segments `{start, end, speaker, text}` (+ optional `.txt` / `.srt`) | 3.2x RT (A10G, 74-min file) |
 
 **`cohere-transcribe.py`** (recommended for plain text) — uses `model.transcribe()` with automatic long-form chunking, overlap, and reassembly. Stable dependencies.
 
 **`cohere-transcribe-vllm.py`** — experimental vLLM variant. Faster but requires nightly vLLM and has minor duplication at chunk boundaries.
 
 **`easytranscriber-transcribe.py`** — when you need **word-level timestamps** (subtitles, search indexing, forced alignment). Runs VAD → ASR → wav2vec2 emissions → forced alignment. Defaults to the Cohere backend so you get the same model as the other scripts with alignment on top; swap to `--backend ct2` + a Whisper model for languages Cohere doesn't cover (e.g. Swedish via `KBLab/kb-whisper-large`).
+
+**`moss-transcribe-diarize.py`** — when you need **who said what**. Joint transcription + speaker diarization + timestamps in one generation pass (no separate ASR/diarization/alignment stages). 128k context handles up to ~90 min of audio per file internally, so files are never pre-chunked and the anonymous speaker labels (`[S01]`, `[S02]`, ...) stay consistent across the whole recording. English + Chinese; also accepts video containers (mp4, mkv, ...); supports hotword biasing for names/jargon.
 
 #### Options — `cohere-transcribe.py` / `cohere-transcribe-vllm.py`
 
@@ -77,6 +80,17 @@ No download/upload step. Buckets are mounted directly as volumes via [hf-mount](
 | `--batch-size-transcribe` | 16 | ASR batch size (where backend supports it) |
 | `--max-files` | all | Limit files to process (for testing) |
 
+#### Options — `moss-transcribe-diarize.py`
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-new-tokens` | 0 (auto) | Token budget per file. Auto scales with audio duration (min 5120, max 65536). Output JSON sets `"truncated": true` if the budget was hit — re-run with a higher value |
+| `--hotwords` | none | Comma-separated terms (names, companies, jargon) appended to the prompt to bias recognition |
+| `--prompt` | built-in | Full prompt override (replaces the built-in transcribe+diarize prompt) |
+| `--emit-txt` | off | Also write `.txt` transcripts (`[start - end] SPEAKER: text` per line) |
+| `--emit-srt` | off | Also write `.srt` subtitles with speaker prefixes |
+| `--max-files` | all | Limit files to process (for testing) |
+
 #### Benchmarks
 
 CBS Suspense (1940s radio drama), 66 episodes, 33 hours of audio.
@@ -94,6 +108,14 @@ CBS Suspense (1940s radio drama), 66 episodes, 33 hours of audio.
 |-----|------|------|--------|
 | L4 | 46.2 min | 42.9x realtime | 66 JSON + SRT + TXT (42,633 segments, 295k words) |
 
+**`moss-transcribe-diarize.py`** (Apollo 11 mission audio, one 74-min multi-speaker tape):
+
+| GPU | Time | RTFx | Output |
+|-----|------|------|--------|
+| A10G | 23.3 min | 3.2x realtime | 743 segments, 7 speakers, 23k tokens, no truncation |
+
+Long files are generation-bound (the whole diarized transcript is decoded in one pass), so RTFx drops as recordings grow; short clips run far faster. `l4x1` also works — same class of GPU.
+
 ### Data
 
 | Script | Description |
@@ -105,3 +127,5 @@ CBS Suspense (1940s radio drama), 66 episodes, 33 hours of audio.
 - **Gated model**: Accept terms at the [model page](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) before use.
 - **Tokenizer workaround**: `cohere-transcribe.py` applies a one-line patch for a tokenizer compat issue. Will be removed once upstream fixes land ([model discussion](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026/discussions/11)).
 - **easytranscriber**: the Cohere backend requires `transformers>=5.4.0` (pinned in the script). Pyannote VAD is gated — accept terms at [pyannote/segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0) and [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) if using `--vad pyannote`. Otherwise stick with the default Silero VAD.
+- **moss-transcribe-diarize**: not gated (Apache 2.0). Uses `trust_remote_code=True` (model code lives in the [model repo](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize)); inference helpers install from the model's [GitHub repo](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) pinned to a commit (the package isn't on PyPI). Generation time scales with audio length — long multi-speaker recordings emit tens of thousands of tokens, so watch the `truncated` flag in the output JSON.
+- **Serving MOSS-Transcribe-Diarize**: upstream's production path is an OpenAI-compatible `/v1/audio/transcriptions` server via [sglang-omni](https://github.com/sgl-project/sglang-omni) (no offline engine — high-concurrency batch goes through the server). Not runnable on Jobs yet: as of 2026-07-09 the only published image (`lmsysorg/sglang-omni:dev`, 2026-06-16) predates the model's support (added 2026-07-04) and the `sgl-omni` CLI, and the newer code needs a newer core `sglang` than the image ships. Revisit when a fresh image lands.

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -124,7 +124,9 @@ Long files are generation-bound (the whole diarized transcript is decoded in one
 
 ## Serve as a live endpoint
 
-MOSS-Transcribe-Diarize can be served as an OpenAI-compatible transcription API with vLLM on Jobs (see [Serving on Jobs](https://huggingface.co/docs/hub/jobs-serving)). Model support was merged into vLLM on 2026-07-08 — after the v0.24.0 release — so use a commit-pinned nightly image until the next release (then plain `vllm/vllm-openai:latest` works). The image needs the audio extras installed first:
+MOSS-Transcribe-Diarize can be served as an OpenAI-compatible transcription API on Jobs (see [Serving on Jobs](https://huggingface.co/docs/hub/jobs-serving)). Two verified paths; both expose `/v1/audio/transcriptions` at `https://<job-id>--8000.hf.jobs` (requests need an HF token with read access to your namespace).
+
+**vLLM** (simplest; returns the raw `[start][Sxx]text[end]` transcript). Model support was merged into vLLM on 2026-07-08 — after the v0.24.0 release — so use a commit-pinned nightly image until the next release (then plain `vllm/vllm-openai:latest` works). The image needs the audio extras installed first:
 
 ```bash
 hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \
@@ -132,18 +134,28 @@ hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \
     bash -c "pip install librosa soundfile && vllm serve OpenMOSS-Team/MOSS-Transcribe-Diarize --trust-remote-code"
 ```
 
-`--expose 8000` makes the server reachable at `https://<job-id>--8000.hf.jobs` (requires an HF token with read access to your namespace). Post audio to `/v1/audio/transcriptions`:
+Parse the response `text` into segments with `parse_transcript` from the model's [GitHub package](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize).
+
+**sglang-omni** (upstream's recommended production server; adds `response_format=verbose_json` with parsed speaker segments). Its prebuilt image predates this model, so install it at job start over a current [sglang nightly image](https://hub.docker.com/r/lmsysorg/sglang/tags) — the clone + fresh-venv sequence is [upstream's documented install](https://github.com/sgl-project/sglang-omni/blob/main/docs/get_started/installation.md) and adds under a minute:
+
+```bash
+hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \
+    lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928 -- \
+    bash -c "pip install -q uv 2>/dev/null; git clone --depth 1 https://github.com/sgl-project/sglang-omni.git && cd sglang-omni && uv venv .venv -p 3.12 && . .venv/bin/activate && uv pip install . && sgl-omni serve --model-path OpenMOSS-Team/MOSS-Transcribe-Diarize --host 0.0.0.0 --port 8000 --max-running-requests 16 --mem-fraction-static 0.80"
+```
+
+Query either server the same way (`response_format=verbose_json` on sglang-omni only; raise `max_new_tokens`, e.g. `65536`, for long recordings):
 
 ```bash
 curl -X POST https://<job-id>--8000.hf.jobs/v1/audio/transcriptions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -F model=OpenMOSS-Team/MOSS-Transcribe-Diarize \
     -F file=@meeting.wav \
-    -F response_format=json \
-    -F temperature=0
+    -F response_format=verbose_json \
+    -F max_new_tokens=65536
 ```
 
-The response `text` is the raw `[start][Sxx]text[end]` transcript — parse it into segments with `parse_transcript` from the model's [GitHub package](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) (`verbose_json` is not supported by vLLM for this model; parsed-segment responses are an [sglang-omni](https://github.com/sgl-project/sglang-omni) adapter feature, see Notes). The job — and its billing — stops at `--timeout` or `hf jobs cancel <job_id>`.
+The job — and its billing — stops at `--timeout` or `hf jobs cancel <job_id>`.
 
 ## Notes
 
@@ -151,4 +163,4 @@ The response `text` is the raw `[start][Sxx]text[end]` transcript — parse it i
 - **Tokenizer workaround**: `cohere-transcribe.py` applies a one-line patch for a tokenizer compat issue. Will be removed once upstream fixes land ([model discussion](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026/discussions/11)).
 - **easytranscriber**: the Cohere backend requires `transformers>=5.4.0` (pinned in the script). Pyannote VAD is gated — accept terms at [pyannote/segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0) and [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) if using `--vad pyannote`. Otherwise stick with the default Silero VAD.
 - **moss-transcribe-diarize**: not gated (Apache 2.0). Uses `trust_remote_code=True` (model code lives in the [model repo](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize)); inference helpers install from the model's [GitHub repo](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) pinned to a commit (the package isn't on PyPI). Generation time scales with audio length — long multi-speaker recordings emit tens of thousands of tokens, so watch the `truncated` flag in the output JSON.
-- **sglang-omni serving**: upstream's recommended production server ([sglang-omni](https://github.com/sgl-project/sglang-omni)) adds `verbose_json` (parsed speaker segments) on the same endpoint, but is not runnable on Jobs yet: as of 2026-07-09 the only published image (`lmsysorg/sglang-omni:dev`, 2026-06-16) predates the model's support (added 2026-07-04) and the `sgl-omni` CLI, and the newer code needs a newer core `sglang` than the image ships. Use the vLLM path above until a fresh image lands.
+- **sglang-omni install**: the `lmsysorg/sglang-omni:dev` image predates this model — don't use it. Install from git over a current `lmsysorg/sglang` nightly image as shown above, and follow the clone + fresh-venv sequence exactly: installing outside the repo skips its `[tool.uv]` dependency overrides and fails on a protobuf conflict. Once they publish a fresh image, `sgl-omni serve` alone will do.

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -5,12 +5,12 @@ tags:
   - audio
   - transcription
   - automatic-speech-recognition
-private: true
+  - speaker-diarization
 ---
 
 # Transcription
 
-Scripts for transcribing audio files using HF Buckets and Jobs.
+Scripts for transcribing — and diarizing — audio files using HF Buckets and Jobs.
 
 ## Quick Start
 
@@ -30,6 +30,14 @@ hf jobs uv run --flavor l4x1 -s HF_TOKEN \
     -v hf://buckets/user/transcripts:/output \
     https://huggingface.co/datasets/uv-scripts/transcription/raw/main/cohere-transcribe.py \
     /input /output --language en --compile
+
+# Or: transcribe + figure out WHO said what (speaker diarization + timestamps)
+hf jobs uv run --flavor l4x1 -s HF_TOKEN \
+    -e UV_TORCH_BACKEND=cu128 \
+    -v hf://buckets/user/audio-files:/input:ro \
+    -v hf://buckets/user/transcripts:/output \
+    https://huggingface.co/datasets/uv-scripts/transcription/raw/main/moss-transcribe-diarize.py \
+    /input /output --emit-txt
 ```
 
 No download/upload step. Buckets are mounted directly as volumes via [hf-mount](https://github.com/huggingface/hf-mount).
@@ -156,7 +164,7 @@ hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \
 
 Parse the response `text` into segments with `parse_transcript` from the model's [GitHub package](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize).
 
-**sglang-omni** (upstream's recommended production server; adds `response_format=verbose_json` with parsed speaker segments). Its prebuilt image predates this model, so install it at job start over a current [sglang nightly image](https://hub.docker.com/r/lmsysorg/sglang/tags) — the clone + fresh-venv sequence is [upstream's documented install](https://github.com/sgl-project/sglang-omni/blob/main/docs/get_started/installation.md) and adds under a minute:
+**sglang-omni** (upstream's recommended production server; adds `response_format=verbose_json` with parsed speaker segments). Its prebuilt image predates this model, so install it at job start over a current [sglang nightly image](https://hub.docker.com/r/lmsysorg/sglang/tags) — the tag below is the tested pin; newer nightlies should also work. The clone + fresh-venv sequence is [upstream's documented install](https://github.com/sgl-project/sglang-omni/blob/main/docs/get_started/installation.md) and adds under a minute:
 
 ```bash
 hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -46,6 +46,7 @@ No download/upload step. Buckets are mounted directly as volumes via [hf-mount](
 | `cohere-transcribe-vllm.py` | Cohere Transcribe (2B) | vLLM nightly | `.txt` | 214x RT (A100) |
 | `easytranscriber-transcribe.py` | Cohere Transcribe 2B (default) or Whisper variants | [easytranscriber](https://github.com/kb-labb/easytranscriber) | JSON word timestamps (+ optional `.txt` / `.srt`) | 42.9x RT (L4) |
 | `moss-transcribe-diarize.py` | [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B) | transformers (remote code) | JSON speaker segments `{start, end, speaker, text}` (+ optional `.txt` / `.srt`) | 3.2x RT (A10G, 74-min file) |
+| `moss-transcribe-diarize-server.py` | [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B) | in-job sgl-omni server | JSON speaker segments (+ optional `.txt`) | 37.8x RT aggregate (A100, 4 streams) |
 
 **`cohere-transcribe.py`** (recommended for plain text) — uses `model.transcribe()` with automatic long-form chunking, overlap, and reassembly. Stable dependencies.
 
@@ -54,6 +55,8 @@ No download/upload step. Buckets are mounted directly as volumes via [hf-mount](
 **`easytranscriber-transcribe.py`** — when you need **word-level timestamps** (subtitles, search indexing, forced alignment). Runs VAD → ASR → wav2vec2 emissions → forced alignment. Defaults to the Cohere backend so you get the same model as the other scripts with alignment on top; swap to `--backend ct2` + a Whisper model for languages Cohere doesn't cover (e.g. Swedish via `KBLab/kb-whisper-large`).
 
 **`moss-transcribe-diarize.py`** — when you need **who said what**. Joint transcription + speaker diarization + timestamps in one generation pass (no separate ASR/diarization/alignment stages). 128k context handles up to ~90 min of audio per file internally, so files are never pre-chunked and the anonymous speaker labels (`[S01]`, `[S02]`, ...) stay consistent across the whole recording. English + Chinese; also accepts video containers (mp4, mkv, ...); supports hotword biasing for names/jargon.
+
+**`moss-transcribe-diarize-server.py`** — same model at **~12x the throughput** for many files: serves it behind sglang-omni inside the job and posts files concurrently (continuous batching). Splits long tapes into ≤55-min clips to fit the context window (speaker labels reset between clips, recorded as `part` on each segment) and automatically continues from the last timestamp when the model stops early, reporting `coverage_s` per file. Needs `a100-large` — 24 GB cards OOM on long-tape KV. The `hf jobs run` command lives in the script docstring (server + driver in one job).
 
 #### Options — `cohere-transcribe.py` / `cohere-transcribe-vllm.py`
 
@@ -78,6 +81,17 @@ No download/upload step. Buckets are mounted directly as volumes via [hf-mount](
 | `--emit-srt` | off | Also write `.srt` subtitles derived from alignment segments |
 | `--batch-size-features` | 8 | Feature-extraction batch size |
 | `--batch-size-transcribe` | 16 | ASR batch size (where backend supports it) |
+| `--max-files` | all | Limit files to process (for testing) |
+
+#### Options — `moss-transcribe-diarize-server.py`
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--concurrency` | 4 | Concurrent transcription requests (KV-cache bound; 6 works on A100) |
+| `--part-minutes` | 55 | Clip length for splitting long audio (longest that fits the context window). Speaker labels reset between clips |
+| `--server` | `http://127.0.0.1:8000` | sgl-omni server URL (in-job localhost by default) |
+| `--request-timeout` | 3600 | Per-request timeout in seconds |
+| `--emit-txt` | off | Also write `.txt` transcripts |
 | `--max-files` | all | Limit files to process (for testing) |
 
 #### Options — `moss-transcribe-diarize.py`
@@ -116,6 +130,12 @@ CBS Suspense (1940s radio drama), 66 episodes, 33 hours of audio.
 
 Long files are generation-bound (the whole diarized transcript is decoded in one pass), so RTFx drops as recordings grow; short clips run far faster. `l4x1` also works — same class of GPU.
 
+**`moss-transcribe-diarize-server.py`** (Apollo 11 mission audio, 3 tapes / 2.7 h, concurrency 4):
+
+| GPU | Time | RTFx | Output |
+|-----|------|------|--------|
+| A100 | 4.3 min | 37.8x realtime aggregate | 1,697 segments, 96–99% coverage per tape |
+
 ### Data
 
 | Script | Description |
@@ -144,7 +164,7 @@ hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \
     bash -c "pip install -q uv 2>/dev/null; git clone --depth 1 https://github.com/sgl-project/sglang-omni.git && cd sglang-omni && uv venv .venv -p 3.12 && . .venv/bin/activate && uv pip install . && sgl-omni serve --model-path OpenMOSS-Team/MOSS-Transcribe-Diarize --host 0.0.0.0 --port 8000 --max-running-requests 16 --mem-fraction-static 0.80"
 ```
 
-Query either server the same way (`response_format=verbose_json` on sglang-omni only; raise `max_new_tokens`, e.g. `65536`, for long recordings):
+Query either server the same way (`response_format=verbose_json` on sglang-omni only; raise `max_new_tokens`, e.g. `65536`, for long recordings). **Caution — long audio on the serve path**: sglang-omni silently truncates input past ~62 minutes (observed deterministically at ~62.5 min on the same tape that transcribes fully via the transformers recipe, regardless of `max_new_tokens`). Split longer recordings before posting — `moss-transcribe-diarize-server.py` does this automatically:
 
 ```bash
 curl -X POST https://<job-id>--8000.hf.jobs/v1/audio/transcriptions \

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -122,10 +122,33 @@ Long files are generation-bound (the whole diarized transcript is decoded in one
 |--------|-------------|
 | `download-ia.py` | Download audio from Internet Archive into a mounted bucket |
 
+## Serve as a live endpoint
+
+MOSS-Transcribe-Diarize can be served as an OpenAI-compatible transcription API with vLLM on Jobs (see [Serving on Jobs](https://huggingface.co/docs/hub/jobs-serving)). Model support was merged into vLLM on 2026-07-08 — after the v0.24.0 release — so use a commit-pinned nightly image until the next release (then plain `vllm/vllm-openai:latest` works). The image needs the audio extras installed first:
+
+```bash
+hf jobs run --detach --expose 8000 --flavor l4x1 -s HF_TOKEN --timeout 2h \
+    vllm/vllm-openai:nightly-2c17d33f4291a55b447317640c81eb61077b1b00 -- \
+    bash -c "pip install librosa soundfile && vllm serve OpenMOSS-Team/MOSS-Transcribe-Diarize --trust-remote-code"
+```
+
+`--expose 8000` makes the server reachable at `https://<job-id>--8000.hf.jobs` (requires an HF token with read access to your namespace). Post audio to `/v1/audio/transcriptions`:
+
+```bash
+curl -X POST https://<job-id>--8000.hf.jobs/v1/audio/transcriptions \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    -F model=OpenMOSS-Team/MOSS-Transcribe-Diarize \
+    -F file=@meeting.wav \
+    -F response_format=json \
+    -F temperature=0
+```
+
+The response `text` is the raw `[start][Sxx]text[end]` transcript — parse it into segments with `parse_transcript` from the model's [GitHub package](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) (`verbose_json` is not supported by vLLM for this model; parsed-segment responses are an [sglang-omni](https://github.com/sgl-project/sglang-omni) adapter feature, see Notes). The job — and its billing — stops at `--timeout` or `hf jobs cancel <job_id>`.
+
 ## Notes
 
 - **Gated model**: Accept terms at the [model page](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) before use.
 - **Tokenizer workaround**: `cohere-transcribe.py` applies a one-line patch for a tokenizer compat issue. Will be removed once upstream fixes land ([model discussion](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026/discussions/11)).
 - **easytranscriber**: the Cohere backend requires `transformers>=5.4.0` (pinned in the script). Pyannote VAD is gated — accept terms at [pyannote/segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0) and [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) if using `--vad pyannote`. Otherwise stick with the default Silero VAD.
 - **moss-transcribe-diarize**: not gated (Apache 2.0). Uses `trust_remote_code=True` (model code lives in the [model repo](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize)); inference helpers install from the model's [GitHub repo](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) pinned to a commit (the package isn't on PyPI). Generation time scales with audio length — long multi-speaker recordings emit tens of thousands of tokens, so watch the `truncated` flag in the output JSON.
-- **Serving MOSS-Transcribe-Diarize**: upstream's production path is an OpenAI-compatible `/v1/audio/transcriptions` server via [sglang-omni](https://github.com/sgl-project/sglang-omni) (no offline engine — high-concurrency batch goes through the server). Not runnable on Jobs yet: as of 2026-07-09 the only published image (`lmsysorg/sglang-omni:dev`, 2026-06-16) predates the model's support (added 2026-07-04) and the `sgl-omni` CLI, and the newer code needs a newer core `sglang` than the image ships. Revisit when a fresh image lands.
+- **sglang-omni serving**: upstream's recommended production server ([sglang-omni](https://github.com/sgl-project/sglang-omni)) adds `verbose_json` (parsed speaker segments) on the same endpoint, but is not runnable on Jobs yet: as of 2026-07-09 the only published image (`lmsysorg/sglang-omni:dev`, 2026-06-16) predates the model's support (added 2026-07-04) and the `sgl-omni` CLI, and the newer code needs a newer core `sglang` than the image ships. Use the vLLM path above until a fresh image lands.

--- a/transcription/cohere-transcribe.py
+++ b/transcription/cohere-transcribe.py
@@ -26,14 +26,14 @@ Input:                              Output:
 Examples:
 
   # Local test (requires CUDA GPU)
-  uv run transcribe-transformers.py ./test-audio ./test-output --language en
+  uv run cohere-transcribe.py ./test-audio ./test-output --language en
 
   # HF Jobs with bucket volumes
   hf jobs uv run --flavor l4x1 \\
       -s HF_TOKEN \\
       -v hf://buckets/user/audio-input:/input:ro \\
       -v hf://buckets/user/transcripts:/output \\
-      transcribe-transformers.py /input /output --language en --compile
+      cohere-transcribe.py /input /output --language en --compile
 
 Model: CohereLabs/cohere-transcribe-03-2026 (2B, Apache 2.0)
   - 14 languages: en, de, fr, it, es, pt, el, nl, pl, ar, vi, zh, ja, ko
@@ -97,14 +97,14 @@ def main():
 Languages: en, de, fr, it, es, pt, el, nl, pl, ar, vi, zh, ja, ko
 
 Examples:
-  uv run transcribe-transformers.py ./audio ./output --language en
-  uv run transcribe-transformers.py /input /output --language en --compile
+  uv run cohere-transcribe.py ./audio ./output --language en
+  uv run cohere-transcribe.py /input /output --language en --compile
 
 HF Jobs with bucket volumes:
   hf jobs uv run --flavor l4x1 -s HF_TOKEN \\
       -v hf://buckets/user/audio-bucket:/input:ro \\
       -v hf://buckets/user/transcripts:/output \\
-      transcribe-transformers.py /input /output --language en --compile
+      cohere-transcribe.py /input /output --language en --compile
         """,
     )
     parser.add_argument("input_dir", help="Directory containing audio files")
@@ -267,19 +267,19 @@ if __name__ == "__main__":
         print("Designed for HF Buckets mounted as volumes.")
         print()
         print("Usage:")
-        print("  uv run transcribe-transformers.py INPUT_DIR OUTPUT_DIR --language en")
+        print("  uv run cohere-transcribe.py INPUT_DIR OUTPUT_DIR --language en")
         print()
         print("Examples:")
-        print("  uv run transcribe-transformers.py ./audio ./output --language en")
-        print("  uv run transcribe-transformers.py ./audio ./output --language en --compile")
+        print("  uv run cohere-transcribe.py ./audio ./output --language en")
+        print("  uv run cohere-transcribe.py ./audio ./output --language en --compile")
         print()
         print("HF Jobs with bucket volumes:")
         print("  hf jobs uv run --flavor l4x1 -s HF_TOKEN \\")
         print("      -v hf://buckets/user/audio-input:/input:ro \\")
         print("      -v hf://buckets/user/transcripts:/output \\")
-        print("      transcribe-transformers.py /input /output --language en --compile")
+        print("      cohere-transcribe.py /input /output --language en --compile")
         print()
-        print("For full help: uv run transcribe-transformers.py --help")
+        print("For full help: uv run cohere-transcribe.py --help")
         sys.exit(0)
 
     main()

--- a/transcription/moss-transcribe-diarize-server.py
+++ b/transcription/moss-transcribe-diarize-server.py
@@ -1,0 +1,403 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "requests",
+#     "librosa",
+#     "soundfile",
+# ]
+# ///
+
+"""
+High-throughput transcription + diarization via an in-job sgl-omni server.
+
+Same model and outputs as moss-transcribe-diarize.py, but serves
+MOSS-Transcribe-Diarize behind sglang-omni inside the job and posts files
+concurrently — continuous batching decodes many tapes at once (measured
+43x realtime aggregate at just 2 streams on a100-large, vs 3.2x for the
+sequential transformers recipe).
+
+This script is the *driver* half: it expects the server on localhost
+(started by the job command below), splits long audio to fit the model's
+context window, posts files concurrently, and writes JSON (+ .txt).
+
+Requires a GPU with enough KV-cache room for long audio — use a100-large
+(80 GB). 24 GB cards (l4x1, a10g) OOM on tapes over ~30 min.
+
+Run on HF Jobs (single command — installs sglang-omni per upstream docs,
+starts the server, then runs this driver against it):
+
+  hf jobs run --detach --flavor a100-large -s HF_TOKEN --timeout 8h \\
+      -v hf://buckets/user/audio-files:/input:ro \\
+      -v hf://buckets/user/transcripts:/output \\
+      lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928 -- \\
+      bash -c "pip install -q uv; git clone --depth 1 https://github.com/sgl-project/sglang-omni.git && cd sglang-omni && uv venv .venv -p 3.12 && . .venv/bin/activate && uv pip install . && (sgl-omni serve --model-path OpenMOSS-Team/MOSS-Transcribe-Diarize --host 0.0.0.0 --port 8000 --max-running-requests 16 --mem-fraction-static 0.80 &) && uv run https://huggingface.co/datasets/uv-scripts/transcription/raw/main/moss-transcribe-diarize-server.py /input /output --emit-txt"
+
+Input:                              Output:
+  /input/tape1.mp3            ->      /output/tape1.json  (segments; parts merged)
+  /input/sub/tape2.mp3        ->      /output/sub/tape2.json
+
+Model: OpenMOSS-Team/MOSS-Transcribe-Diarize (0.9B, Apache 2.0)
+  - Long tapes are split into clips that fit the model's context window;
+    speaker labels are consistent WITHIN a clip but reset BETWEEN clips
+    (clip index is recorded on every segment as "part").
+  - The model occasionally stops generating early (EOS mid-tape); the driver
+    detects short coverage and automatically continues from the last
+    timestamp. Compare coverage_s vs duration_s in the output JSON.
+"""
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+MODEL = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+
+AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".ogg", ".m4a", ".wma", ".aac", ".opus"}
+
+SAMPLE_RATE = 16000
+
+# Context budget. The model's window is 131072 tokens and the server
+# reserves max_new_tokens from it, so input audio gets
+# (131072 - max_new_tokens - margin) tokens. Audio tokenizes at ~17.5
+# tokens/sec (30s Whisper chunks -> temporal merge), so requesting 65536
+# output tokens silently truncates input past ~62 min. We split audio into
+# parts that fit alongside a generation budget sized to the part.
+CONTEXT_TOKENS = 131072
+AUDIO_TOKENS_PER_SECOND = 17.5
+CONTEXT_MARGIN_TOKENS = 2048
+GENERATION_TOKENS_PER_AUDIO_SECOND = 20  # same over-provision as sibling script
+MIN_GENERATION_TOKENS = 5120
+
+# Longest part where input + generation + margin fits the window:
+# d*17.5 + max(5120, d*20) + 2048 <= 131072  ->  d ~ 3440s. Stay under it.
+DEFAULT_PART_SECONDS = 3300  # 55 min
+
+
+def generation_budget(duration_s: float) -> int:
+    """Output-token budget for a clip, capped so input still fits the window."""
+    want = max(
+        MIN_GENERATION_TOKENS, int(duration_s * GENERATION_TOKENS_PER_AUDIO_SECOND)
+    )
+    room = (
+        CONTEXT_TOKENS
+        - CONTEXT_MARGIN_TOKENS
+        - int(duration_s * AUDIO_TOKENS_PER_SECOND)
+    )
+    return max(MIN_GENERATION_TOKENS, min(want, room))
+
+
+def discover_audio_files(input_dir: Path) -> list[Path]:
+    return [
+        p
+        for p in sorted(input_dir.rglob("*"))
+        if p.is_file() and p.suffix.lower() in AUDIO_EXTENSIONS
+    ]
+
+
+def transcribe_clip(server: str, clip: Path, duration_s: float, timeout_s: int) -> dict:
+    import requests
+
+    with open(clip, "rb") as f:
+        resp = requests.post(
+            f"{server}/v1/audio/transcriptions",
+            data={
+                "model": MODEL,
+                "response_format": "verbose_json",
+                "max_new_tokens": generation_budget(duration_s),
+            },
+            files={"file": (clip.name, f)},
+            timeout=timeout_s,
+        )
+    resp.raise_for_status()
+    return resp.json()
+
+
+SPEAKER_RE = re.compile(r"^\[(S\d+)\]\s*")
+
+
+def parse_verbose_segments(
+    payload: dict, offset_s: float, part_index: int
+) -> list[dict]:
+    """Normalize sgl-omni verbose_json segments; shift by part offset."""
+    out = []
+    for seg in payload.get("segments", []):
+        m = SPEAKER_RE.match(seg["text"])
+        out.append(
+            {
+                "start": round(seg["start"] + offset_s, 2),
+                "end": round(seg["end"] + offset_s, 2),
+                "speaker": m.group(1) if m else None,
+                "text": SPEAKER_RE.sub("", seg["text"]).strip(),
+                "part": part_index,
+            }
+        )
+    return out
+
+
+def write_txt(segments: list[dict], path: Path):
+    lines = [
+        f"[{s['start']:.2f} - {s['end']:.2f}] {s['speaker'] or '?'}: {s['text']}"
+        for s in segments
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def wait_for_server(server: str, timeout_s: int = 1800):
+    import requests
+
+    logger.info(f"Waiting for server at {server}...")
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            if requests.get(f"{server}/health", timeout=5).status_code == 200:
+                logger.info("Server is ready")
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(10)
+    logger.error(f"Server did not become ready within {timeout_s}s")
+    sys.exit(1)
+
+
+# A clip's transcript should reach near its end. If generation stops more
+# than this many seconds short (the model sometimes emits EOS early — and
+# always does past ~62 min of input), transcribe the remainder as a new clip.
+COVERAGE_SLACK_S = 240
+MIN_CONTINUATION_PROGRESS_S = 60
+
+
+def process_file(
+    file_path: Path,
+    input_dir: Path,
+    output_dir: Path,
+    server: str,
+    part_seconds: int,
+    request_timeout: int,
+    emit_txt: bool,
+    workdir: Path,
+) -> dict:
+    import librosa
+    import soundfile
+
+    rel = file_path.relative_to(input_dir)
+    start_time = time.time()
+
+    audio, _ = librosa.load(str(file_path), sr=SAMPLE_RATE, mono=True)
+    duration = len(audio) / SAMPLE_RATE
+
+    # Work queue of (offset_s) positions still needing transcription. Each
+    # round transcribes up to part_seconds from the offset; if the model
+    # stops early (early EOS or the serve stack's ~62-min input cap), the
+    # uncovered remainder is re-queued as a continuation. Speaker labels are
+    # consistent within a clip and reset between clips ("part" index).
+    segments: list[dict] = []
+    offset = 0.0
+    part_index = 0
+    while duration - offset > COVERAGE_SLACK_S / 2:
+        clip_dur = min(part_seconds, duration - offset)
+        if offset == 0.0 and clip_dur >= duration:
+            clip_path = file_path  # single-clip file: send as-is
+        else:
+            clip_path = workdir / f"{file_path.stem}.part{part_index:02d}.wav"
+            lo = int(offset * SAMPLE_RATE)
+            hi = int((offset + clip_dur) * SAMPLE_RATE)
+            soundfile.write(str(clip_path), audio[lo:hi], SAMPLE_RATE)
+
+        payload = transcribe_clip(server, clip_path, clip_dur, request_timeout)
+        if clip_path != file_path:
+            clip_path.unlink(missing_ok=True)
+        clip_segments = parse_verbose_segments(payload, offset, part_index)
+        segments.extend(clip_segments)
+
+        covered = (
+            (max(s["end"] for s in clip_segments) - offset) if clip_segments else 0.0
+        )
+        part_index += 1
+        if clip_dur - covered <= COVERAGE_SLACK_S:
+            offset += clip_dur  # clip fully covered — next part
+        elif covered >= MIN_CONTINUATION_PROGRESS_S:
+            logger.info(
+                f"  {rel}: early stop at {offset + covered:.0f}s of "
+                f"{offset + clip_dur:.0f}s — continuing from there"
+            )
+            offset += covered
+        else:
+            # No meaningful progress (e.g. trailing static) — skip this clip
+            # to avoid looping; the gap is visible in the coverage stats.
+            logger.warning(
+                f"  {rel}: no progress on clip at {offset:.0f}s "
+                f"({len(clip_segments)} segments) — skipping {clip_dur:.0f}s"
+            )
+            offset += clip_dur
+
+    coverage_s = round(max((s["end"] for s in segments), default=0.0), 1)
+    speakers_per_part = {
+        p: sorted({s["speaker"] for s in segments if s["part"] == p and s["speaker"]})
+        for p in sorted({s["part"] for s in segments})
+    }
+    record = {
+        "file": str(rel),
+        "model": MODEL,
+        "duration_s": round(duration, 1),
+        "coverage_s": coverage_s,
+        "num_parts": part_index,
+        "segments": segments,
+        "num_segments": len(segments),
+        "speakers_per_part": speakers_per_part,
+    }
+
+    json_path = output_dir / rel.with_suffix(".json")
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    if emit_txt:
+        write_txt(segments, json_path.with_suffix(".txt"))
+
+    elapsed = time.time() - start_time
+    logger.info(
+        f"  {rel}: {duration / 60:.0f} min, {part_index} clip(s), "
+        f"{len(segments)} segments, coverage {coverage_s / max(duration, 1) * 100:.0f}% "
+        f"in {elapsed:.0f}s"
+    )
+    return {
+        "file": str(rel),
+        "duration_s": round(duration, 1),
+        "coverage_s": coverage_s,
+        "num_parts": part_index,
+        "num_segments": len(segments),
+        "elapsed_s": round(elapsed, 1),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Concurrent transcription + diarization via in-job sgl-omni server.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="See module docstring for the full `hf jobs run` command.",
+    )
+    parser.add_argument("input_dir", help="Directory containing audio files")
+    parser.add_argument("output_dir", help="Directory to write transcript JSON files")
+    parser.add_argument(
+        "--server",
+        default="http://127.0.0.1:8000",
+        help="sgl-omni server base URL (default: in-job localhost:8000)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=4,
+        help="Concurrent transcription requests (default: 4; KV-cache bound)",
+    )
+    parser.add_argument(
+        "--part-minutes",
+        type=float,
+        default=DEFAULT_PART_SECONDS / 60,
+        help="Split audio into parts of this length (default: 55 min — the "
+        "longest that fits the model's context window with generation room). "
+        "Speaker labels reset between parts.",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=3600,
+        help="Per-request timeout in seconds (default: 3600)",
+    )
+    parser.add_argument(
+        "--emit-txt", action="store_true", help="Also write .txt transcripts"
+    )
+    parser.add_argument(
+        "--max-files", type=int, default=None, help="Limit files (for testing)"
+    )
+
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    if not input_dir.is_dir():
+        logger.error(f"Input directory does not exist: {input_dir}")
+        sys.exit(1)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = discover_audio_files(input_dir)
+    if not files:
+        logger.error(f"No audio files found in {input_dir}")
+        sys.exit(1)
+    if args.max_files:
+        files = files[: args.max_files]
+    logger.info(f"Found {len(files)} audio file(s)")
+
+    wait_for_server(args.server)
+
+    part_seconds = int(args.part_minutes * 60)
+    start_time = time.time()
+    results = []
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.concurrency
+        ) as pool:
+            futures = {
+                pool.submit(
+                    process_file,
+                    f,
+                    input_dir,
+                    output_dir,
+                    args.server,
+                    part_seconds,
+                    args.request_timeout,
+                    args.emit_txt,
+                    workdir,
+                ): f
+                for f in files
+            }
+            for fut in concurrent.futures.as_completed(futures):
+                f = futures[fut]
+                try:
+                    results.append(fut.result())
+                except Exception as exc:
+                    logger.error(f"  {f.name} FAILED: {exc}")
+                    results.append({"file": f.name, "error": str(exc)})
+
+    elapsed = time.time() - start_time
+
+    summary_path = output_dir / "summary.jsonl"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        for r in results:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    ok = [r for r in results if "error" not in r]
+    total_audio = sum(r["duration_s"] for r in ok)
+    elapsed_str = f"{elapsed / 60:.1f} min" if elapsed > 60 else f"{elapsed:.1f}s"
+    logger.info("=" * 50)
+    logger.info(f"Done! {len(ok)}/{len(files)} file(s) in {elapsed_str}")
+    if total_audio:
+        logger.info(f"  Audio: {total_audio / 3600:.1f} h total")
+        logger.info(f"  RTFx: {total_audio / elapsed:.1f}x realtime (aggregate)")
+    if len(ok) < len(files):
+        logger.warning(f"  Failed: {len(files) - len(ok)} file(s) — see {summary_path}")
+    logger.info(f"  Summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print("=" * 60)
+        print("Concurrent Transcription + Diarization (sgl-omni server)")
+        print("=" * 60)
+        print("\nDriver for an in-job sgl-omni server: splits long audio to")
+        print("fit the model's context window, posts files concurrently,")
+        print("writes JSON segments with timestamps + speaker labels.")
+        print("\nSee module docstring for the full `hf jobs run` command")
+        print("(server + driver in one job, a100-large recommended).")
+        print("\nFor full help: uv run moss-transcribe-diarize-server.py --help")
+        sys.exit(0)
+
+    main()

--- a/transcription/moss-transcribe-diarize-server.py
+++ b/transcription/moss-transcribe-diarize-server.py
@@ -13,8 +13,8 @@ High-throughput transcription + diarization via an in-job sgl-omni server.
 Same model and outputs as moss-transcribe-diarize.py, but serves
 MOSS-Transcribe-Diarize behind sglang-omni inside the job and posts files
 concurrently — continuous batching decodes many tapes at once (measured
-37.8x realtime aggregate at concurrency 4 on a100-large including server
-boot, vs 3.2x for the sequential transformers recipe).
+47.4x realtime aggregate on a100-large: 174.5 h of audio in 3.8 h for
+$9.46, vs 3.2x realtime for the sequential transformers recipe).
 
 This script is the *driver* half: it expects the server on localhost
 (started by the job command below), splits long audio to fit the model's

--- a/transcription/moss-transcribe-diarize-server.py
+++ b/transcription/moss-transcribe-diarize-server.py
@@ -333,7 +333,21 @@ def main():
         sys.exit(1)
     if args.max_files:
         files = files[: args.max_files]
-    logger.info(f"Found {len(files)} audio file(s)")
+
+    # Resume: outputs are written per file, so a rerun after a timeout or
+    # crash only processes what's missing.
+    done = {
+        f
+        for f in files
+        if (output_dir / f.relative_to(input_dir).with_suffix(".json")).exists()
+    }
+    if done:
+        logger.info(f"Skipping {len(done)} file(s) with existing output JSON")
+        files = [f for f in files if f not in done]
+        if not files:
+            logger.info("Nothing to do — all outputs exist")
+            return
+    logger.info(f"Found {len(files)} audio file(s) to process")
 
     wait_for_server(args.server)
 

--- a/transcription/moss-transcribe-diarize-server.py
+++ b/transcription/moss-transcribe-diarize-server.py
@@ -13,8 +13,8 @@ High-throughput transcription + diarization via an in-job sgl-omni server.
 Same model and outputs as moss-transcribe-diarize.py, but serves
 MOSS-Transcribe-Diarize behind sglang-omni inside the job and posts files
 concurrently — continuous batching decodes many tapes at once (measured
-43x realtime aggregate at just 2 streams on a100-large, vs 3.2x for the
-sequential transformers recipe).
+37.8x realtime aggregate at concurrency 4 on a100-large including server
+boot, vs 3.2x for the sequential transformers recipe).
 
 This script is the *driver* half: it expects the server on localhost
 (started by the job command below), splits long audio to fit the model's

--- a/transcription/moss-transcribe-diarize.py
+++ b/transcription/moss-transcribe-diarize.py
@@ -1,0 +1,444 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "moss-transcribe-diarize @ git+https://github.com/OpenMOSS/MOSS-Transcribe-Diarize@b5ad0f8386b155ddb89f9332ba3ca71891900357",
+#     "transformers>=5.0,<6",
+#     "torch>=2.8",
+#     "huggingface-hub",
+#     "librosa",
+#     "soundfile",
+# ]
+# ///
+
+"""
+Transcribe + diarize audio files using MOSS-Transcribe-Diarize (0.9B).
+
+Joint transcription, speaker attribution, and timestamps in a single
+generation pass — no separate ASR/diarization/alignment stages. The model
+handles long-form audio internally (128k context, up to ~90 min per file),
+so files are never pre-chunked: speaker labels ([S01], [S02], ...) stay
+consistent across the whole recording.
+
+Designed to work with HF Buckets mounted as volumes via `hf jobs uv run -v ...`.
+
+Input:                              Output:
+  /input/meeting.mp3          ->      /output/meeting.json   (segments)
+  /input/sub/interview.mp4    ->      /output/sub/interview.json
+                                      (+ .txt / .srt with --emit-txt / --emit-srt)
+
+Examples:
+
+  # Local test (requires CUDA GPU)
+  uv run moss-transcribe-diarize.py ./audio ./output --emit-txt
+
+  # HF Jobs with bucket volumes
+  hf jobs uv run --flavor l4x1 -s HF_TOKEN \\
+      -e UV_TORCH_BACKEND=cu128 \\
+      -v hf://buckets/user/audio-files:/input:ro \\
+      -v hf://buckets/user/transcripts:/output \\
+      https://huggingface.co/datasets/uv-scripts/transcription/raw/main/moss-transcribe-diarize.py \\
+      /input /output --emit-txt --emit-srt
+
+Model: OpenMOSS-Team/MOSS-Transcribe-Diarize (0.9B, Apache 2.0, not gated)
+  - Languages: en, zh (no --language flag needed)
+  - Also accepts video containers (mp4, mov, mkv, ...) — audio track is decoded
+  - Hotword biasing: --hotwords "Acme Corp,Kubernetes,Dr. Chen"
+  - Inference helpers installed from the model's GitHub repo (not on PyPI),
+    pinned to a commit for reproducibility
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+MODEL = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+# The git-pinned helper package above and the model's remote code are
+# co-released, so pin the model revision they were verified against.
+# Loosen once upstream stabilizes (model is days old and actively updated).
+REVISION = "d7231bbae2587a4af278735eb765b318c4f64edd"
+
+AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".ogg", ".m4a", ".wma", ".aac", ".opus"}
+VIDEO_EXTENSIONS = {".mp4", ".m4v", ".mov", ".mkv", ".webm", ".avi", ".flv", ".wmv"}
+MEDIA_EXTENSIONS = AUDIO_EXTENSIONS | VIDEO_EXTENSIONS
+
+# Auto max_new_tokens: model default 5120, ceiling 65536 (docs' long-form value).
+# ~100 tokens covers well under 10s of dense multi-speaker speech, so 20 tok/s
+# of audio is a safe over-provision; generation stops at EOS anyway.
+MAX_NEW_TOKENS_FLOOR = 5120
+MAX_NEW_TOKENS_CEILING = 65536
+TOKENS_PER_AUDIO_SECOND = 20
+
+PROGRESS_LOG_EVERY_TOKENS = 4096
+
+
+def check_cuda_availability():
+    if not torch.cuda.is_available():
+        logger.error("CUDA is not available. This script requires a GPU.")
+        sys.exit(1)
+    logger.info(f"CUDA available. GPU: {torch.cuda.get_device_name(0)}")
+
+
+def discover_media_files(input_dir: Path) -> list[Path]:
+    """Walk input_dir recursively, returning sorted list of audio/video files."""
+    files = []
+    for path in sorted(input_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS:
+            files.append(path)
+    return files
+
+
+def get_media_duration(file_path: Path) -> float | None:
+    """Get duration in seconds; PyAV fallback covers video containers."""
+    try:
+        import librosa
+
+        return librosa.get_duration(path=str(file_path))
+    except Exception:
+        pass
+    try:
+        import av
+
+        with av.open(str(file_path)) as container:
+            if container.duration is not None:
+                return container.duration / av.time_base
+    except Exception:
+        pass
+    return None
+
+
+def auto_max_new_tokens(duration_s: float | None) -> int:
+    """Scale the token budget with audio length; unknown duration gets the ceiling."""
+    if duration_s is None:
+        return MAX_NEW_TOKENS_CEILING
+    return min(
+        MAX_NEW_TOKENS_CEILING,
+        max(MAX_NEW_TOKENS_FLOOR, int(duration_s * TOKENS_PER_AUDIO_SECOND)),
+    )
+
+
+def write_txt(segments, path: Path):
+    """Readable transcript: one `[start - end] SPEAKER: text` line per segment."""
+    lines = [
+        f"[{seg.start:.2f} - {seg.end:.2f}] {seg.speaker}: {seg.text}"
+        for seg in segments
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Transcribe + diarize audio using MOSS-Transcribe-Diarize.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Languages: en, zh (auto — no language flag)
+
+Examples:
+  uv run moss-transcribe-diarize.py ./audio ./output --emit-txt
+  uv run moss-transcribe-diarize.py ./audio ./output --hotwords "Acme,Dr. Chen"
+  uv run moss-transcribe-diarize.py /input /output --max-files 1 --max-new-tokens 2048
+
+HF Jobs with bucket volumes:
+  hf jobs uv run --flavor l4x1 -s HF_TOKEN \\
+      -e UV_TORCH_BACKEND=cu128 \\
+      -v hf://buckets/user/audio-bucket:/input:ro \\
+      -v hf://buckets/user/transcripts:/output \\
+      moss-transcribe-diarize.py /input /output --emit-txt --emit-srt
+        """,
+    )
+    parser.add_argument("input_dir", help="Directory containing audio/video files")
+    parser.add_argument("output_dir", help="Directory to write transcript JSON files")
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=0,
+        help="Max generated tokens per file. 0 = auto-scale with audio duration "
+        f"(min {MAX_NEW_TOKENS_FLOOR}, max {MAX_NEW_TOKENS_CEILING})",
+    )
+    parser.add_argument(
+        "--hotwords",
+        default=None,
+        help="Comma-separated terms (names, products, jargon) appended to the "
+        "prompt to bias recognition",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Full prompt override (replaces the built-in transcribe+diarize "
+        "prompt; overrides --hotwords)",
+    )
+    parser.add_argument(
+        "--emit-txt",
+        action="store_true",
+        help="Also write .txt transcripts ([start - end] SPEAKER: text per line)",
+    )
+    parser.add_argument(
+        "--emit-srt",
+        action="store_true",
+        help="Also write .srt subtitles with speaker prefixes",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Limit number of files to process (for testing)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print resolved package versions",
+    )
+
+    args = parser.parse_args()
+
+    check_cuda_availability()
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+
+    if not input_dir.is_dir():
+        logger.error(f"Input directory does not exist: {input_dir}")
+        sys.exit(1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Discover media files
+    logger.info(f"Scanning {input_dir} for audio/video files...")
+    files = discover_media_files(input_dir)
+    if not files:
+        logger.error(f"No media files found in {input_dir}")
+        logger.error(f"Supported extensions: {', '.join(sorted(MEDIA_EXTENSIONS))}")
+        sys.exit(1)
+
+    if args.max_files:
+        files = files[: args.max_files]
+
+    logger.info(f"Found {len(files)} file(s)")
+
+    # Load model
+    logger.info(f"Loading {MODEL}...")
+    from moss_transcribe_diarize import parse_transcript
+    from moss_transcribe_diarize.inference_utils import (
+        DEFAULT_PROMPT,
+        build_transcription_messages,
+        generate_transcription,
+    )
+    from transformers import AutoModelForCausalLM, AutoProcessor
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    model = (
+        AutoModelForCausalLM.from_pretrained(
+            MODEL, revision=REVISION, trust_remote_code=True, dtype="auto"
+        )
+        .to(dtype=dtype)
+        .to(device)
+        .eval()
+    )
+    processor = AutoProcessor.from_pretrained(
+        MODEL, revision=REVISION, trust_remote_code=True
+    )
+    logger.info("Model loaded")
+
+    if args.prompt:
+        prompt = args.prompt
+    elif args.hotwords:
+        # Hotword convention from the model card: append a 热词提示 (hotword
+        # hint) line to the default prompt.
+        terms = ", ".join(t.strip() for t in args.hotwords.split(",") if t.strip())
+        prompt = f"{DEFAULT_PROMPT}热词提示：{terms}"
+        logger.info(f"Hotwords: {terms}")
+    else:
+        prompt = DEFAULT_PROMPT
+
+    # Transcribe files one at a time (no pre-chunking: the model handles
+    # long-form internally, which is what keeps speaker labels consistent).
+    # Outputs are written per file so partial progress survives job timeouts.
+    start_time = time.time()
+    total_audio_duration = 0.0
+    results = []
+
+    for i, file_path in enumerate(files, 1):
+        rel = file_path.relative_to(input_dir)
+        duration = get_media_duration(file_path)
+        max_new_tokens = (
+            args.max_new_tokens
+            if args.max_new_tokens > 0
+            else auto_max_new_tokens(duration)
+        )
+
+        duration_str = f"{duration:.0f}s" if duration else "unknown length"
+        logger.info(
+            f"[{i}/{len(files)}] {rel} ({duration_str}, "
+            f"max_new_tokens={max_new_tokens})..."
+        )
+
+        def log_progress(n, _budget=max_new_tokens):
+            if n % PROGRESS_LOG_EVERY_TOKENS == 0:
+                logger.info(f"    ... {n}/{_budget} tokens")
+
+        file_start = time.time()
+        messages = build_transcription_messages(file_path, prompt=prompt)
+        result = generate_transcription(
+            model,
+            processor,
+            messages,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            device=device,
+            dtype=dtype,
+            token_callback=log_progress,
+        )
+        file_elapsed = time.time() - file_start
+
+        raw_text = result["text"]
+        generated_tokens = result["generated_tokens"]
+        truncated = generated_tokens >= max_new_tokens
+        if truncated:
+            logger.warning(
+                f"    Hit max_new_tokens={max_new_tokens} — transcript is likely "
+                f"incomplete. Re-run with a higher --max-new-tokens."
+            )
+
+        segments = parse_transcript(raw_text)
+        speakers = sorted({seg.speaker for seg in segments})
+
+        record = {
+            "file": str(rel),
+            "model": MODEL,
+            "duration_s": round(duration, 1) if duration else None,
+            "raw_transcript": raw_text,
+            "segments": [
+                {
+                    "start": seg.start,
+                    "end": seg.end,
+                    "speaker": seg.speaker,
+                    "text": seg.text,
+                }
+                for seg in segments
+            ],
+            "num_segments": len(segments),
+            "num_speakers": len(speakers),
+            "generated_tokens": generated_tokens,
+            "truncated": truncated,
+        }
+
+        json_path = output_dir / rel.with_suffix(".json")
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        if args.emit_txt:
+            write_txt(segments, json_path.with_suffix(".txt"))
+
+        if args.emit_srt:
+            from moss_transcribe_diarize.subtitle import (
+                export_srt,
+                subtitle_segments_from_transcript_segments,
+            )
+
+            srt_text = export_srt(
+                subtitle_segments_from_transcript_segments(segments),
+                show_speaker=True,
+            )
+            json_path.with_suffix(".srt").write_text(srt_text, encoding="utf-8")
+
+        if duration:
+            total_audio_duration += duration
+
+        results.append(
+            {
+                "file": str(rel),
+                "duration_s": round(duration, 1) if duration else None,
+                "num_segments": len(segments),
+                "num_speakers": len(speakers),
+                "generated_tokens": generated_tokens,
+                "truncated": truncated,
+                "elapsed_s": round(file_elapsed, 1),
+            }
+        )
+        logger.info(
+            f"    -> {json_path.name}: {len(segments)} segments, "
+            f"{len(speakers)} speaker(s), {generated_tokens} tokens, "
+            f"{file_elapsed:.0f}s"
+        )
+
+    elapsed = time.time() - start_time
+
+    # Write summary
+    summary_path = output_dir / "summary.jsonl"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        for r in results:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    # Report
+    elapsed_str = f"{elapsed / 60:.1f} min" if elapsed > 60 else f"{elapsed:.1f}s"
+    truncated_count = sum(1 for r in results if r["truncated"])
+    logger.info("=" * 50)
+    logger.info(f"Done! Processed {len(files)} file(s) in {elapsed_str}")
+    logger.info(f"  Output: {output_dir}")
+    if total_audio_duration > 0:
+        rtfx = total_audio_duration / elapsed
+        logger.info(f"  Audio: {total_audio_duration / 60:.1f} min total")
+        logger.info(f"  RTFx: {rtfx:.1f}x realtime")
+    if truncated_count:
+        logger.warning(f"  Truncated: {truncated_count} file(s) hit max_new_tokens")
+    logger.info(f"  Summary: {summary_path}")
+
+    if args.verbose:
+        import importlib.metadata
+
+        logger.info("--- Package versions ---")
+        for pkg in [
+            "moss-transcribe-diarize",
+            "transformers",
+            "torch",
+            "av",
+            "librosa",
+            "soundfile",
+        ]:
+            try:
+                logger.info(f"  {pkg}=={importlib.metadata.version(pkg)}")
+            except importlib.metadata.PackageNotFoundError:
+                logger.info(f"  {pkg}: not installed")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print("=" * 60)
+        print("Transcription + Diarization with MOSS-Transcribe-Diarize")
+        print("=" * 60)
+        print("\nTranscribe audio/video from a directory -> JSON segments")
+        print("with timestamps and speaker labels ([S01], [S02], ...).")
+        print("One pass per file — no chunking, labels stay consistent.")
+        print("Designed for HF Buckets mounted as volumes.")
+        print()
+        print("Usage:")
+        print("  uv run moss-transcribe-diarize.py INPUT_DIR OUTPUT_DIR")
+        print()
+        print("Examples:")
+        print("  uv run moss-transcribe-diarize.py ./audio ./output --emit-txt")
+        print(
+            "  uv run moss-transcribe-diarize.py ./audio ./output --hotwords 'Acme,Dr. Chen'"
+        )
+        print()
+        print("HF Jobs with bucket volumes:")
+        print("  hf jobs uv run --flavor l4x1 -s HF_TOKEN \\")
+        print("      -e UV_TORCH_BACKEND=cu128 \\")
+        print("      -v hf://buckets/user/audio-files:/input:ro \\")
+        print("      -v hf://buckets/user/transcripts:/output \\")
+        print("      moss-transcribe-diarize.py /input /output --emit-txt --emit-srt")
+        print()
+        print("For full help: uv run moss-transcribe-diarize.py --help")
+        sys.exit(0)
+
+    main()


### PR DESCRIPTION
Two new recipes for [OpenMOSS-Team/MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) (0.9B, Apache 2.0, released this week) — joint transcription + speaker attribution + timestamps in one generation pass.

## What's in here

- **`moss-transcribe-diarize.py`** — sequential transformers recipe (bucket in → bucket out). No chunking: the model handles long-form internally, keeping speaker labels consistent across the whole file. JSON segments + optional `.txt`/`.srt`, auto-scaled token budget with truncation detection, `--hotwords`, video container support. Helper package installed from the model's GitHub repo pinned to a commit SHA (not on PyPI); Hub model revision pinned to match.
- **`moss-transcribe-diarize-server.py`** — high-throughput variant: serves the model with sglang-omni *inside* the job and streams files through it concurrently. Splits long audio into ≤55-min clips (context-window math in comments), coverage-based continuation when the model stops early, skip-existing resume.
- **README**: serve-as-endpoint section (verified vLLM-nightly and sglang-omni paths, incl. the install-from-git-over-sglang-nightly trick and the `verbose_json` difference), options tables, benchmarks, docs polish (stale `private: true` dropped, `speaker-diarization` tag, stale filename fix in cohere-transcribe.py docstring).

## Verified on Jobs

| Recipe | Hardware | Result |
|---|---|---|
| batch | a10g-large | 74-min tape: 743 segments, 7 speakers, 3.2x RT |
| server | a100-large | **174.5 h Apollo 11 (103 tapes) in 3.8 h — 47.4x RT, $9.46**, 97% coverage |

Output published: [`davanstrien/apollo-11-diarized`](https://huggingface.co/datasets/davanstrien/apollo-11-diarized) + search demo [`davanstrien/apollo-11-search`](https://huggingface.co/spaces/davanstrien/apollo-11-search).

## Known model behaviors handled (documented in README/docstrings)

- sglang-omni serve path silently truncates input past ~62 min → clip splitting
- occasional early EOS mid-tape (deterministic per input) → continuation loop
- hallucination loops on static-only audio (some IA reels are blank transfers) → filtered at dataset assembly, raw preserved
- 24 GB cards OOM on long-tape KV → a100-large documented for long-form

`tools/verify-superset.sh transcription` ✅ (additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1evJxAdVYECgqmByxqEbJ