### PR TITLE
video: qwen38-caption.py — whole-video captioning + timestamped timelines (PoC)

### DIFF
--- a/video/README.md
+++ b/video/README.md
@@ -38,6 +38,34 @@ hf jobs uv run --image vllm/vllm-openai:latest --flavor a10g-small \
 
 ## Scripts
 
+### qwen38-caption.py
+
+Runs [Qwen/Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) (27B dense VLM,
+Apache 2.0, not gated) over a directory of videos via vLLM — **whole videos, no
+chunking**. The model ingests video natively at hour scale: an 11-minute film is
+one request. Output is a resumable parquet dataset, one row per video with
+`caption` (and, with `--timestamps`, an `events` column of `<start - end>`
+descriptions in global seconds).
+
+`--timestamps` asks for a full event timeline instead of a prose caption. The
+model reads times off per-frame time tags rather than estimating, so timestamps
+are accurate to the frame-sampling interval (~2s at the default `--fps 2`;
+verified against extracted frames on an 11-minute film — 96 events, on-screen
+text quoted verbatim).
+
+Thinking mode is off by default; `--thinking` re-enables it with the model
+card's thinking sampling params and a larger token budget.
+
+**Hardware**: bf16 weights are ~52 GB — `a100-large` minimum; `h200` generates
+~2.3x faster.
+
+**vs marlin-caption.py**: Marlin is ~13x smaller and cheaper per minute of
+footage, but must chunk at 60s (with per-chunk timestamp offsetting) and returns
+grounding candidates rather than reliable timelines. Qwen3.8 handles the whole
+film in one pass with verbatim on-screen-text reading. Rough guide: bulk
+captioning of large collections → Marlin; rich timelines, text-heavy or
+long-form material → Qwen3.8.
+
 ### marlin-caption.py
 
 Runs [NemoStation/Marlin-2B](https://huggingface.co/NemoStation/Marlin-2B) (2B video

--- a/video/qwen38-caption.py
+++ b/video/qwen38-caption.py
@@ -39,9 +39,10 @@ Examples:
   # Local machine with a CUDA GPU (needs ~60 GB VRAM)
   uv run qwen38-caption.py ./videos ./captions-out
 
-Thinking mode is OFF by default (captioning gains little from it and it
-multiplies latency); --thinking turns it back on with a generous budget and
-the model card's thinking-mode sampling params.
+Thinking mode defaults off for captions (little gain, big latency) but ON for
+--timestamps: measured on the 11-min film, the non-thinking model may answer a
+timeline request with a one-line summary, while thinking mode produced a
+frame-verified 96-event timeline. --thinking / --no-thinking overrides.
 
 Model: Qwen/Qwen3.8-27B (27B dense, hybrid GDN linear attention, vision tower).
 bf16 weights are ~52 GB — a100-large is the smallest sensible Jobs flavor;
@@ -69,13 +70,25 @@ CAPTION_PROMPT = (
 )
 TIMESTAMPS_PROMPT = (
     "Watch this video and produce a timeline of events covering the WHOLE video "
-    "from start to finish. For each event give the time range as <start - end> "
-    "in seconds (e.g. <95.0 - 112.5>) and a one-sentence description. "
-    "Include title cards, on-screen text (quoted), and scene changes."
+    "from start to finish. Output ONLY the timeline, one event per line. For "
+    "each event give the time range as <start - end> in decimal seconds "
+    "(e.g. <95.0 - 112.5>) followed by a one-sentence description. "
+    "Include title cards, on-screen text (quoted), and scene changes. "
+    "Do not summarize; cover the full duration."
 )
 
 THINK = re.compile(r"<think>.*?</think>\s*|^.*?</think>\s*", re.DOTALL)
-EVENT_LINE = re.compile(r"<(\d+\.?\d*)\s*-\s*(\d+\.?\d*)>\s*[:–\-]?\s*(.+)")
+# accepts decimal seconds (<95.0 - 112.5>) and clock forms (<01:35 - 01:52>)
+EVENT_LINE = re.compile(
+    r"<(\d+(?::\d{2}){0,2}(?:\.\d+)?)\s*-\s*(\d+(?::\d{2}){0,2}(?:\.\d+)?)>\s*[:–\-]?\s*(.+)")
+
+
+def to_seconds(ts: str) -> float:
+    parts = [float(x) for x in ts.split(":")]
+    out = 0.0
+    for part in parts:
+        out = out * 60 + part
+    return round(out, 2)
 
 
 def probe_duration(path: Path) -> float | None:
@@ -90,7 +103,7 @@ def probe_duration(path: Path) -> float | None:
 
 
 def parse_events(text: str) -> list[dict]:
-    return [{"start": float(a), "end": float(b), "text": d.strip()}
+    return [{"start": to_seconds(a), "end": to_seconds(b), "text": d.strip()}
             for a, b, d in EVENT_LINE.findall(text)]
 
 
@@ -102,8 +115,9 @@ def main():
     parser.add_argument("--timestamps", action="store_true",
                         help="Return a <start - end> event timeline per video instead of a prose caption")
     parser.add_argument("--prompt", help="Override the built-in prompt")
-    parser.add_argument("--thinking", action="store_true",
-                        help="Enable thinking mode (slower; uses the model card's thinking sampling params)")
+    parser.add_argument("--thinking", action=argparse.BooleanOptionalAction, default=None,
+                        help="Thinking mode. Default: on for --timestamps (measured: without it the "
+                             "model may summarize instead of covering the video), off otherwise")
     parser.add_argument("--fps", type=float, default=2.0,
                         help="Frame sampling rate passed to the processor (default 2)")
     parser.add_argument("--max-videos", type=int, help="Only process the first N videos (testing)")
@@ -132,10 +146,11 @@ def main():
             for p in videos]
 
     prompt = args.prompt or (TIMESTAMPS_PROMPT if args.timestamps else CAPTION_PROMPT)
+    thinking = args.timestamps if args.thinking is None else args.thinking
     # Timeline output scales with video length; measured 9.6K tokens for an
     # 11-min film — leave generous headroom. Thinking needs its own budget on top.
     max_tokens = 16384 if args.timestamps else 4096
-    if args.thinking:
+    if thinking:
         max_tokens += 32768
 
     def to_request(row: dict) -> dict:
@@ -146,7 +161,7 @@ def main():
             ]}],
             "max_tokens": max_tokens,
         }
