### PR TITLE
ocr: language support docs + machine-readable models.json catalog

### DIFF
--- a/ocr/AGENTS.md
+++ b/ocr/AGENTS.md
@@ -25,6 +25,10 @@ a short note. Axes that matter:
   `falcon-perception` are alternatives for specific models.
 - **Task support**: most scripts do plain text; some expose `--task-mode`
   (table, formula, layout, etc.) — check the script's own docstring.
+- **Language coverage**: [`models.json`](./models.json) maps every script to its model,
+  params, backend, required image pins, and what the model card claims about languages —
+  with an `evidence` level (`per-language-benchmark` beats a bare `multilingual` tag).
+  Human-readable version: [LANGUAGES.md](./LANGUAGES.md).
 
 For the authoritative benchmark numbers on any model in the table, query the model
 card programmatically — every OCR model publishes eval results on its card:

--- a/ocr/CLAUDE.md
+++ b/ocr/CLAUDE.md
@@ -15,6 +15,11 @@ script's docstring and `README.md`; benchmark result tables live in `OCR-BENCHMA
 Read this before adding or changing a recipe. Each rule maps to a failure we've actually hit; the
 planned **self-review skill** (see [Deferred](#deferred--tracked)) just enforces this list.
 
+- **Catalog entry.** Adding or changing a recipe means updating [`models.json`](./models.json)
+  (script → model, params, backend, image pins, language claim) and, if the language claim
+  changed, [LANGUAGES.md](./LANGUAGES.md). Language fields record what the **model card claims**
+  (with an evidence level), never inferred coverage. Hand-maintained for now; if drift becomes a
+  problem, the follow-up is generating the README table from the JSON.
 - **Self-contained single file.** Each recipe is one PEP 723 UV script runnable from a raw URL
   (`hf jobs uv run <url>`). No shared *importable local* module (the job env only gets the one file).
   Extra pip deps are fine — **pin them**. A heavy/stable/shared subsystem may become an opt-in *package*

--- a/ocr/LANGUAGES.md
+++ b/ocr/LANGUAGES.md
@@ -1,0 +1,38 @@
+# Language support
+
+What each model's own card claims about language coverage — compiled from the model cards as of **2026-07-15**. Treat these as **claims, not guarantees**: only one model (Surya) publishes per-language scores, and a "multilingual" tag tells you very little. Machine-readable version (plus params, backend, image pins): [`models.json`](models.json).
+
+The fastest way to find out whether a model handles *your* language is to run it on a few of your own pages — `--max-samples 10` costs a few cents on a T4/L4:
+
+```bash
+hf jobs uv run --flavor l4x1 -s HF_TOKEN \
+    https://huggingface.co/datasets/uv-scripts/ocr/raw/main/surya-ocr.py \
+    your-dataset your-output --max-samples 10
+```
+
+_Sorted by strength of evidence, then coverage:_
+
+| Model | Card claim | Evidence |
+|-------|-----------|----------|
+| [Surya OCR 2](https://huggingface.co/datalab-to/surya-ocr-2) | **91 languages** | The only **per-language benchmark** published ([full table](https://github.com/datalab-to/surya/blob/master/static/docs/multilingual.md)): 38/91 score ≥90%, 76/91 ≥80%. Weakest of the top-15: Arabic 72.7%, Vietnamese 73.2% |
+| [dots.ocr](https://huggingface.co/rednote-hilab/dots.ocr) | 100 languages | Explicit **low-resource** claim, backed by an in-house benchmark (1,493 PDFs across 100 languages) — aggregate scores only, not per-language |
+| [Tesseract 5](https://github.com/tesseract-ocr/tesseract) | 125 traineddata packs (~100+ languages + script models) | Fully **enumerable** ([tessdata_best](https://github.com/tesseract-ocr/tessdata_best)) — the broadest *named* coverage here, incl. many low-resource languages; script models (Latin, Cyrillic, Devanagari, …) cover languages without a dedicated pack |
+| [Qianfan-OCR](https://huggingface.co/baidu/Qianfan-OCR) | 192 languages | Headline claim; no list or per-language numbers |
+| [PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) / [1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) / [1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 109 languages; 1.5 adds Tibetan + Bengali | Names scripts (Cyrillic, Arabic, Devanagari, Thai) and claims handwriting + historical documents; no per-language numbers |
+| [PP-OCRv6](https://huggingface.co/collections/PaddlePaddle/pp-ocrv6) | 48 languages | Official card claim |
+| [Nanonets-OCR2-3B](https://huggingface.co/nanonets/Nanonets-OCR2-3B) | 11 named + "many more" (incl. Arabic + CJK) | Illustrative list, no benchmark — but the only card claiming multilingual **handwriting** |
+| [LightOnOCR-2-1B](https://huggingface.co/lightonai/LightOnOCR-2-1B) | 11 (9 European + zh/ja) | Declared, not benchmarked. [v1](https://huggingface.co/lightonai/LightOnOCR-1B-1025) is explicitly European/Latin-script only (9) |
+| [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 8 (zh en fr es ru de ja ko) | Declared in card metadata only; no per-language evidence in the card body |
+| [HunyuanOCR-1.5](https://huggingface.co/tencent/HunyuanOCR) | "Multilingual" | Nothing enumerated, but explicitly targets **low-resource + ancient-script OCR** as a design goal (new in 1.5; the pinned 1.0 revision doesn't claim this) |
+| [dots.mocr](https://huggingface.co/rednote-hilab/dots.mocr) · [DeepSeek-OCR](https://huggingface.co/deepseek-ai/DeepSeek-OCR) / [-2](https://huggingface.co/deepseek-ai/DeepSeek-OCR-2) · [Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) · [NuExtract3](https://huggingface.co/numind/NuExtract3) | "Multilingual", unspecified | A tag or one-liner only — no count, list, or benchmark |
+| [olmOCR-2](https://huggingface.co/allenai/olmOCR-2-7B-1025-FP8) · [Nanonets-OCR-s](https://huggingface.co/nanonets/Nanonets-OCR-s) · [SmolDocling](https://huggingface.co/ds4sd/SmolDocling-256M-preview) · [LFM2.5-VL-Extract](https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-Extract) | English only | Stated on the card |
+| [Falcon-OCR](https://huggingface.co/tiiuae/Falcon-OCR) · [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) · [FireRed-OCR](https://huggingface.co/FireRedTeam/FireRed-OCR) · [ABot-OCR](https://huggingface.co/acvlab/ABot-OCR) · [RolmOCR](https://huggingface.co/reducto/RolmOCR) · [NuMarkdown-8B](https://huggingface.co/numind/NuMarkdown-8B-Thinking) · [lift](https://huggingface.co/datalab-to/lift) | Not stated | No language information on the card at all |
+
+Text-only extraction: [LFM2-1.2B-Extract](https://huggingface.co/LiquidAI/LFM2-1.2B-Extract) (chains after OCR) names 9 languages: English, Arabic, Chinese, French, German, Japanese, Korean, Portuguese, Spanish.
+
+## Reading the table for low-resource work
+
+- **Only Surya lets you check your language before running anything** — its [benchmark table](https://github.com/datalab-to/surya/blob/master/static/docs/multilingual.md) has a row per language.
+- **Tesseract's coverage is enumerable** — if your language has a [traineddata pack](https://github.com/tesseract-ocr/tessdata_best), it's supported (quality varies; it's the legacy baseline, not the quality leader).
+- **dots.ocr and HunyuanOCR-1.5 are the VLMs that talk about low-resource languages at all**; PaddleOCR-VL-1.5 names Tibetan and Bengali specifically.
+- A big claimed number (192, 109) without a list or per-language scores means you're testing it yourself either way — which is cheap (see the command above).

--- a/ocr/README.md
+++ b/ocr/README.md
@@ -45,12 +45,14 @@ hf datasets leaderboard allenai/olmOCR-bench
 
 But which model wins on *your* documents is still document-dependent — so [ocr-bench](https://github.com/davanstrien/ocr-bench) builds a **per-collection leaderboard** for your own data (pairwise VLM-as-judge, optionally human-validated), using these scripts under the hood.
 
+**Language coverage:** [LANGUAGES.md](LANGUAGES.md) lists what each model's card claims (and how much evidence backs it). Machine-readable catalog for agents — script → model, params, backend, image pins, languages: [`models.json`](models.json).
+
 _Sorted by model size:_
 
 | Script | Model | Size | Backend | Notes |
 |--------|-------|------|---------|-------|
 | [`tesseract-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/tesseract-ocr.py) | [Tesseract 5](https://github.com/tesseract-ocr/tesseract) | n/a (classical) | pytesseract (CPU) | **The legacy baseline** — no GPU at all, runs on `cpu-upgrade`. Plain-text output, `--lang`/`--psm`/`--oem` exposed, 100+ language packs via apt. Apache 2.0 |
-| [`pp-ocrv6.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/pp-ocrv6.py) | [PP-OCRv6](https://huggingface.co/collections/PaddlePaddle/pp-ocrv6) | 1.5–34.5M | PaddleOCR (paddle) | **Smallest neural** — classical det+rec pipeline, not a VLM. Three tiers (`--model-tier tiny\|small\|medium`), plain-text output (not markdown). 50 langs. Runs on `t4-small`. Apache 2.0 |
+| [`pp-ocrv6.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/pp-ocrv6.py) | [PP-OCRv6](https://huggingface.co/collections/PaddlePaddle/pp-ocrv6) | 1.5–34.5M | PaddleOCR (paddle) | **Smallest neural** — classical det+rec pipeline, not a VLM. Three tiers (`--model-tier tiny\|small\|medium`), plain-text output (not markdown). 48 langs. Runs on `t4-small`. Apache 2.0 |
 | [`falcon-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/falcon-ocr.py) | [Falcon-OCR](https://huggingface.co/tiiuae/Falcon-OCR) | 0.3B | falcon-perception | Smallest VLM in collection. #1 on multi-column docs and tables (olmOCR), Apache 2.0 |
 | [`smoldocling-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/smoldocling-ocr.py) | [SmolDocling](https://huggingface.co/ds4sd/SmolDocling-256M-preview) | 256M | Transformers | DocTags structured output |
 | [`surya-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/surya-ocr.py) | [Surya OCR 2](https://huggingface.co/datalab-to/surya-ocr-2) | 0.65B | vLLM | **Structured** OCR + `--task layout\|table`: per-block HTML with bboxes & reading order in an extra `surya_blocks` column. 91 langs, top-under-3B on olmOCR-Bench. Modified OpenRAIL-M license. Needs the **pinned** `vllm/vllm-openai:v0.20.1` image |
@@ -63,7 +65,7 @@ _Sorted by model size:_
 | [`lighton-ocr2.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/lighton-ocr2.py) | [LightOnOCR-2-1B](https://huggingface.co/lightonai/LightOnOCR-2-1B) | 1B | vLLM | 7× faster than v1, RLVR trained |
 | [`hunyuan-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/hunyuan-ocr.py) | [HunyuanOCR 1.0](https://huggingface.co/tencent/HunyuanOCR/tree/f6af82ee007fe6091b29fb3bb287b491ead41c82) | 1B | vLLM | Lightweight VLM. Pinned to the last 1.0 revision (repo root became 1.5 in-place on 2026-07-06). [Hunyuan Community License](https://huggingface.co/tencent/HunyuanOCR/blob/main/LICENSE) (excludes EU/UK/KR) |
 | [`hunyuan-ocr-1.5.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/hunyuan-ocr-1.5.py) | [HunyuanOCR-1.5](https://huggingface.co/tencent/HunyuanOCR) | 1B | vLLM | 128K context, 4K images, 12 task types, ancient scripts. ~4-5× faster/page than dots.ocr & DeepSeek-OCR-2 (tech report). [Hunyuan Community License](https://huggingface.co/tencent/HunyuanOCR/blob/main/LICENSE) (excludes EU/UK/KR) |
-| [`dots-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/dots-ocr.py) | [DoTS.ocr](https://huggingface.co/Tencent/DoTS.ocr) | 1.7B | vLLM | 100+ languages |
+| [`dots-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/dots-ocr.py) | [dots.ocr](https://huggingface.co/rednote-hilab/dots.ocr) | 1.7B | vLLM | 100 languages (in-house bench), explicit low-resource claim |
 | [`firered-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/firered-ocr.py) | [FireRed-OCR](https://huggingface.co/FireRedTeam/FireRed-OCR) | 2.1B | vLLM | Qwen3-VL fine-tune, Apache 2.0 |
 | [`abot-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/abot-ocr.py) | [ABot-OCR](https://huggingface.co/acvlab/ABot-OCR) | 2B | vLLM | Qwen3-VL based, doc→Markdown (text/LaTeX/HTML tables). Needs `vllm/vllm-openai` image. [paper](https://arxiv.org/abs/2605.27978) |
 | [`nanonets-ocr.py`](https://huggingface.co/datasets/uv-scripts/ocr/blob/main/nanonets-ocr.py) | [Nanonets-OCR-s](https://huggingface.co/nanonets/Nanonets-OCR-s) | 2B | vLLM | LaTeX, tables, forms |

--- a/ocr/models.json
+++ b/ocr/models.json
@@ -1,0 +1,360 @@
+{
+  "_meta": {
+    "description": "Machine-readable catalog of the OCR recipes in this directory: script -> model, params, backend, required image pins, and what the model's own card claims about language coverage. Human-readable language notes: LANGUAGES.md. Language evidence levels, strongest first: per-language-benchmark | count-claim | named-list | multilingual-unspecified | english-only | not-stated | not-applicable. Claims come from model cards (compiled 2026-07-15) - treat as claims, not guarantees.",
+    "updated": "2026-07-15",
+    "run_pattern": "hf jobs uv run --flavor <flavor> -s HF_TOKEN https://huggingface.co/datasets/uv-scripts/ocr/raw/main/<script> <input-dataset> <output-dataset>"
+  },
+  "tesseract-ocr.py": {
+    "model_id": null,
+    "model_name": "Tesseract 5",
+    "params": null,
+    "backend": "pytesseract (CPU)",
+    "task": "ocr",
+    "output": "plain text",
+    "license": "apache-2.0",
+    "languages": {
+      "evidence": "named-list",
+      "count": "125 traineddata packs (~100+ languages + script models)",
+      "list_url": "https://github.com/tesseract-ocr/tessdata_best",
+      "notes": "Broadest named coverage; script models (Latin, Cyrillic, Devanagari, ...) cover languages without a dedicated pack. Legacy baseline quality."
+    }
+  },
+  "pp-ocrv6.py": {
+    "model_id": "PaddlePaddle/PP-OCRv6",
+    "params": "1.5M-34.5M",
+    "backend": "paddleocr",
+    "task": "ocr",
+    "output": "plain text",
+    "license": "apache-2.0",
+    "languages": { "evidence": "count-claim", "count": 48 }
+  },
+  "falcon-ocr.py": {
+    "model_id": "tiiuae/Falcon-OCR",
+    "params": "0.3B",
+    "backend": "falcon-perception",
+    "task": "ocr",
+    "output": "markdown",
+    "license": "apache-2.0",
+    "languages": { "evidence": "not-stated" }
+  },
+  "smoldocling-ocr.py": {
+    "model_id": "ds4sd/SmolDocling-256M-preview",
+    "params": "256M",
+    "backend": "transformers",
+    "task": "ocr",
+    "output": "DocTags",
+    "languages": { "evidence": "english-only" }
+  },
+  "surya-ocr.py": {
+    "model_id": "datalab-to/surya-ocr-2",
+    "params": "0.65B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai:v0.20.1",
+    "task": "ocr | layout | table",
+    "output": "markdown + surya_blocks (per-block HTML, bboxes, reading order)",
+    "license": "modified OpenRAIL-M",
+    "languages": {
+      "evidence": "per-language-benchmark",
+      "count": 91,
+      "benchmark_url": "https://github.com/datalab-to/surya/blob/master/static/docs/multilingual.md",
+      "notes": "38/91 languages score >=90%, 76/91 >=80%; weakest of top-15: Arabic 72.7%, Vietnamese 73.2%."
+    }
+  },
+  "glm-ocr.py": {
+    "model_id": "zai-org/GLM-OCR",
+    "params": "0.9B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": {
+      "evidence": "named-list",
+      "count": 8,
+      "named": ["zh", "en", "fr", "es", "ru", "de", "ja", "ko"],
+      "notes": "Declared in card metadata only; no per-language evidence in the card body."
+    }
+  },
+  "paddleocr-vl.py": {
+    "model_id": "PaddlePaddle/PaddleOCR-VL",
+    "params": "0.9B",
+    "backend": "vllm",
+    "task": "ocr | table | formula | chart",
+    "output": "markdown",
+    "languages": {
+      "evidence": "count-claim",
+      "count": 109,
+      "notes": "Names scripts (Cyrillic, Arabic, Devanagari, Thai); claims handwriting + historical documents; no per-language numbers."
+    }
+  },
+  "paddleocr-vl-1.5.py": {
+    "model_id": "PaddlePaddle/PaddleOCR-VL-1.5",
+    "params": "0.9B",
+    "backend": "transformers",
+    "task": "ocr (6 modes)",
+    "output": "markdown",
+    "languages": {
+      "evidence": "count-claim",
+      "count": "109+ (adds Tibetan, Bengali)",
+      "notes": "Claims improved rare-character and ancient-text recognition."
+    }
+  },
+  "paddleocr-vl-1.6.py": {
+    "model_id": "PaddlePaddle/PaddleOCR-VL-1.6",
+    "params": "0.9B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": {
+      "evidence": "count-claim",
+      "count": "109+ (inherited from 1.5, not restated)",
+      "notes": "Upgrade-focused card; language-specific claims are Chinese ancient documents and rare characters."
+    }
+  },
+  "ovis-ocr2.py": {
+    "model_id": "ATH-MaaS/OvisOCR2",
+    "params": "0.9B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown + LaTeX + HTML tables",
+    "license": "apache-2.0",
+    "languages": { "evidence": "not-stated" }
+  },
+  "lighton-ocr.py": {
+    "model_id": "lightonai/LightOnOCR-1B-1025",
+    "params": "1B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": {
+      "evidence": "named-list",
+      "count": 9,
+      "named": ["en", "fr", "de", "es", "it", "nl", "pt", "sv", "da"],
+      "notes": "Explicitly European / Latin-alphabet focused."
+    }
+  },
+  "lighton-ocr2.py": {
+    "model_id": "lightonai/LightOnOCR-2-1B",
+    "params": "1B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": {
+      "evidence": "named-list",
+      "count": 11,
+      "named": ["en", "fr", "de", "es", "it", "nl", "pt", "sv", "da", "zh", "ja"],
+      "notes": "Adds zh/ja over v1; declared, not benchmarked per language."
+    }
+  },
+  "hunyuan-ocr.py": {
+    "model_id": "tencent/HunyuanOCR",
+    "revision": "f6af82ee007fe6091b29fb3bb287b491ead41c82",
+    "params": "1B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "license": "Hunyuan Community License (excludes EU/UK/KR)",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "hunyuan-ocr-1.5.py": {
+    "model_id": "tencent/HunyuanOCR",
+    "params": "1B",
+    "backend": "vllm",
+    "task": "ocr | 12 task types",
+    "output": "markdown",
+    "license": "Hunyuan Community License (excludes EU/UK/KR)",
+    "languages": {
+      "evidence": "multilingual-unspecified",
+      "notes": "Explicitly targets low-resource + ancient-script OCR as a design goal; nothing enumerated."
+    }
+  },
+  "dots-ocr.py": {
+    "model_id": "rednote-hilab/dots.ocr",
+    "params": "1.7B",
+    "backend": "vllm",
+    "task": "ocr + layout",
+    "output": "markdown",
+    "languages": {
+      "evidence": "count-claim",
+      "count": 100,
+      "notes": "Explicit low-resource claim backed by in-house dots.ocr-bench (1,493 PDFs across 100 languages); aggregate scores only."
+    }
+  },
+  "firered-ocr.py": {
+    "model_id": "FireRedTeam/FireRed-OCR",
+    "params": "2.1B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "license": "apache-2.0",
+    "languages": { "evidence": "not-stated" }
+  },
+  "abot-ocr.py": {
+    "model_id": "acvlab/ABot-OCR",
+    "params": "2B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai",
+    "task": "ocr",
+    "output": "markdown (text, LaTeX, HTML tables)",
+    "languages": { "evidence": "not-stated" }
+  },
+  "nanonets-ocr.py": {
+    "model_id": "nanonets/Nanonets-OCR-s",
+    "params": "2B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown (LaTeX, tables, forms)",
+    "languages": { "evidence": "english-only" }
+  },
+  "dots-mocr.py": {
+    "model_id": "rednote-hilab/dots.mocr",
+    "params": "3B",
+    "backend": "vllm",
+    "task": "ocr | 8 prompt modes incl. SVG, layout + bbox",
+    "output": "markdown",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "nanonets-ocr2.py": {
+    "model_id": "nanonets/Nanonets-OCR2-3B",
+    "params": "3B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai:v0.10.2",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": {
+      "evidence": "named-list",
+      "count": "11 named + 'many more'",
+      "named": ["en", "zh", "fr", "es", "pt", "de", "it", "ru", "ja", "ko", "ar"],
+      "notes": "Only card claiming multilingual handwriting; list illustrative, no per-language benchmark."
+    }
+  },
+  "deepseek-ocr-vllm.py": {
+    "model_id": "deepseek-ai/DeepSeek-OCR",
+    "params": "4B",
+    "backend": "vllm",
+    "task": "ocr | 5 resolution + 5 prompt modes",
+    "output": "markdown",
+    "license": "mit",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "deepseek-ocr.py": {
+    "model_id": "deepseek-ai/DeepSeek-OCR",
+    "params": "4B",
+    "backend": "transformers",
+    "task": "ocr",
+    "output": "markdown",
+    "license": "mit",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "deepseek-ocr2-vllm.py": {
+    "model_id": "deepseek-ai/DeepSeek-OCR-2",
+    "params": "3B",
+    "backend": "vllm (nightly)",
+    "image": "vllm/vllm-openai",
+    "task": "ocr",
+    "output": "markdown",
+    "license": "apache-2.0",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "unlimited-ocr-vllm.py": {
+    "model_id": "baidu/Unlimited-OCR",
+    "params": "3.3B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai:unlimited-ocr",
+    "task": "ocr (layout-grounded markdown; single-image batch)",
+    "output": "markdown",
+    "license": "mit",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "nuextract3.py": {
+    "model_id": "numind/NuExtract3",
+    "params": "4B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai",
+    "task": "ocr | schema-guided extraction",
+    "output": "markdown or JSON",
+    "languages": { "evidence": "multilingual-unspecified" }
+  },
+  "qianfan-ocr.py": {
+    "model_id": "baidu/Qianfan-OCR",
+    "params": "4.7B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": {
+      "evidence": "count-claim",
+      "count": 192,
+      "notes": "Headline claim; no list or per-language numbers."
+    }
+  },
+  "olmocr2-vllm.py": {
+    "model_id": "allenai/olmOCR-2-7B-1025-FP8",
+    "params": "7B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "markdown",
+    "languages": { "evidence": "english-only" }
+  },
+  "rolm-ocr.py": {
+    "model_id": "reducto/RolmOCR",
+    "params": "7B",
+    "backend": "vllm",
+    "task": "ocr",
+    "output": "plain text",
+    "languages": { "evidence": "not-stated" }
+  },
+  "numarkdown-ocr.py": {
+    "model_id": "numind/NuMarkdown-8B-Thinking",
+    "params": "8B",
+    "backend": "vllm",
+    "task": "ocr (reasoning)",
+    "output": "markdown",
+    "languages": { "evidence": "not-stated" }
+  },
+  "lfm2-vl-extract.py": {
+    "model_id": "LiquidAI/LFM2.5-VL-1.6B-Extract",
+    "params": "1.6B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai",
+    "task": "schema-guided extraction (image -> JSON)",
+    "output": "JSON",
+    "languages": {
+      "evidence": "english-only",
+      "notes": "Vision card declares en only; the text sibling's 9-language list does NOT carry over."
+    }
+  },
+  "lfm2-extract.py": {
+    "model_id": "LiquidAI/LFM2-1.2B-Extract",
+    "params": "1.2B",
+    "backend": "vllm",
+    "image": "vllm/vllm-openai",
+    "task": "schema-guided extraction (text -> structured); chain after any OCR recipe",
+    "output": "JSON / XML / YAML",
+    "languages": {
+      "evidence": "named-list",
+      "count": 9,
+      "named": ["en", "ar", "zh", "fr", "de", "ja", "ko", "pt", "es"],
+      "notes": "Text-only model (not OCR). Card prose names 9 incl. Portuguese; card YAML lists 8 (pt missing)."
+    }
+  },
+  "lift-extract.py": {
+    "model_id": "datalab-to/lift",
+    "params": "9B",
+    "backend": "transformers | vllm",
+    "task": "schema-guided extraction (image or multi-page PDF -> JSON)",
+    "output": "JSON",
+    "license": "modified OpenRAIL-M",
+    "languages": { "evidence": "not-stated" }
+  },
+  "pp-doclayout.py": {
+    "model_id": "PaddlePaddle/PP-DocLayout-L",
+    "params": "123M",
+    "backend": "paddleocr",
+    "task": "layout detection (no text extraction)",
+    "output": "bounding boxes + region classes",
+    "languages": { "evidence": "not-applicable" }
+  },
+  "glm-ocr-v2.py": { "variant_of": "glm-ocr.py", "notes": "Adds checkpoint/resume for very large jobs." },
+  "glm-ocr-bucket.py": { "variant_of": "glm-ocr.py", "notes": "Reads images/PDFs from a mounted bucket, writes one .md per page." },
+  "falcon-ocr-bucket.py": { "variant_of": "falcon-ocr.py", "notes": "Reads images/PDFs from a mounted bucket, writes one .md per page." },
+  "surya-ocr-bucket.py": { "variant_of": "surya-ocr.py", "notes": "Bucket-to-bucket structured OCR (--io-mode mount|copy), resumable." },
+  "ocr-vllm-judge.py": { "model_id": "configurable", "task": "pairwise OCR-quality judging (VLM-as-judge)", "languages": { "evidence": "not-applicable" } }
+}


### PR DESCRIPTION
## Context

Prompted by a LinkedIn request (Krum Arnaudov): "it would be fantastic to be able to see languages supported in the scripts repo ... not sure how practical it is to list all, split between low-resource/high-resource, but it would definitely be very helpful."

Rather than assert coverage we can't verify, this documents **what each model's own card claims**, with an explicit evidence level — from `per-language-benchmark` (only Surya) down to `not-stated`.

## What's included

- **`ocr/LANGUAGES.md`** — per-model language claims sorted by evidence strength, with the low-resource reading guide and the "test it on 10 of your own pages" tip. Kept out of the main README to avoid clutter; README gets a one-line pointer.
- **`ocr/models.json`** — machine-readable catalog for agents: script → model, params, backend, required image pins, output, license (where stated), and the language claim with evidence level. Pointer added to `AGENTS.md`'s "Picking a script" section.
- **Two factual fixes in the README table**: PP-OCRv6 "50 langs" → **48** (official card figure), and the dead `Tencent/DoTS.ocr` link → `rednote-hilab/dots.ocr` (what the script actually uses).
- **Authoring convention** in `ocr/CLAUDE.md`: new/changed recipe updates the catalog.

## Method

Language claims extracted from all ~30 model cards (2026-07-15) by three parallel agents instructed to quote exact card text and report "not stated" rather than infer from base models. Notable: only Surya publishes per-language scores (91 langs); dots.ocr and HunyuanOCR-1.5 are the only VLMs making explicit low-resource claims; several "multilingual" tags have zero prose backing.

## Follow-up (not in this PR)

`models.json` is hand-maintained; if drift becomes a problem, generate the README table + LANGUAGES.md from the JSON so there's one source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)