### PR TITLE
docs: local folder mounts — hf jobs uv run -v ./dir:/mnt (hub ≥ 1.22)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,8 @@ workflow's optional `repo_id` / `repo_type` inputs.)
   plus **`hf-jobs` when `JOB_ID` is set** — these are the adoption meters
   (`list_datasets(tags="uv-script")` / `tags="hf-jobs"` count stamped public outputs).
 - GPU scripts check `torch.cuda.is_available()` and exit with a clear message. Write outputs to the Hub
-  (`push_to_hub`) or a bucket (`-v hf://…`), never local paths (Jobs disk is ephemeral). Name by task, not tool.
+  (`push_to_hub`) or a bucket (`-v hf://…`), never bare local paths (Jobs disk is ephemeral; local *input*
+  dirs can be mounted with `-v ./dir:/mnt`, which syncs them to a bucket). Name by task, not tool.
 
 ## The mirror — how it works
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,8 @@ if __name__ == "__main__":
 
 - **Self-contained:** declare all deps inline; no `requirements.txt`, no shared importable modules.
 - **Hub-native I/O:** read inputs from and write outputs to the Hub (`push_to_hub`) or a bucket (`-v hf://…`).
-  Job disk is ephemeral — never rely on local output paths.
+  Job disk is ephemeral — never rely on local output paths. (Users can mount a local *input* folder with
+  `-v ./dir:/mnt`, which syncs it to a bucket — scripts just see a mounted directory.)
 - **GPU scripts:** check `torch.cuda.is_available()` and exit with a clear message if a GPU is required.
 - **Fast downloads:** prefer `huggingface-hub[hf_transfer]`.
 - **Naming:** name by task, not tool (`classify-dataset.py`, not `bert-classify.py`).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
 
 No `pip install`, no local setup. `--secrets HF_TOKEN` forwards your token so the job can write the output dataset back to the Hub. (Jobs needs the `hf` CLI — `uv tool install huggingface_hub` — and a Hugging Face account with [pay-as-you-go credit](https://huggingface.co/pricing) — no subscription needed; it's billed by the second, and a small CPU job costs ~$0.01/hr. Run `hf jobs hardware` for current flavors and prices.)
 
+**Got local files instead of a Hub dataset?** Mount a folder straight into the job with `-v` — the CLI syncs it to a private bucket automatically, and re-runs only sync what changed (no "upload to a repo first" step; `huggingface_hub` ≥ 1.22):
+
+```bash
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+  -v ./my-scans:/input -v ./ocr-output:/output:rw \
+  https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr-bucket.py \
+  /input /output
+```
+
+Mounts are read-only unless you add `:rw`; for a read-write mount the CLI prints the `hf buckets sync` command that pulls the job's output back down when it's done.
+
 **Prefer your own machine?** A recipe is just a UV script, so on a box with the hardware it needs — most recipes here want a CUDA GPU — you can run it (or inspect it with `--help`) directly, no Jobs required:
 
 ```bash

--- a/gliner/extract-entities.py
+++ b/gliner/extract-entities.py
@@ -68,7 +68,8 @@ def parse_args():
         help=(
             "Input. Either a HF dataset ID (e.g. 'org/dataset') or a local path "
             "to parquet/jsonl file(s) — useful when running in HF Jobs with a mounted "
-            "bucket: '-v hf://buckets/<ns>/<bucket>:/input' then pass '/input/cards.parquet'."
+            "bucket ('-v hf://buckets/<ns>/<bucket>:/input') or a local folder synced "
+            "automatically ('-v ./data:/input', hub >= 1.22), then pass '/input/cards.parquet'."
         ),
     )
     p.add_argument(

--- a/iiif-tiles/README.md
+++ b/iiif-tiles/README.md
@@ -65,6 +65,15 @@ hf jobs uv run tile_iiif.py \
     --collection-name "Historic Manuscripts"
 ```
 
+Scans still on your machine? Mount the folder straight into the job — the CLI syncs it to a private bucket automatically (re-runs only sync changed files; `huggingface_hub` ≥ 1.22), so there's no separate upload step:
+
+```bash
+hf jobs uv run -v ./my-scans:/input tile_iiif.py \
+    --source-dir /input \
+    --output-bucket myorg/iiif-tiles \
+    --collection-name "Historic Manuscripts"
+```
+
 ## View the results
 
 Once tiles are in a bucket, open the manifest in any IIIF viewer:

--- a/ocr/AGENTS.md
+++ b/ocr/AGENTS.md
@@ -73,6 +73,19 @@ A couple of scripts have `-bucket.py` variants (currently `falcon-ocr-bucket.py`
 `ls` the repo to check whether a `-bucket.py` variant exists for the model you want
 before assuming it's available.
 
+The `-v` source can also be a **local directory** (`huggingface_hub` ≥ 1.22) — the CLI
+syncs it to a private bucket and mounts it, so local images/PDFs need no upload step:
+
+    hf jobs uv run --flavor l4x1 -s HF_TOKEN \
+      -v ./pages:/input \
+      -v hf://buckets/<user>/<output>:/output \
+      https://huggingface.co/datasets/uv-scripts/ocr/raw/main/<script>-bucket.py \
+      /input /output
+
+Re-runs only sync new/changed files. Local mounts are read-only by default; a local
+*output* dir works too with `:rw` — pull results back with the `hf buckets sync`
+command the CLI prints at launch.
+
 ## Common flags across dataset-mode scripts
 
 Most scripts support: `--max-samples`, `--shuffle`, `--seed`, `--split`, `--image-column`,

--- a/ocr/CLAUDE.md
+++ b/ocr/CLAUDE.md
@@ -21,7 +21,8 @@ planned **self-review skill** (see [Deferred](#deferred--tracked)) just enforces
   dep (e.g. bucket I/O → `bucketbag`, [#67](https://github.com/davanstrien/uv-scripts-for-ai/issues/67)),
   never a local import. Recipes = inline; internal tooling may share freely.
 - **GPU + output.** Check `torch.cuda.is_available()` and exit clearly if absent. Write to the Hub
-  (`push_to_hub`) or a bucket (`-v hf://…`), never local paths (Jobs disk is ephemeral).
+  (`push_to_hub`) or a bucket (`-v hf://…`), never bare local paths (Jobs disk is ephemeral; local *input*
+  dirs mount via `-v ./dir:/mnt`, synced to a bucket automatically).
 - **vLLM image + fail-fast preflight.** If the model's arch isn't in a stable vLLM wheel, **omit
   `vllm`/`torch` from deps** and run on the pinned `vllm/vllm-openai` image via
   `--image … --python … -e PYTHONPATH=…`; add a preflight that `sys.exit(1)`s naming the exact flags

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -72,7 +72,7 @@ To spend review effort well (active learning), order the queue by informativenes
 
 ## Rules that keep jobs working
 
-- Jobs disk is ephemeral — write to the Hub, never local paths. The default pattern is **a dataset in, a dataset out** (`push_to_hub`). For data you rewrite often (mutable, incremental writes, checkpoints, one file per item), use a [storage bucket](https://huggingface.co/docs/hub/storage-buckets) instead — mount one with `-v hf://buckets/<user>/<bucket>:/mnt`, or read/write `hf://buckets/…` paths via fsspec. See [buckets.md](buckets.md).
+- Jobs disk is ephemeral — write outputs to the Hub, never local paths. The default pattern is **a dataset in, a dataset out** (`push_to_hub`). **Local input files** don't need an upload step: `-v ./scans:/input` syncs the folder to a private bucket and mounts it in the Job (re-runs only sync changed files; `huggingface_hub` ≥ 1.22). For data you rewrite often (mutable, incremental writes, checkpoints, one file per item), use a [storage bucket](https://huggingface.co/docs/hub/storage-buckets) — mount one with `-v hf://buckets/<user>/<bucket>:/mnt`, or read/write `hf://buckets/…` paths via fsspec. See [buckets.md](buckets.md).
 - GPU recipes check `torch.cuda.is_available()` and exit clearly if missing — match `--flavor` to the recipe.
 - Test on `--max-samples 10` first.
 

--- a/skills/uv-recipes/buckets.md
+++ b/skills/uv-recipes/buckets.md
@@ -23,6 +23,27 @@ hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
 
 The `ocr` family already ships bucket-aware recipes — **`glm-ocr-bucket.py`** and **`falcon-ocr-bucket.py`** read images/PDFs from a mounted bucket and write one `.md` per page. Read the recipe's `--help` for exact arguments.
 
+## Mount a local folder (no upload step)
+
+The `-v` source can also be a **local directory** (requires `huggingface_hub` ≥ 1.22). The CLI syncs it to a bucket and mounts it in the Job — no "upload to a repo first" step:
+
+```bash
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
+  -v ./scans:/input \
+  -v hf://buckets/<user>/<bucket>:/output \
+  https://huggingface.co/datasets/uv-scripts/ocr/raw/main/glm-ocr-bucket.py \
+  /input /output
+```
+
+How it behaves:
+
+- Files sync to a **private** `<namespace>/jobs-artifacts` bucket (auto-created), into a subfolder derived from the directory path — **re-running only syncs new or changed files**.
+- It's a **copy, not a live mount**: local edits after launch aren't visible to the Job; re-run the command to re-sync.
+- **Read-only by default.** Append `:rw` (e.g. `-v ./out:/output:rw`) to let the Job write back; pull results down afterwards with the `hf buckets sync` command the CLI prints at launch.
+- Python API equivalent: `sync_job_volume("./scans", "/input")` returns a `Volume` to pass in `run_uv_job(..., volumes=[...])`.
+
+Prefer a **named bucket** (previous section) when the data is large or has thousands of files — bulk reads over the FUSE mount are slow, so at that scale copy from the mount to the Job's local disk first, or use a bucket you populate once — or when several machines/jobs share it.
+
 ## Write to a bucket from Python (fsspec)
 
 A recipe that writes incrementally can use `hf://buckets/…` paths directly:

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -42,6 +42,8 @@ hf jobs uv run --flavor l4x1 -s HF_TOKEN \
 
 No download/upload step. Buckets are mounted directly as volumes via [hf-mount](https://github.com/huggingface/hf-mount).
 
+Audio already on your machine? Mount the folder directly — `-v ./audio:/input` syncs it to a private bucket and mounts it in the job (re-runs only sync changed files; `huggingface_hub` ≥ 1.22), so you can skip the `download-ia`/bucket step.
+
 > **Local dev**: if you've cloned this repo, swap the URL for the local filename (e.g. `cohere-transcribe.py /input /output ...`).
 
 ## Scripts

--- a/vlm-object-detection/README.md
+++ b/vlm-object-detection/README.md
@@ -195,6 +195,8 @@ In HF Jobs, pass example artifacts via volume mount:
 --example-answer-file /example/answer.json
 ```
 
+Or skip the dataset repo and mount a local folder directly — `-v ./example:/example` syncs it to a private bucket automatically (`huggingface_hub` ≥ 1.22).
+
 Pick an example that looks similar to your typical target page — the model anchors heavily to "what a page should look like."
 
 ## Acknowledgements


### PR DESCRIPTION
## What

Document the new sync-to-job local volume mounts (`hf jobs uv run script.py -v ./scans:/inputs`, huggingface_hub ≥ 1.22) across the skill and recipe docs. Previously every `-v` example in the repo mounted an `hf://` source and the local-data story was always "get it into a bucket/dataset first".

- **`skills/uv-recipes/buckets.md`** — new "Mount a local folder (no upload step)" section: syntax, the private `jobs-artifacts` bucket under the hood, incremental re-sync, copy-not-live caveat, `:rw` + `hf buckets sync` pull-back, `sync_job_volume` Python API, and when a named bucket is still the right call (many-file dirs / shared data).
- **`skills/uv-recipes/SKILL.md`** — the "never local paths" rule now splits inputs from outputs: local inputs mount via `-v ./scans:/input`; outputs still go to the Hub.
- **`README.md`** — quickstart "got local files?" block (local input + local `:rw` output).
- **Per-recipe:** `ocr/AGENTS.md` (local dir next to the `-bucket.py` example), `transcription/README.md` (skip `download-ia` for local audio), `gliner/extract-entities.py` help text, `vlm-object-detection/README.md` (few-shot artifacts without a dataset repo), `iiif-tiles/README.md` (local scans → Jobs → tile bucket).
- **Contributor-rule echoes** kept consistent: `AGENTS.md`, `CONTRIBUTING.md`, `ocr/CLAUDE.md`.

## Verified on real Jobs (cpu-basic)

- Initial sync: 3 files → `jobs-artifacts/<dir>-<hash>`, visible read-only at the mount.
- Incremental re-sync after editing one file + adding one: **2 uploads / 2 skips** — the "only sync what changed" claim holds.
- `:rw` write-back round trip: job wrote to the mount, `hf buckets sync` pulled it down; empty output dirs get a `.keep` placeholder so they mount fine.
- `tile_iiif.py --source-dir /input` with `-v ./scans:/input` ran end-to-end (4 images tiled, valid manifest) with **zero script changes** — `--source-dir` is a plain directory read, so it composes with the mount as-is.

No script logic changed anywhere (gliner is help-text only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMtzN4P4ussA5EmSfZBWmW