-        if args.thinking:  # model-card sampling params per mode
+        if thinking:  # model-card sampling params per mode
             req.update({"temperature": 1.0, "top_p": 0.95, "top_k": 20})
         else:
             req.update({"temperature": 0.7, "top_p": 0.8, "top_k": 20,

--- a/video/qwen38-caption.py
+++ b/video/qwen38-caption.py
@@ -1,0 +1,200 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "saturate[hf]",
+#     "vllm",
+# ]
+# ///
+
+"""
+Caption whole videos — no chunking — with Qwen3.8-27B, writing a resumable dataset.
+
+Qwen3.8-27B (Apache 2.0, not gated) ingests videos natively at hour scale: an
+11-minute film is one request, and in --timestamps mode the model returns a
+timeline of <start - end> events whose times are read off per-frame time tags
+(verified accurate to the ~2s sampling interval, with on-screen text quoted
+verbatim). This is the structural difference from marlin-caption.py, which must
+split anything over ~60s into chunks.
+
+Serves the model on vLLM inside the job and pumps every video in INPUT_DIR
+through it with saturate: crash-safe parquet out, exact resume (re-running
+skips completed videos), congestion-aware concurrency.
+
+Input:                              Output (one parquet dataset):
+  /input/film.mp4   (11 min)  ->      1 row per video — columns: video,
+  /input/clip.mp4   (45 s)    ->      duration_s, caption, events (JSON,
+                                      --timestamps mode), token counts
+
+Examples:
+
+  # Caption a bucket of videos on HF Jobs
+  hf jobs uv run --image vllm/vllm-openai:latest --flavor a100-large \\
+      -s HF_TOKEN \\
+      -v hf://buckets/user/my-videos:/input:ro \\
+      qwen38-caption.py /input hf://buckets/user/my-videos/captions
+
+  # Timestamped event timeline per film instead of a prose caption
+  ... qwen38-caption.py /input hf://buckets/user/out --timestamps
+
+  # Local machine with a CUDA GPU (needs ~60 GB VRAM)
+  uv run qwen38-caption.py ./videos ./captions-out
+
+Thinking mode is OFF by default (captioning gains little from it and it
+multiplies latency); --thinking turns it back on with a generous budget and
+the model card's thinking-mode sampling params.
+
+Model: Qwen/Qwen3.8-27B (27B dense, hybrid GDN linear attention, vision tower).
+bf16 weights are ~52 GB — a100-large is the smallest sensible Jobs flavor;
+h200 generates ~2.3x faster if latency matters.
+"""
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+MODEL = "Qwen/Qwen3.8-27B"
+VIDEO_EXTENSIONS = {".mp4", ".mkv", ".webm", ".mov", ".avi", ".m4v"}
+
+CAPTION_PROMPT = (
+    "Describe this video: the setting, the people, what happens over its course, "
+    "and any text that appears on screen."
+)
+TIMESTAMPS_PROMPT = (
+    "Watch this video and produce a timeline of events covering the WHOLE video "
+    "from start to finish. For each event give the time range as <start - end> "
+    "in seconds (e.g. <95.0 - 112.5>) and a one-sentence description. "
+    "Include title cards, on-screen text (quoted), and scene changes."
+)
+
+THINK = re.compile(r"<think>.*?</think>\s*|^.*?</think>\s*", re.DOTALL)
+EVENT_LINE = re.compile(r"<(\d+\.?\d*)\s*-\s*(\d+\.?\d*)>\s*[:–\-]?\s*(.+)")
+
+
+def probe_duration(path: Path) -> float | None:
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "csv=p=0", str(path)],
+            capture_output=True, text=True, timeout=120)
+        return round(float(out.stdout.strip()), 2)
+    except (ValueError, subprocess.SubprocessError):
+        return None
+
+
+def parse_events(text: str) -> list[dict]:
+    return [{"start": float(a), "end": float(b), "text": d.strip()}
+            for a, b, d in EVENT_LINE.findall(text)]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input_dir", help="Directory of videos (e.g. a mounted bucket)")
+    parser.add_argument("output", help="Dataset output: hf://datasets/..., hf://buckets/..., or local path")
+    parser.add_argument("--timestamps", action="store_true",
+                        help="Return a <start - end> event timeline per video instead of a prose caption")
+    parser.add_argument("--prompt", help="Override the built-in prompt")
+    parser.add_argument("--thinking", action="store_true",
+                        help="Enable thinking mode (slower; uses the model card's thinking sampling params)")
+    parser.add_argument("--fps", type=float, default=2.0,
+                        help="Frame sampling rate passed to the processor (default 2)")
+    parser.add_argument("--max-videos", type=int, help="Only process the first N videos (testing)")
+    parser.add_argument("--window-max", type=int, default=8,
+                        help="Max in-flight requests (default 8 — whole-video requests are large)")
+    parser.add_argument("--max-model-len", type=int, default=131072)
+    parser.add_argument("--retry-errors", action="store_true",
+                        help="Re-attempt rows that errored in a previous run")
+    args = parser.parse_args()
+
+    if shutil.which("ffprobe") is None:
+        sys.exit("ffprobe not found — use the vllm/vllm-openai image (has it) or install ffmpeg")
+
+    input_root = Path(args.input_dir).resolve()
+    videos = sorted(p for p in input_root.rglob("*")
+                    if p.suffix.lower() in VIDEO_EXTENSIONS)
+    if args.max_videos:
+        videos = videos[: args.max_videos]
+    if not videos:
+        sys.exit(f"no videos found under {input_root}")
+    logger.info("found %d videos", len(videos))
+
+    rows = [(str(p.relative_to(input_root)),
+             {"video": str(p.relative_to(input_root)), "path": str(p),
+              "duration_s": probe_duration(p)})
+            for p in videos]
+
+    prompt = args.prompt or (TIMESTAMPS_PROMPT if args.timestamps else CAPTION_PROMPT)
+    # Timeline output scales with video length; measured 9.6K tokens for an
+    # 11-min film — leave generous headroom. Thinking needs its own budget on top.
+    max_tokens = 16384 if args.timestamps else 4096
+    if args.thinking:
+        max_tokens += 32768
+
+    def to_request(row: dict) -> dict:
+        req = {
+            "messages": [{"role": "user", "content": [
+                {"type": "video_url", "video_url": {"url": f"file://{row['path']}"}},
+                {"type": "text", "text": prompt},
+            ]}],
+            "max_tokens": max_tokens,
+        }
+        if args.thinking:  # model-card sampling params per mode
+            req.update({"temperature": 1.0, "top_p": 0.95, "top_k": 20})
+        else:
+            req.update({"temperature": 0.7, "top_p": 0.8, "top_k": 20,
+                        "chat_template_kwargs": {"enable_thinking": False}})
+        return req
+
+    def parse(row: dict, resp: dict) -> dict:
+        text = THINK.sub("", resp["choices"][0]["message"]["content"] or "").strip()
+        usage = resp.get("usage") or {}
+        out = {"video": row["video"], "duration_s": row["duration_s"],
+               "caption": text,
+               "prompt_tokens": usage.get("prompt_tokens"),
+               "completion_tokens": usage.get("completion_tokens")}
+        if args.timestamps:
+            out["events"] = json.dumps(parse_events(text))
+        return out
+
+    from saturate import Auto, Engine, pump
+
+    with Engine(
+        MODEL,
+        engine="vllm",
+        extra_args=[
+            "--allowed-local-media-path", str(input_root),
+            "--max-model-len", str(args.max_model_len),
+            "--mm-processor-kwargs",
+            json.dumps({"fps": args.fps, "do_sample_frames": True}),
+            # Unbounded growth on distinct videos — OOM-kills the node if left on.
+            "--mm-processor-cache-gb", "0",
+        ],
+    ) as endpoint:
+        stats = pump(
+            rows,
+            to_request=to_request,
+            parse=parse,
+            endpoint=endpoint,
+            output=args.output,
+            window=Auto(initial=4, max_limit=args.window_max),
+            retry_errors=args.retry_errors,
+        )
+
+    logger.info("done: %d ok, %d failed, %.1f tok/s (window settled at %d)",
+                stats.rows_processed, stats.rows_failed,
+                stats.tokens_per_sec, stats.final_limit)
+    if stats.rows_failed:
+        logger.warning("failed rows are recorded in the output; re-run with "
+                       "--retry-errors to attempt them again")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`video/qwen38-caption.py`: caption **whole videos with no chunking** using Qwen/Qwen3.8-27B (27B dense VLM, Apache 2.0, ungated) served on vLLM in-job, driven by saturate (crash-safe parquet, exact resume) — same shape as `marlin-caption.py`, minus the chunking machinery Marlin needs.

- `--timestamps`: per-video `<start - end>` event timeline in global seconds. Times are read off per-frame time tags, not estimated — **verified to ~2s against extracted frames** on an 11-min 1935 film (96 events, on-screen text quoted verbatim, title-card text word-for-word).
- Thinking off by default (`chat_template_kwargs`); `--thinking` re-enables with model-card sampling params + larger budget.
- README: new script section + honest Marlin-vs-Qwen3.8 guidance (bulk/cheap → Marlin; timelines/text/long-form → Qwen3.8).

## Status: PoC — shared before merge

Being shared as work-in-progress (branch raw URL runs directly via `hf jobs uv run`). Merge once we're confident; no Hub sync until then.

## Evidence

- Caption mode Jobs-tested on `a100-large` (`vllm/vllm-openai:latest` image): 3/3 videos incl. the full 11-min film in one request, 0 failed, 947.7 tok/s aggregate (job `6a7f586f`).
- `--timestamps` mode: verification re-run in flight (first run's requests all succeeded but the output flush hit a concurrent-bucket-mount collision from the test setup, not the script — job `6a7f5871`); result will be posted here.
- Timestamp accuracy evidence from the probe runs: 8/8 then 8/10-exact frame checks across the full film (jobs `6a7f4d0c`, `6a7f5185`).

## Known limits

- Both engines cap video sampling at ~13K prompt tokens regardless of `--fps` (Qwen3-VL processor frame budget) — fine to ±2s; raising the budget for tighter accuracy is future work.
- bf16 weights ~52 GB → `a100-large` minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xKNwUAGVdWrLgjLacx25k