### PR TITLE
object-detection: falcon-perception fixes + e2e distil SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 | Domain | What it does | On the Hub |
 |---|---|---|
 | **ocr** ⭐ | OCR / document → text & structured data — GLM, PaddleOCR-VL, Nanonets, olmOCR, dots, … (30+ models) | [`uv-scripts/ocr`](https://huggingface.co/datasets/uv-scripts/ocr) |
-| **vision** | Zero-shot detection & segmentation over image datasets | [`sam3`](https://huggingface.co/datasets/uv-scripts/sam3) · [`object-detection`](https://huggingface.co/datasets/uv-scripts/object-detection) · [`vlm-object-detection`](https://huggingface.co/datasets/uv-scripts/vlm-object-detection) |
+| **vision** | Zero-shot detection & segmentation over image datasets; `object-detection` also ships a [`SKILL.md`](object-detection/SKILL.md) for the full no-labels→trained-detector loop | [`sam3`](https://huggingface.co/datasets/uv-scripts/sam3) · [`object-detection`](https://huggingface.co/datasets/uv-scripts/object-detection) · [`vlm-object-detection`](https://huggingface.co/datasets/uv-scripts/vlm-object-detection) |
 | **audio** | Transcription, speaker diarization & speech translation | [`transcription`](https://huggingface.co/datasets/uv-scripts/transcription) |
 | **video** | Caption videos with timestamped events + temporal grounding (Marlin-2B, chunked for long films) | [`video`](https://huggingface.co/datasets/uv-scripts/video) |
 | **embeddings** | Embed text/images (auto-batch, prompt-aware); build a searchable Lance vector DB on the Hub | [`embeddings`](https://huggingface.co/datasets/uv-scripts/embeddings) |

--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -5,7 +5,7 @@ tags: [uv-script, object-detection]
 
 # Object Detection Dataset Scripts
 
-7 scripts to **create**, convert, validate, inspect, diff, and sample object detection datasets on the Hub. Supports 6 bbox formats — no setup required.
+8 scripts to **create**, convert, review, validate, inspect, diff, and sample object detection datasets on the Hub. Supports 6 bbox formats — no setup required.
 
 Start from nothing: `falcon-perception.py` generates a first-pass detection dataset for any class you can name, zero-shot, with no labelling and no training. The other six then convert, check, and measure it.
 This repository is inspired by [panlabel](https://github.com/strickvl/panlabel)
@@ -33,6 +33,7 @@ That's it! The script will:
 |--------|-------------|
 | `falcon-perception.py` | **Create** a detection dataset zero-shot from any image dataset — name a class, get boxes + masks (runs on Apple Silicon too) |
 | `falcon-perception-bucket.py` | Same, reading images from an HF bucket, resumable across restarts |
+| `review-detections.py` | **Review** a detection dataset in your browser — keyboard accept/reject per image or per box, acceptance + missed rates, pushes a `review` column |
 | `convert-hf-dataset.py` | Convert between 6 bbox formats and push to Hub |
 | `validate-hf-dataset.py` | Check annotations for errors (invalid bboxes, duplicates, bounds) |
 | `stats-hf-dataset.py` | Compute statistics (counts, label histogram, area, co-occurrence) |

--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -281,7 +281,7 @@ uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/conv
 uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/diff-hf-datasets.py you/plates-illustrations you/corrected   # IoU match = zero-shot accuracy
 ```
 
-**Runs without a CUDA GPU.** Unlike most recipes in this repo, `falcon-perception.py` selects the MLX backend on Apple Silicon automatically. It is slower there (~6 s/img vs ~0.4 on an A10G), which is the right trade for step 1 and 2 above — checking your class name works before spending GPU hours.
+**Runs without a CUDA GPU.** Unlike most recipes in this repo, `falcon-perception.py` selects the MLX backend on Apple Silicon automatically. It is slower there (about 6 s/img vs 0.4 on an A10G), which is the right trade for step 1 and 2 above — checking your class name works before spending GPU hours.
 
 ### Known limits
 

--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -252,21 +252,24 @@ Works with any Hugging Face dataset containing object detection annotations — 
 The other scripts assume you already have annotations. `falcon-perception.py` is where they can come from — [Falcon-Perception](https://huggingface.co/tiiuae/Falcon-Perception) finds every instance of a class you name, with no label set and no training:
 
 ```bash
+RAW=https://huggingface.co/datasets/uv-scripts/object-detection/raw/main
+
 # 1. does the model do the thing? (your laptop — no GPU needed)
-uv run falcon-perception.py --image page.jpg --query illustration --preview
+uv run $RAW/falcon-perception.py --image page.jpg --query illustration --preview
 
 # 2. does it work on YOUR data? (first rows of the real corpus)
-uv run falcon-perception.py --dataset biglam/british-library-book-images \
+uv run $RAW/falcon-perception.py --dataset biglam/british-library-book-images \
     --config plates --limit 3 --preview
 
 # 3. the whole corpus, on a GPU
-hf jobs uv run --flavor a10g-large --secrets HF_TOKEN falcon-perception.py -- \
+hf jobs uv run --flavor a10g-large --secrets HF_TOKEN \
+    $RAW/falcon-perception.py \
     --dataset biglam/british-library-book-images --config plates \
     --id-col fname --query illustration --out you/plates-illustrations
 
 # 4. it is already in `yolo` format — the rest of this directory just works
-uv run validate-hf-dataset.py you/plates-illustrations --bbox-format yolo
-uv run stats-hf-dataset.py    you/plates-illustrations --bbox-format yolo
+uv run $RAW/validate-hf-dataset.py you/plates-illustrations --bbox-format yolo
+uv run $RAW/stats-hf-dataset.py    you/plates-illustrations --bbox-format yolo
 ```
 
 Falcon emits boxes as normalised centre x,y + w,h, which *is* the `yolo` format above, so no conversion step is needed.
@@ -274,9 +277,9 @@ Falcon emits boxes as normalised centre x,y + w,h, which *is* the `yolo` format 
 **The correction loop.** A zero-shot first pass is a starting point, not ground truth. Convert it for human review, correct it, then diff the two to find out how good the first pass actually was:
 
 ```bash
-uv run convert-hf-dataset.py you/plates-illustrations you/for-review --from yolo --to label_studio
+uv run $RAW/convert-hf-dataset.py you/plates-illustrations you/for-review --from yolo --to label_studio
 #  ... correct in Label Studio, push as you/corrected ...
-uv run diff-hf-datasets.py you/plates-illustrations you/corrected   # IoU match = zero-shot accuracy
+uv run $RAW/diff-hf-datasets.py you/plates-illustrations you/corrected   # IoU match = zero-shot accuracy
 ```
 
 **Runs without a CUDA GPU.** Unlike most recipes in this repo, `falcon-perception.py` selects the MLX backend on Apple Silicon automatically. It is slower there (~6 s/img vs ~0.4 on an A10G), which is the right trade for step 1 and 2 above — checking your class name works before spending GPU hours.
@@ -297,9 +300,9 @@ Measured, not guessed — see the script docstrings for the failure each one cam
 `--out` takes a file path as readily as a repo id — no Hub push, nothing to clean up:
 
 ```bash
-uv run falcon-perception.py --image page.jpg --query illustration --out results.json
-uv run falcon-perception.py --image "scans/*.jpg" --query illustration --out results.jsonl
-uv run falcon-perception.py --image page.jpg --query illustration --json | jq '.[0].objects.bbox'
+uv run $RAW/falcon-perception.py --image page.jpg --query illustration --out results.json
+uv run $RAW/falcon-perception.py --image "scans/*.jpg" --query illustration --out results.jsonl
+uv run $RAW/falcon-perception.py --image page.jpg --query illustration --json | jq '.[0].objects.bbox'
 ```
 
 Anything ending `.json`, `.jsonl` or `.parquet` is written locally; anything else is treated as a Hub dataset repo id.
@@ -310,10 +313,18 @@ Anything ending `.json`, `.jsonl` or `.parquet` is written locally; anything els
 
 ```python
 from datasets import load_dataset
-load_dataset("parquet", data_files=["hf://buckets/you/bl-masks/part-000000.parquet", ...],
+load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
              split="train").push_to_hub("you/bl-masks")
 ```
 
 ### Output columns
 
-`objects.bbox` (`yolo`), `objects.category`, `objects.area`, `objects.rectangularity`, plus `image`, `image_id`, `width`, `height`, `n_instances`, and `masks_rle` (COCO RLE — segmentation rides along; the bbox scripts ignore it).
+`objects.bbox` (`yolo`), `objects.category`, `objects.area`, `objects.rectangularity`, plus `image`, `image_id` (int64 — COCO-style trainers require an integer id), `source_id` (the original key), `width`, `height`, `n_instances`, and `masks_rle` (COCO RLE — segmentation rides along; the bbox scripts ignore it).
+
+### Train on the output
+
+Convert to COCO pixel boxes, then fine-tune a compact Apache-2.0 detector (D-FINE, RT-DETRv2 — not ultralytics/YOLO, which is AGPL). The [`SKILL.md`](SKILL.md) in this directory walks an agent (or you) through the whole loop — teacher labels → validate → convert → train → honest eval:
+
+```bash
+uv run $RAW/convert-hf-dataset.py you/plates-illustrations you/plates-coco --from yolo --to coco_xywh
+```

--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -252,24 +252,22 @@ Works with any Hugging Face dataset containing object detection annotations — 
 The other scripts assume you already have annotations. `falcon-perception.py` is where they can come from — [Falcon-Perception](https://huggingface.co/tiiuae/Falcon-Perception) finds every instance of a class you name, with no label set and no training:
 
 ```bash
-RAW=https://huggingface.co/datasets/uv-scripts/object-detection/raw/main
-
 # 1. does the model do the thing? (your laptop — no GPU needed)
-uv run $RAW/falcon-perception.py --image page.jpg --query illustration --preview
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py --image page.jpg --query illustration --preview
 
 # 2. does it work on YOUR data? (first rows of the real corpus)
-uv run $RAW/falcon-perception.py --dataset biglam/british-library-book-images \
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py --dataset biglam/british-library-book-images \
     --config plates --limit 3 --preview
 
 # 3. the whole corpus, on a GPU
 hf jobs uv run --flavor a10g-large --secrets HF_TOKEN \
-    $RAW/falcon-perception.py \
+    https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
     --dataset biglam/british-library-book-images --config plates \
     --id-col fname --query illustration --out you/plates-illustrations
 
 # 4. it is already in `yolo` format — the rest of this directory just works
-uv run $RAW/validate-hf-dataset.py you/plates-illustrations --bbox-format yolo
-uv run $RAW/stats-hf-dataset.py    you/plates-illustrations --bbox-format yolo
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/validate-hf-dataset.py you/plates-illustrations --bbox-format yolo
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/stats-hf-dataset.py    you/plates-illustrations --bbox-format yolo
 ```
 
 Falcon emits boxes as normalised centre x,y + w,h, which *is* the `yolo` format above, so no conversion step is needed.
@@ -277,9 +275,9 @@ Falcon emits boxes as normalised centre x,y + w,h, which *is* the `yolo` format 
 **The correction loop.** A zero-shot first pass is a starting point, not ground truth. Convert it for human review, correct it, then diff the two to find out how good the first pass actually was:
 
 ```bash
-uv run $RAW/convert-hf-dataset.py you/plates-illustrations you/for-review --from yolo --to label_studio
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/convert-hf-dataset.py you/plates-illustrations you/for-review --from yolo --to label_studio
 #  ... correct in Label Studio, push as you/corrected ...
-uv run $RAW/diff-hf-datasets.py you/plates-illustrations you/corrected   # IoU match = zero-shot accuracy
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/diff-hf-datasets.py you/plates-illustrations you/corrected   # IoU match = zero-shot accuracy
 ```
 
 **Runs without a CUDA GPU.** Unlike most recipes in this repo, `falcon-perception.py` selects the MLX backend on Apple Silicon automatically. It is slower there (~6 s/img vs ~0.4 on an A10G), which is the right trade for step 1 and 2 above — checking your class name works before spending GPU hours.
@@ -300,9 +298,9 @@ Measured, not guessed — see the script docstrings for the failure each one cam
 `--out` takes a file path as readily as a repo id — no Hub push, nothing to clean up:
 
 ```bash
-uv run $RAW/falcon-perception.py --image page.jpg --query illustration --out results.json
-uv run $RAW/falcon-perception.py --image "scans/*.jpg" --query illustration --out results.jsonl
-uv run $RAW/falcon-perception.py --image page.jpg --query illustration --json | jq '.[0].objects.bbox'
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py --image page.jpg --query illustration --out results.json
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py --image "scans/*.jpg" --query illustration --out results.jsonl
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py --image page.jpg --query illustration --json | jq '.[0].objects.bbox'
 ```
 
 Anything ending `.json`, `.jsonl` or `.parquet` is written locally; anything else is treated as a Hub dataset repo id.
@@ -326,5 +324,5 @@ load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
 Convert to COCO pixel boxes, then fine-tune a compact Apache-2.0 detector (D-FINE, RT-DETRv2 — not ultralytics/YOLO, which is AGPL). The [`SKILL.md`](SKILL.md) in this directory walks an agent (or you) through the whole loop — teacher labels → validate → convert → train → honest eval:
 
 ```bash
-uv run $RAW/convert-hf-dataset.py you/plates-illustrations you/plates-coco --from yolo --to coco_xywh
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/convert-hf-dataset.py you/plates-illustrations you/plates-coco --from yolo --to coco_xywh
 ```

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: detection-bootstrap
-description: Bootstrap an object-detection dataset and a small trained detector from images that have NO labels — zero-shot label with Falcon-Perception, validate, convert, then fine-tune a compact Apache-licensed model, all on Hugging Face Jobs. Use when you have an image collection and want a detector but no annotations exist.
+description: Bootstrap an object-detection dataset and a small trained detector from images that have NO labels — zero-shot label with Falcon-Perception, validate, convert, then fine-tune a compact Apache-licensed model, all on Hugging Face Jobs. Runs fully autonomously or with human review checkpoints. Use when you have an image collection and want a detector but no annotations exist.
 ---
 
 # Bootstrap a detector from unlabeled images
@@ -12,6 +12,21 @@ Every step is a self-contained UV script from `uv-scripts/object-detection` on t
 ```
 RAW=https://huggingface.co/datasets/uv-scripts/object-detection/raw/main
 ```
+
+## First: with or without a human?
+
+The loop runs both ways — decide before you start:
+
+- **With a human in the loop** (better models): show them the step-1 previews — "is the teacher boxing
+  the right things?" is the highest-value question, and its fix is the cheapest (a better query, ~$2 to
+  re-run the teacher). Then train on a small slice first (~500–1k images, ~$1) and show ~20 rendered
+  predictions before spending on the full corpus. If corrections are worth collecting at volume, build a
+  minimal review UI — image + predicted boxes, accept/edit, corrections written back to a Hub dataset —
+  fold them in and retrain (~$1). The `convert-hf-dataset.py --to label_studio` → correct →
+  `diff-hf-datasets.py` loop in this repo's README is the packaged version of that.
+- **Autonomously** (headless): never pause for review — judge by the numeric proxies each step provides,
+  and carry the obligation to the end instead: the final report and the model card must say the model is
+  **unreviewed**.
 
 ## 1. Sense-check the class name before spending GPU money (~free)
 
@@ -132,7 +147,8 @@ detection-only and say so rather than burning the day on it.
 - The student can at best match its teacher (measured on a comparable loop: student 97.4% vs teacher
   95.0% human-acceptable on the same sample). The point of distilling is **throughput and cost**
   (~10–100× cheaper per image than the teacher), not accuracy gains.
-- Spot-check ~20 predictions visually before calling it done.
+- Spot-check ~20 predictions visually before calling it done — or, if running without a human and you
+  cannot view images, state prominently in the report that the model is **unreviewed**.
 
 ## 7. Publish with honest provenance
 

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -108,9 +108,22 @@ Before training, split off a held-out slice (e.g. 10% of images) and never train
 
 Other trainers work too — the dataset is plain COCO. [RF-DETR](https://github.com/roboflow/rf-detr)
 (Apache-2.0, DINOv2 backbone) is a good starter, and its Seg variant can learn from the teacher's
-`masks_rle` masks (decode each RLE in its own `size` frame, not the recorded width/height — they
-never match). Pin the package version — the API is young — and if the segmentation training path
-resists, ship detection-only and say so rather than burning the day on it.
+`masks_rle` masks. Decode them like this — each RLE lives in its own frame, which never matches the
+recorded width/height:
+
+```python
+import json, numpy as np
+from PIL import Image
+from pycocotools import mask as mask_utils
+
+for rle in json.loads(row["masks_rle"]):
+    seg = mask_utils.decode({**rle, "counts": rle["counts"].encode()})  # frame = rle["size"]
+    if seg.shape != (row["height"], row["width"]):
+        seg = np.asarray(Image.fromarray(seg).resize((row["width"], row["height"]), Image.NEAREST))
+```
+
+Pin the package version — the API is young — and if the segmentation training path resists, ship
+detection-only and say so rather than burning the day on it.
 
 ## 6. Evaluate honestly
 

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -106,6 +106,12 @@ mAP eval, Hub persistence) — install it with `hf skills add huggingface-vision
 have it, and follow its object-detection path with the `<USER>/<NAME>-coco` dataset from step 4.
 Before training, split off a held-out slice (e.g. 10% of images) and never train on it.
 
+Other trainers work too — the dataset is plain COCO. [RF-DETR](https://github.com/roboflow/rf-detr)
+(Apache-2.0, DINOv2 backbone) is a good starter, and its Seg variant can learn from the teacher's
+`masks_rle` masks (decode each RLE in its own `size` frame, not the recorded width/height — they
+never match). Pin the package version — the API is young — and if the segmentation training path
+resists, ship detection-only and say so rather than burning the day on it.
+
 ## 6. Evaluate honestly
 
 - Report mAP on the held-out slice. Be clear about what it measures: **agreement with the teacher**,

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -21,8 +21,9 @@ The loop runs both ways — decide before you start:
   the right things?" is the highest-value question, and its fix is the cheapest (a better query, ~$2 to
   re-run the teacher). Then train on a small slice first (~500–1k images, ~$1) and show ~20 rendered
   predictions before spending on the full corpus. If corrections are worth collecting at volume, build a
-  minimal review UI — image + predicted boxes, accept/edit, corrections written back to a Hub dataset —
-  fold them in and retrain (~$1). Diff the corrected set against the first pass
+  review pass with `$RAW/review-detections.py` (keyboard accept/reject in the browser, per image or
+  per box; prints the quotable acceptance + missed rates and pushes a `review` column) — fold
+  corrections in and retrain (~$1). Diff the corrected set against the first pass
   (`$RAW/diff-hf-datasets.py`) to measure how good the zero-shot pass actually was.
 - **Autonomously** (headless): never pause for review — judge by the numeric proxies each step provides,
   and carry the obligation to the end instead: the final report and the model card must say the model is

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -15,24 +15,24 @@ Hugging Face Hub, or a `hf jobs` command. `--help` works on every script.
 You can use the approach outlined in this skill with or without a human in the loop.
 
 - **With a human in the loop** (better models): show them the step-1 previews — "is the teacher boxing
-  the right things?" is the highest-value question, and its fix is the cheapest (a better query, ~$2 to
-  re-run the teacher). Then train on a small slice first (~500–1k images, ~$1) and show ~20 rendered
+  the right things?" is the highest-value question, and its fix is the cheapest (a better query, about $2 to
+  re-run the teacher). Then train on a small slice first (500–1k images, about $1) and show 20 rendered
   predictions before spending on the full corpus. If corrections are worth collecting at volume, run a
   review pass with `review-detections.py` (keyboard accept/reject in the browser, per image or per box;
   prints the quotable acceptance + missed rates and pushes a `review` column), fold corrections in and
-  retrain (~$1). Diff the corrected set against the first pass (`diff-hf-datasets.py`) to measure how
+  retrain (about $1). Diff the corrected set against the first pass (`diff-hf-datasets.py`) to measure how
   good the zero-shot pass actually was.
 - **Autonomously** (headless): don't pause for review — use the numeric proxies, and say **unreviewed**
   in the final report and model card.
 
-## 1. Sense-check the class name before spending GPU money (~free)
+## 1. Sense-check the class name before spending GPU money (free)
 
 Falcon-Perception queries are **class names, not instructions** ("photograph" works; "the photographs,
 excluding captions" returns nothing), and **one class per run** (combined queries collapse — run per
 class and merge on `image_id`). Model details: `hf models card tiiuae/Falcon-Perception`.
 
 Check cheaply on 3 images before any full pass. The teacher (Falcon-Perception) is a **0.6B model,
-~1.3 GB download** — it runs on a CUDA GPU (fast), Apple Silicon (MLX backend auto-selected, ~6 s/image),
+1.3 GB download** — it runs on a CUDA GPU (fast), Apple Silicon (MLX backend auto-selected, about 6 s/image),
 or plain CPU (slow, but fine for 3 images). Run the check wherever is practical for you:
 
 ```
@@ -50,8 +50,8 @@ Judge the result before scaling up:
 - **If you can view images**, look at the rendered previews (or the pushed check dataset) — are the
   right things boxed?
 - **If you can't**, compare instance counts across candidate queries (`stats-hf-dataset.py` below works
-  on a pushed check dataset): ~0 instances/image means the class name is wrong for this material —
-  try a synonym (`photograph` / `illustration` / `figure` / `cartoon`). Suspiciously many (> ~10/image)
+  on a pushed check dataset): near-zero instances/image means the class name is wrong for this material —
+  try a synonym (`photograph` / `illustration` / `figure` / `cartoon`). Suspiciously many (more than about 10/image)
   usually means the query is matching layout blocks, not pictures.
 - **No vision at all?** A vision-capable subagent can judge the previews if you can spawn one;
   otherwise tell the user the check ran unviewed.
@@ -76,7 +76,7 @@ hf jobs uv run --flavor a10g-large --secrets HF_TOKEN --timeout 2h \
 - Output schema: `objects.bbox` in **YOLO format** (normalized center x, y, w, h), `objects.category`,
   `objects.area`, `objects.rectangularity`, plus `image`, `image_id`, `width`, `height`.
 - There are **no confidence scores** (the model has none). `rectangularity` (mask area ÷ box area) is the
-  triage proxy: values near 0 are usually junk, ~0.785 is a circle, ~1.0 a full rectangle.
+  triage proxy: values near 0 are usually junk, 0.785 is a circle, 1.0 a full rectangle.
 - Submit with `--detach` (returns the job id immediately), then block on completion with
   `hf jobs wait <id> [<id> ...] --timeout 2h` — it exits 0 only if every job succeeded, so it
   chains cleanly into the next step. `hf jobs logs <id>` / `hf jobs inspect <id>` for progress and errors.
@@ -146,8 +146,8 @@ for rle in json.loads(row["masks_rle"]):
   not accuracy against human truth — no human labels exist in this loop.
 - The student can at best match its teacher (measured on a comparable loop: student 97.4% vs teacher
   95.0% human-acceptable on the same sample). The point of distilling is **throughput and cost**
-  (~10–100× cheaper per image than the teacher), not accuracy gains.
-- Spot-check ~20 predictions visually before calling it done — or, if running without a human and you
+  (10–100× cheaper per image than the teacher), not accuracy gains.
+- Spot-check 20 or so predictions visually before calling it done — or, if running without a human and you
   cannot view images, state prominently in the report that the model is **unreviewed**.
 - It can make sense to run this process in a loop: predict → review (a human, or a vision-capable
   agent, via `review-detections.py`) → retrain on the corrections → review again, until the acceptance

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: detection-bootstrap
+description: Bootstrap an object-detection dataset and a small trained detector from images that have NO labels — zero-shot label with Falcon-Perception, validate, convert, then fine-tune a compact Apache-licensed model, all on Hugging Face Jobs. Use when you have an image collection and want a detector but no annotations exist.
+---
+
+# Bootstrap a detector from unlabeled images
+
+The loop: **zero-shot teacher labels → validate → convert → train a small student → evaluate → publish.**
+Every step is a self-contained UV script from `uv-scripts/object-detection` on the Hugging Face Hub, or a
+`hf jobs` command. `--help` works on every script. Set
+
+```
+RAW=https://huggingface.co/datasets/uv-scripts/object-detection/raw/main
+```
+
+## 1. Sense-check the class name before spending GPU money (~free)
+
+Falcon-Perception queries are **class names, not instructions**:
+
+- `--query photograph` works. `--query "the photographs, excluding captions"` returns **nothing**
+  (measured: 0.01 instances/image). Never write instruction-style queries.
+- **One class per run.** A combined query returned 6 instances where single-class runs found 24.
+  N classes = N runs; merge afterwards (outputs share `image_id`).
+
+Check cheaply on 3 images before any full pass. The teacher (Falcon-Perception) is a **0.6B model,
+~1.3 GB download** — it runs on a CUDA GPU (fast), Apple Silicon (MLX backend auto-selected, ~6 s/image),
+or plain CPU (slow, but fine for 3 images). Run the check wherever is practical for you:
+
+```
+# locally, if your machine can:
+uv run $RAW/falcon-perception.py --dataset <USER>/<IMAGES> --limit 3 \
+  --query photograph --preview
+
+# or the same check as a small job (previews don't persist on Jobs — push a tiny dataset instead):
+hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
+  $RAW/falcon-perception.py --dataset <USER>/<IMAGES> --limit 3 \
+  --query photograph --out <USER>/<NAME>-check --private
+```
+
+Judge the result before scaling up:
+- **If you can view images**, look at the rendered previews (or the pushed check dataset) — are the
+  right things boxed?
+- **If you can't**, compare instance counts across candidate queries (`stats-hf-dataset.py` below works
+  on a pushed check dataset): ~0 instances/image means the class name is wrong for this material —
+  try a synonym (`photograph` / `illustration` / `figure` / `cartoon`). Suspiciously many (> ~10/image)
+  usually means the query is matching layout blocks, not pictures.
+
+(Falcon-Perception has a custom architecture, so it can't be served as an OpenAI-compatible endpoint —
+iterate via the batch script. If you swap in a teacher that vLLM can serve, a temporary hot server on
+Jobs is the faster way to iterate on queries: see
+[Serve Models on Jobs](https://huggingface.co/docs/hub/jobs-serving).)
+
+## 2. Teacher pass on Jobs (~$1 per 1k images)
+
+```
+hf jobs uv run --flavor a10g-large --secrets HF_TOKEN --timeout 2h \
+  $RAW/falcon-perception.py --dataset <USER>/<IMAGES> \
+  --query photograph --out <USER>/<NAME>-photograph --private
+```
+
+- ~0.4–0.6 s/image on `a10g-large`. Do **not** use `a10g-small` — the engine sizes itself from the GPU,
+  ignores host RAM, and gets OOM-killed (exit 137) before processing anything.
+- One job per class (step 1's rule). Merge per-class outputs by concatenating the `objects` entries of
+  rows with the same `image_id`.
+- Output schema: `objects.bbox` in **YOLO format** (normalized center x, y, w, h), `objects.category`,
+  `objects.area`, `objects.rectangularity`, plus `image`, `image_id`, `width`, `height`.
+- There are **no confidence scores** (the model has none). `rectangularity` (mask area ÷ box area) is the
+  triage proxy: values near 0 are usually junk, ~0.785 is a circle, ~1.0 a full rectangle.
+- Submit with `--detach` (returns the job id immediately), then block on completion with
+  `hf jobs wait <id> [<id> ...] --timeout 2h` — it exits 0 only if every job succeeded, so it
+  chains cleanly into the next step. `hf jobs logs <id>` / `hf jobs inspect <id>` for progress and errors.
+- A job can sit in SCHEDULING for a long time while the flavor queue drains — that is a queue, not a
+  failure. **Don't resubmit**: a second copy racing to the same `--out` just doubles the bill. If you do
+  switch flavor, cancel the queued copy first (`hf jobs cancel <id>`).
+- For images in a storage bucket instead of a dataset, use `$RAW/falcon-perception-bucket.py` (resumable).
+
+## 3. Validate the labels (free, local)
+
+```
+uv run $RAW/validate-hf-dataset.py <USER>/<NAME>-photograph --bbox-format yolo
+uv run $RAW/stats-hf-dataset.py    <USER>/<NAME>-photograph --bbox-format yolo
+```
+
+Expect **VALID** with 0 out-of-bounds and 0 zero-area boxes. `W001` warnings on empty images are normal —
+they are true negatives (pages with no instance), and they are useful training signal; keep them.
+Drop obvious junk before training: degenerate slivers (extreme aspect ratio + tiny area) and near-duplicate
+boxes (IoU > 0.9 within one image).
+
+## 4. Convert YOLO → COCO for training (free, local)
+
+Trainers expect COCO `xywh` pixels; the teacher emits YOLO normalized. One command:
+
+```
+uv run $RAW/convert-hf-dataset.py <USER>/<NAME>-photograph <USER>/<NAME>-coco \
+  --from yolo --to coco_xywh
+```
+
+## 5. Train a small detector (~$1–2 on Jobs)
+
+Fine-tune a **compact, permissively licensed** detector: **D-FINE** or **RT-DETRv2** (both Apache-2.0,
+in `transformers`). Do **not** reach for ultralytics/YOLO weights — they are **AGPL**, which you cannot
+ship from most projects.
+
+The **`huggingface-vision-trainer`** skill covers this end to end (dataset validation, augmentation,
+mAP eval, Hub persistence) — install it with `hf skills add huggingface-vision-trainer` if you don't
+have it, and follow its object-detection path with the `<USER>/<NAME>-coco` dataset from step 4.
+Before training, split off a held-out slice (e.g. 10% of images) and never train on it.
+
+## 6. Evaluate honestly
+
+- Report mAP on the held-out slice. Be clear about what it measures: **agreement with the teacher**,
+  not accuracy against human truth — no human labels exist in this loop.
+- The student can at best match its teacher (measured on a comparable loop: student 97.4% vs teacher
+  95.0% human-acceptable on the same sample). The point of distilling is **throughput and cost**
+  (~10–100× cheaper per image than the teacher), not accuracy gains.
+- Spot-check ~20 predictions visually before calling it done.
+
+## 7. Publish with honest provenance
+
+Push the model and dataset (private first). The cards must state: labels are **zero-shot weak labels**
+from Falcon-Perception (name the script + date), which filters ran, and that **recall is unmeasured**
+unless you measured it against an independent source. Say what the model is for and what it was
+trained on. A model trained this way is a starting point for human correction, not a ground-truth system.

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -22,8 +22,8 @@ The loop runs both ways — decide before you start:
   re-run the teacher). Then train on a small slice first (~500–1k images, ~$1) and show ~20 rendered
   predictions before spending on the full corpus. If corrections are worth collecting at volume, build a
   minimal review UI — image + predicted boxes, accept/edit, corrections written back to a Hub dataset —
-  fold them in and retrain (~$1). The `convert-hf-dataset.py --to label_studio` → correct →
-  `diff-hf-datasets.py` loop in this repo's README is the packaged version of that.
+  fold them in and retrain (~$1). Diff the corrected set against the first pass
+  (`$RAW/diff-hf-datasets.py`) to measure how good the zero-shot pass actually was.
 - **Autonomously** (headless): never pause for review — judge by the numeric proxies each step provides,
   and carry the obligation to the end instead: the final report and the model card must say the model is
   **unreviewed**.

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -6,37 +6,30 @@ description: Bootstrap an object-detection dataset and a small trained detector 
 # Bootstrap a detector from unlabeled images
 
 The loop: **zero-shot teacher labels → validate → convert → train a small student → evaluate → publish.**
-Every step is a self-contained UV script from `uv-scripts/object-detection` on the Hugging Face Hub, or a
-`hf jobs` command. `--help` works on every script. Set
+Every step is a self-contained UV script from
+[`uv-scripts/object-detection`](https://huggingface.co/datasets/uv-scripts/object-detection) on the
+Hugging Face Hub, or a `hf jobs` command. `--help` works on every script.
 
-```
-RAW=https://huggingface.co/datasets/uv-scripts/object-detection/raw/main
-```
+## Check if a human in the loop
 
-## First: with or without a human?
-
-The loop runs both ways — decide before you start:
+You can use the approach outlined in this skill with or without a human in the loop.
 
 - **With a human in the loop** (better models): show them the step-1 previews — "is the teacher boxing
   the right things?" is the highest-value question, and its fix is the cheapest (a better query, ~$2 to
   re-run the teacher). Then train on a small slice first (~500–1k images, ~$1) and show ~20 rendered
-  predictions before spending on the full corpus. If corrections are worth collecting at volume, build a
-  review pass with `$RAW/review-detections.py` (keyboard accept/reject in the browser, per image or
-  per box; prints the quotable acceptance + missed rates and pushes a `review` column) — fold
-  corrections in and retrain (~$1). Diff the corrected set against the first pass
-  (`$RAW/diff-hf-datasets.py`) to measure how good the zero-shot pass actually was.
-- **Autonomously** (headless): never pause for review — judge by the numeric proxies each step provides,
-  and carry the obligation to the end instead: the final report and the model card must say the model is
-  **unreviewed**.
+  predictions before spending on the full corpus. If corrections are worth collecting at volume, run a
+  review pass with `review-detections.py` (keyboard accept/reject in the browser, per image or per box;
+  prints the quotable acceptance + missed rates and pushes a `review` column), fold corrections in and
+  retrain (~$1). Diff the corrected set against the first pass (`diff-hf-datasets.py`) to measure how
+  good the zero-shot pass actually was.
+- **Autonomously** (headless): don't pause for review — use the numeric proxies, and say **unreviewed**
+  in the final report and model card.
 
 ## 1. Sense-check the class name before spending GPU money (~free)
 
-Falcon-Perception queries are **class names, not instructions**:
-
-- `--query photograph` works. `--query "the photographs, excluding captions"` returns **nothing**
-  (measured: 0.01 instances/image). Never write instruction-style queries.
-- **One class per run.** A combined query returned 6 instances where single-class runs found 24.
-  N classes = N runs; merge afterwards (outputs share `image_id`).
+Falcon-Perception queries are **class names, not instructions** ("photograph" works; "the photographs,
+excluding captions" returns nothing), and **one class per run** (combined queries collapse — run per
+class and merge on `image_id`). Model details: `hf models card tiiuae/Falcon-Perception`.
 
 Check cheaply on 3 images before any full pass. The teacher (Falcon-Perception) is a **0.6B model,
 ~1.3 GB download** — it runs on a CUDA GPU (fast), Apple Silicon (MLX backend auto-selected, ~6 s/image),
@@ -44,13 +37,13 @@ or plain CPU (slow, but fine for 3 images). Run the check wherever is practical 
 
 ```
 # locally, if your machine can:
-uv run $RAW/falcon-perception.py --dataset <USER>/<IMAGES> --limit 3 \
-  --query photograph --preview
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
+  --dataset <USER>/<IMAGES> --limit 3 --query photograph --preview
 
 # or the same check as a small job (previews don't persist on Jobs — push a tiny dataset instead):
 hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
-  $RAW/falcon-perception.py --dataset <USER>/<IMAGES> --limit 3 \
-  --query photograph --out <USER>/<NAME>-check --private
+  https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
+  --dataset <USER>/<IMAGES> --limit 3 --query photograph --out <USER>/<NAME>-check --private
 ```
 
 Judge the result before scaling up:
@@ -60,22 +53,24 @@ Judge the result before scaling up:
   on a pushed check dataset): ~0 instances/image means the class name is wrong for this material —
   try a synonym (`photograph` / `illustration` / `figure` / `cartoon`). Suspiciously many (> ~10/image)
   usually means the query is matching layout blocks, not pictures.
+- **No vision at all?** A vision-capable subagent can judge the previews if you can spawn one;
+  otherwise tell the user the check ran unviewed.
 
 (Falcon-Perception has a custom architecture, so it can't be served as an OpenAI-compatible endpoint —
 iterate via the batch script. If you swap in a teacher that vLLM can serve, a temporary hot server on
 Jobs is the faster way to iterate on queries: see
 [Serve Models on Jobs](https://huggingface.co/docs/hub/jobs-serving).)
 
-## 2. Teacher pass on Jobs (~$1 per 1k images)
+## 2. Teacher pass on Jobs
 
 ```
 hf jobs uv run --flavor a10g-large --secrets HF_TOKEN --timeout 2h \
-  $RAW/falcon-perception.py --dataset <USER>/<IMAGES> \
-  --query photograph --out <USER>/<NAME>-photograph --private
+  https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
+  --dataset <USER>/<IMAGES> --query photograph --out <USER>/<NAME>-photograph --private
 ```
 
-- ~0.4–0.6 s/image on `a10g-large`. Do **not** use `a10g-small` — the engine sizes itself from the GPU,
-  ignores host RAM, and gets OOM-killed (exit 137) before processing anything.
+- Avoid `a10g-small` — the engine sizes itself from the GPU and ignores host RAM, so it gets
+  OOM-killed. `hf jobs hardware` lists current options and prices.
 - One job per class (step 1's rule). Merge per-class outputs by concatenating the `objects` entries of
   rows with the same `image_id`.
 - Output schema: `objects.bbox` in **YOLO format** (normalized center x, y, w, h), `objects.category`,
@@ -85,16 +80,19 @@ hf jobs uv run --flavor a10g-large --secrets HF_TOKEN --timeout 2h \
 - Submit with `--detach` (returns the job id immediately), then block on completion with
   `hf jobs wait <id> [<id> ...] --timeout 2h` — it exits 0 only if every job succeeded, so it
   chains cleanly into the next step. `hf jobs logs <id>` / `hf jobs inspect <id>` for progress and errors.
-- A job can sit in SCHEDULING for a long time while the flavor queue drains — that is a queue, not a
-  failure. **Don't resubmit**: a second copy racing to the same `--out` just doubles the bill. If you do
-  switch flavor, cancel the queued copy first (`hf jobs cancel <id>`).
-- For images in a storage bucket instead of a dataset, use `$RAW/falcon-perception-bucket.py` (resumable).
+- A job can sit in SCHEDULING while the flavor queue drains — that is a queue, not a failure.
+  **Don't resubmit**: a second copy racing to the same `--out` just doubles the bill. If you do
+  switch (`hf jobs hardware` for alternatives), cancel the queued copy first (`hf jobs cancel <id>`).
+- For images in a [storage bucket](https://huggingface.co/docs/hub/storage-buckets) instead of a
+  dataset, use `falcon-perception-bucket.py` from the same repo (resumable).
 
 ## 3. Validate the labels (free, local)
 
 ```
-uv run $RAW/validate-hf-dataset.py <USER>/<NAME>-photograph --bbox-format yolo
-uv run $RAW/stats-hf-dataset.py    <USER>/<NAME>-photograph --bbox-format yolo
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/validate-hf-dataset.py \
+  <USER>/<NAME>-photograph --bbox-format yolo
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/stats-hf-dataset.py \
+  <USER>/<NAME>-photograph --bbox-format yolo
 ```
 
 Expect **VALID** with 0 out-of-bounds and 0 zero-area boxes. `W001` warnings on empty images are normal —
@@ -107,20 +105,24 @@ boxes (IoU > 0.9 within one image).
 Trainers expect COCO `xywh` pixels; the teacher emits YOLO normalized. One command:
 
 ```
-uv run $RAW/convert-hf-dataset.py <USER>/<NAME>-photograph <USER>/<NAME>-coco \
-  --from yolo --to coco_xywh
+uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/convert-hf-dataset.py \
+  <USER>/<NAME>-photograph <USER>/<NAME>-coco --from yolo --to coco_xywh
 ```
 
-## 5. Train a small detector (~$1–2 on Jobs)
+## 5. Train a small detector
 
-Fine-tune a **compact, permissively licensed** detector: **D-FINE** or **RT-DETRv2** (both Apache-2.0,
-in `transformers`). Do **not** reach for ultralytics/YOLO weights — they are **AGPL**, which you cannot
-ship from most projects.
+Good starting points: [D-FINE](https://huggingface.co/ustc-community/dfine-small-coco) or
+[RT-DETRv2](https://huggingface.co/PekingU/rtdetr_v2_r18vd) — compact, Apache-2.0, in `transformers`
+(boxes only; for masks see the RF-DETR note below). Check the license fits the use —
+`hf models card <id>` shows it; flag restrictive licenses (e.g. ultralytics/YOLO is AGPL) to the user
+rather than deciding for them. Explore further:
+[transformers object-detection models](https://huggingface.co/models?pipeline_tag=object-detection&library=transformers&sort=trending) ·
+[ultralytics-library models](https://huggingface.co/models?library=ultralytics).
 
-The **`huggingface-vision-trainer`** skill covers this end to end (dataset validation, augmentation,
-mAP eval, Hub persistence) — install it with `hf skills add huggingface-vision-trainer` if you don't
-have it, and follow its object-detection path with the `<USER>/<NAME>-coco` dataset from step 4.
-Before training, split off a held-out slice (e.g. 10% of images) and never train on it.
+The **`huggingface-vision-trainer`** skill covers the training end to end (dataset validation,
+augmentation, mAP eval, Hub persistence) — install it with `hf skills add huggingface-vision-trainer`
+if you don't have it, and follow its object-detection path with the `<USER>/<NAME>-coco` dataset from
+step 4. Before training, decide a pragmatic validation split and never train on it.
 
 Other trainers work too — the dataset is plain COCO. [RF-DETR](https://github.com/roboflow/rf-detr)
 (Apache-2.0, DINOv2 backbone) is a good starter, and its Seg variant can learn from the teacher's
@@ -138,9 +140,6 @@ for rle in json.loads(row["masks_rle"]):
         seg = np.asarray(Image.fromarray(seg).resize((row["width"], row["height"]), Image.NEAREST))
 ```
 
-Pin the package version — the API is young — and if the segmentation training path resists, ship
-detection-only and say so rather than burning the day on it.
-
 ## 6. Evaluate honestly
 
 - Report mAP on the held-out slice. Be clear about what it measures: **agreement with the teacher**,
@@ -150,10 +149,14 @@ detection-only and say so rather than burning the day on it.
   (~10–100× cheaper per image than the teacher), not accuracy gains.
 - Spot-check ~20 predictions visually before calling it done — or, if running without a human and you
   cannot view images, state prominently in the report that the model is **unreviewed**.
+- It can make sense to run this process in a loop: predict → review (a human, or a vision-capable
+  agent, via `review-detections.py`) → retrain on the corrections → review again, until the acceptance
+  rate stops improving.
 
 ## 7. Publish with honest provenance
 
-Push the model and dataset (private first). The cards must state: labels are **zero-shot weak labels**
-from Falcon-Perception (name the script + date), which filters ran, and that **recall is unmeasured**
-unless you measured it against an independent source. Say what the model is for and what it was
-trained on. A model trained this way is a starting point for human correction, not a ground-truth system.
+Push the model and dataset — ask the user whether public or private; if you can't ask, default to
+private and say so. The cards must state: labels are **zero-shot weak labels** from Falcon-Perception
+(name the script + date), which filters ran, and that **recall is unmeasured** unless you measured it
+against an independent source. Say what the model is for and what it was trained on. A model trained
+this way is a first pass. The review loop above is how it gets better.

--- a/object-detection/falcon-perception-bucket.py
+++ b/object-detection/falcon-perception-bucket.py
@@ -11,8 +11,9 @@
 # ///
 """Falcon-Perception over a whole HF bucket, resumable.
 
-    hf jobs uv run --flavor a10g-large --secrets HF_TOKEN falcon-bucket.py -- \
-        --src biglam/bl-images --include 'full/embellishments/**/*.jpg' \
+    hf jobs uv run --flavor a10g-large --secrets HF_TOKEN \
+        https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception-bucket.py \
+        --src biglam/bl-images --prefix full/embellishments \
         --out davanstrien/bl-masks --query illustration
 
 Input  : bucketbag batched_files — bounded scratch, files deleted as the loop advances
@@ -26,9 +27,8 @@ run resumable (`completed_keys` reads the done-set back from `__source_key`).
 To hand the result to the rest of this directory, publish it once at the end:
 
     from datasets import load_dataset
-    load_dataset("parquet", data_files=[
-        "hf://buckets/you/bl-masks/part-000000.parquet", ...
-    ], split="train").push_to_hub("you/bl-masks")
+    load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
+                 split="train").push_to_hub("you/bl-masks")
 
     uv run validate-hf-dataset.py you/bl-masks --bbox-format yolo
 
@@ -47,6 +47,7 @@ GOTCHAS (all measured, none in the model card):
 """
 
 import argparse
+import hashlib
 import io
 import json
 import time
@@ -56,12 +57,18 @@ import pyarrow.parquet as pq
 from bucketbag import batched_files, boost, completed_keys, iter_keys, put_files
 from pycocotools import mask as mask_utils
 
+
+def stable_id(key):
+    """Deterministic int64 image_id from the source key (COCO consumers need an int;
+    a hash, not a running index, keeps ids identical across resumed runs)."""
+    return int.from_bytes(hashlib.blake2b(str(key).encode(), digest_size=8).digest(), "big") >> 1
+
 # Same YOLO column layout as falcon-perception.py, so both outputs validate with
 # `validate-hf-dataset.py --bbox-format yolo` and can be concatenated.
 # `__source_key` is bucketbag's resume column — the name is load-bearing.
 SCHEMA = pa.schema([
     ("__source_key", pa.string()),
-    ("image_id", pa.string()),
+    ("image_id", pa.int64()),  # int, not str: COCO-style trainers tensorise it
     ("width", pa.int32()),
     ("height", pa.int32()),
     ("objects", pa.struct([
@@ -114,6 +121,18 @@ def main():
     p.add_argument("--no-resume", action="store_true")
     args = p.parse_args()
 
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SystemExit(
+            "This script needs a CUDA GPU (PagedInferenceEngine). "
+            "For MLX/CPU-capable runs use falcon-perception.py instead."
+        )
+    if args.format == "jsonl" and not args.no_resume:
+        # completed_keys only reads the done-set back from .parquet parts, so jsonl
+        # output silently reprocesses EVERYTHING on every re-run.
+        raise SystemExit("--format jsonl is not resumable; pass --no-resume to run it anyway.")
+
     boost()  # raise xet small-file concurrency — the whole point on many small objects
 
     done = set() if args.no_resume else completed_keys(args.out)
@@ -132,7 +151,6 @@ def main():
     if not keys:
         return
 
-    import torch  # noqa: F401
     from falcon_perception import PERCEPTION_MODEL_ID, build_prompt_for_task, load_and_prepare_model, setup_torch_config
     from falcon_perception.data import ImageProcessor
     from falcon_perception.paged_inference import (
@@ -166,17 +184,18 @@ def main():
         for it in batch:
             try:
                 img = it.image.convert("RGB")  # convert() forces the load off disk
+                orig_size = img.size  # SOURCE dims -- the images downstream tools decode
                 if max(img.size) > args.max_dim * 2:
                     img.thumbnail((args.max_dim * 2, args.max_dim * 2))
-                pairs.append((str(it.key), img))
+                pairs.append((str(it.key), img, orig_size))
             except Exception as e:
-                pairs.append((str(it.key), e))
+                pairs.append((str(it.key), e, None))
 
-        good = [(k, im) for k, im in pairs if not isinstance(im, Exception)]
+        good = [(k, im, sz) for k, im, sz in pairs if not isinstance(im, Exception)]
         seqs = [
             Sequence(text=prompt, image=im, min_image_size=256,
                      max_image_size=args.max_dim, request_idx=i, task=args.task)
-            for i, (_, im) in enumerate(good)
+            for i, (_, im, _) in enumerate(good)
         ]
         t0 = time.perf_counter()
         if seqs:
@@ -185,14 +204,16 @@ def main():
         gen_total += dt
 
         rows = []
-        for (key, im), seq in zip(good, seqs):
+        for (key, im, orig_size), seq in zip(good, seqs):
             aux = seq.output_aux
             boxes = pair_bboxes(aux.bboxes_raw)
             masks = list(aux.masks_rle)
             for m in masks:
                 if isinstance(m.get("counts"), bytes):
                     m["counts"] = m["counts"].decode()
-            W, H = im.size
+            # width/height are the SOURCE image's dims: boxes are normalised (frame-free),
+            # and downstream pixel conversions run against the untouched bucket images.
+            W, H = orig_size
             bbox, area, rect = [], [], []
             for i, b in enumerate(boxes):
                 bbox.append([b["x"], b["y"], b["w"], b["h"]])  # yolo: cx, cy, w, h normalised
@@ -204,27 +225,38 @@ def main():
                         m = masks[i]
                         if isinstance(m.get("counts"), str):
                             m = {**m, "counts": m["counts"].encode()}
-                        r = min(float(mask_utils.area(m)) / max(a * W * H, 1.0), 1.0)
+                        # box area measured in the MASK's own frame (rle size) — mixing
+                        # frames skews r
+                        mh, mw = (m.get("size") or [H, W])[:2]
+                        r = min(float(mask_utils.area(m)) / max(a * mw * mh, 1.0), 1.0)
                     except Exception:
                         r = 0.0
                 rect.append(r)
             rows.append({
-                "__source_key": key, "image_id": key, "width": W, "height": H,
+                "__source_key": key, "image_id": stable_id(key), "width": W, "height": H,
                 "objects": {"bbox": bbox, "category": [0] * len(bbox),
                             "area": area, "rectangularity": rect},
                 "n_instances": len(bbox), "masks_rle": json.dumps(masks),
                 "query": args.query, "gen_seconds": dt / max(len(seqs), 1), "error": None,
             })
-        for key, err in [(k, v) for k, v in pairs if isinstance(v, Exception)]:
+        for key, err, _ in [(k, v, s) for k, v, s in pairs if isinstance(v, Exception)]:
             # a durable error row, never a gap — and it counts as done so it is
-            # not retried forever on every re-run
+            # not retried forever on every re-run. objects is EMPTY, not null:
+            # a null struct crashes validate-hf-dataset.py after publish.
             rows.append({k: None for k in SCHEMA.names} | {
-                "__source_key": key, "image_id": key, "query": args.query,
+                "__source_key": key, "image_id": stable_id(key), "query": args.query,
+                "objects": {"bbox": [], "category": [], "area": [], "rectangularity": []},
+                "n_instances": 0, "masks_rle": "[]",
                 "error": f"{type(err).__name__}: {err}",
             })
 
+        # part name derives from batch CONTENT, not a run-local counter: a resumed run's
+        # counter restarts at 0 and put_files overwrites, silently destroying the first
+        # run's parts. A content-derived name is stable per batch and collision-free
+        # across resumes (a re-run of the same batch overwrites its own part, idempotent).
         ext = "jsonl" if args.format == "jsonl" else "parquet"
-        put_files([(f"part-{batch_i:06d}.{ext}", serialise(rows, args.format))], args.out)
+        part = hashlib.blake2b(rows[0]["__source_key"].encode(), digest_size=6).hexdigest()
+        put_files([(f"part-{part}.{ext}", serialise(rows, args.format))], args.out)
         n += len(rows); batch_i += 1
         rate = n / (time.perf_counter() - t_all)
         print(f"batch {batch_i}: {len(rows)} rows ({dt / max(len(seqs), 1):.2f}s/img)  "

--- a/object-detection/falcon-perception-bucket.py
+++ b/object-detection/falcon-perception-bucket.py
@@ -121,17 +121,22 @@ def main():
     p.add_argument("--no-resume", action="store_true")
     args = p.parse_args()
 
-    import torch
-
-    if not torch.cuda.is_available():
-        raise SystemExit(
-            "This script needs a CUDA GPU (PagedInferenceEngine). "
-            "For MLX/CPU-capable runs use falcon-perception.py instead."
-        )
     if args.format == "jsonl" and not args.no_resume:
         # completed_keys only reads the done-set back from .parquet parts, so jsonl
         # output silently reprocesses EVERYTHING on every re-run.
         raise SystemExit("--format jsonl is not resumable; pass --no-resume to run it anyway.")
+
+    try:
+        import torch
+
+        has_cuda = torch.cuda.is_available()
+    except ImportError:  # falcon-perception pins torch off-darwin, so it may be absent
+        has_cuda = False
+    if not has_cuda:
+        raise SystemExit(
+            "This script needs a CUDA GPU (PagedInferenceEngine). "
+            "For MLX/CPU-capable runs use falcon-perception.py instead."
+        )
 
     boost()  # raise xet small-file concurrency — the whole point on many small objects
 

--- a/object-detection/falcon-perception-bucket.py
+++ b/object-detection/falcon-perception-bucket.py
@@ -140,6 +140,12 @@ def main():
 
     boost()  # raise xet small-file concurrency — the whole point on many small objects
 
+    from huggingface_hub import HfApi
+
+    # first run: the out bucket may not exist yet — completed_keys 404s on a
+    # missing bucket, killing the job before anything happens
+    HfApi().create_bucket(args.out, private=True, exist_ok=True)
+
     done = set() if args.no_resume else completed_keys(args.out)
     print(f"{len(done)} keys already done", flush=True)
 

--- a/object-detection/falcon-perception.py
+++ b/object-detection/falcon-perception.py
@@ -33,7 +33,8 @@ your class name works on your images before spending GPU hours on the corpus.
         --config plates --limit 3 --preview
 
     # 3. the whole corpus, on a GPU
-    hf jobs uv run --flavor a10g-large --secrets HF_TOKEN falcon-perception.py -- \
+    hf jobs uv run --flavor a10g-large --secrets HF_TOKEN \
+        https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
         --dataset biglam/british-library-book-images --config plates \
         --id-col fname --query illustration --out you/plates-illustrations
 
@@ -70,6 +71,7 @@ MEASURED LIMITS -- not guesses; each one cost a failed run:
 
 import argparse
 import glob as globlib
+import hashlib
 import io
 import itertools
 import json
@@ -78,6 +80,17 @@ import pathlib
 import platform
 import sys
 import time
+
+
+def stable_id(key):
+    """Deterministic int64 image_id from the source key.
+
+    COCO-style consumers (transformers RT-DETR / D-FINE annotation prep) require an
+    INTEGER image_id -- a string crashes them with "ValueError: too many dimensions
+    'str'". A content hash (not a running index) keeps ids identical across separate
+    runs over the same source, so per-class runs merge on image_id cleanly.
+    """
+    return int.from_bytes(hashlib.blake2b(str(key).encode(), digest_size=8).digest(), "big") >> 1
 
 # ── backend / engine selection ──────────────────────────────────────────────
 # The MLX and torch APIs match parameter-for-parameter, but are NOT drop-in:
@@ -210,6 +223,50 @@ def batched(it, n):
             buf = []
     if buf:
         yield buf
+
+
+SCRIPT_URL = "https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py"
+
+
+def push_card(repo_id, query, counters):
+    """Dataset card with the repo's canonical provenance stamp (see AGENTS.md)."""
+    from huggingface_hub import DatasetCard
+
+    on_jobs = os.environ.get("JOB_ID") is not None  # set by HF Jobs in-container
+    hw = os.environ.get("ACCELERATOR") or ""  # e.g. "a10g-large"; empty on CPU
+    origin = (
+        f"Produced on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs)"
+        + (f" (`{hw}`)" if hw else "")
+    ) if on_jobs else "Generated"
+    tags = "\n".join(f"- {t}" for t in (["uv-script", "hf-jobs"] if on_jobs else ["uv-script"]))
+    args_summary = " ".join(sys.argv[1:])
+    card = DatasetCard(f"""---
+tags:
+{tags}
+---
+
+# Zero-shot detection: `{query}`
+
+{counters["images"]} images, {counters["instances"]} instances. Labels are **zero-shot weak
+labels** from [Falcon-Perception](https://huggingface.co/tiiuae/Falcon-Perception) -- no human
+annotated anything, and recall against human truth is unmeasured. `objects.bbox` is `yolo`
+format (normalised centre x, y, w, h); `objects.rectangularity` (mask area / box area) is the
+triage proxy -- the model emits no confidence scores.
+
+## Reproduction
+
+{origin} with the [`falcon-perception.py`]({SCRIPT_URL}) recipe from [uv-scripts](https://huggingface.co/uv-scripts). Run it yourself:
+
+```bash
+hf jobs uv run --flavor a10g-large --secrets HF_TOKEN \\
+    {SCRIPT_URL} \\
+    {args_summary}
+```
+""")
+    try:
+        card.push_to_hub(repo_id)
+    except Exception as e:
+        print(f"WARNING: could not push dataset card ({e})", flush=True)
 
 
 # ── the two generation paths ────────────────────────────────────────────────
@@ -348,33 +405,44 @@ def main():
     gen = (run_paged(model, tokenizer, items, prompt, args) if use_paged
            else run_batch(model, tokenizer, items, prompt, args, backend, model_args.max_seq_len))
 
-    records, n, t0 = [], 0, time.perf_counter()
-    for key, im, aux, dt in gen:
-        W, H = im.size
-        boxes = pair_bboxes(aux.bboxes_raw)
-        rles = list(aux.masks_rle)
-        bbox, area, rect = [], [], []
-        for i, b in enumerate(boxes):
-            bbox.append([b["x"], b["y"], b["w"], b["h"]])  # yolo: cx, cy, w, h normalised
-            a = b["w"] * b["h"]
-            area.append(a)
-            r = 0.0
-            if i < len(rles):  # rectangularity -- the only triage signal available
-                try:
-                    m = rles[i]
-                    if isinstance(m.get("counts"), str):
-                        m = {**m, "counts": m["counts"].encode()}
-                    r = min(float(mask_utils.area(m)) / max(a * W * H, 1.0), 1.0)
-                except Exception:
-                    r = 0.0
-            rect.append(r)
-        n += 1
-        print(f"[{n}] {key[:55]:55s} {len(bbox):2d} inst  {dt:.2f}s", flush=True)
-        if args.preview:
-            print(f"     -> {save_preview(key, im, boxes, rles, args.preview_dir)}", flush=True)
-        if args.out or args.json:
-            records.append({
-                "image": im, "image_id": key, "width": W, "height": H,
+    # Records are STREAMED, never accumulated: a whole-corpus run used to hold every
+    # decoded PIL image in a list until the final push (~3-12 MB each -> tens of GB
+    # RSS -> OOM-killed before anything was pushed).
+    counters = {"images": 0, "instances": 0}
+    json_rows = []  # populated only when --json; records here are image-free
+    t0 = time.perf_counter()
+
+    def iter_records():
+        for key, im, aux, dt in gen:
+            W, H = im.size
+            boxes = pair_bboxes(aux.bboxes_raw)
+            rles = list(aux.masks_rle)
+            bbox, area, rect = [], [], []
+            for i, b in enumerate(boxes):
+                bbox.append([b["x"], b["y"], b["w"], b["h"]])  # yolo: cx, cy, w, h normalised
+                a = b["w"] * b["h"]
+                area.append(a)
+                r = 0.0
+                if i < len(rles):  # rectangularity -- the only triage signal available
+                    try:
+                        m = rles[i]
+                        if isinstance(m.get("counts"), str):
+                            m = {**m, "counts": m["counts"].encode()}
+                        # measure box area in the MASK's own frame (rle size), not the
+                        # fitted image's -- the two never match, and mixing frames skews r
+                        mh, mw = (m.get("size") or [H, W])[:2]
+                        r = min(float(mask_utils.area(m)) / max(a * mw * mh, 1.0), 1.0)
+                    except Exception:
+                        r = 0.0
+                rect.append(r)
+            counters["images"] += 1
+            counters["instances"] += len(bbox)
+            print(f"[{counters['images']}] {key[:55]:55s} {len(bbox):2d} inst  {dt:.2f}s", flush=True)
+            if args.preview:
+                print(f"     -> {save_preview(key, im, boxes, rles, args.preview_dir)}", flush=True)
+            rec = {
+                "image": im, "image_id": stable_id(key), "source_id": key,
+                "width": W, "height": H,
                 "objects": {"bbox": bbox, "category": [0] * len(bbox),
                             "area": area, "rectangularity": rect},
                 "n_instances": len(bbox),
@@ -382,38 +450,21 @@ def main():
                     {**m, "counts": m["counts"].decode() if isinstance(m.get("counts"), bytes) else m.get("counts")}
                     for m in rles
                 ]),
-            })
+            }
+            if args.json:
+                json_rows.append(plain(rec))
+            yield rec
 
-    wall = time.perf_counter() - t0
-    print(f"\n{n} images in {wall:.1f}s ({n / max(wall, 1e-9):.2f} img/s)", flush=True)
+    def plain(r):  # everything except the PIL image, which is not serialisable
+        return {k: v for k, v in r.items() if k != "image"}
 
-    # --- local file output: everything except the PIL image, which is not serialisable
-    def plain(recs):
-        return [{k: v for k, v in r.items() if k != "image"} for r in recs]
+    hub_out = args.out and not args.out.endswith((".json", ".jsonl", ".parquet"))
 
-    if args.json:
-        print(json.dumps(plain(records), indent=2), flush=True)
-
-    if args.out and args.out.endswith((".json", ".jsonl", ".parquet")):
-        rows = plain(records)
-        if args.out.endswith(".json"):
-            pathlib.Path(args.out).write_text(json.dumps(rows, indent=2))
-        elif args.out.endswith(".jsonl"):
-            pathlib.Path(args.out).write_text("".join(json.dumps(r) + "\n" for r in rows))
-        else:
-            import pyarrow as pa
-            import pyarrow.parquet as pq
-
-            pq.write_table(pa.Table.from_pylist(rows), args.out, compression="zstd")
-        total = sum(r["n_instances"] for r in rows)
-        print(f"{total} instances -> {args.out}", flush=True)
-        return
-
-    if args.out:
+    if hub_out:
         from datasets import Dataset, Features, Image as ImageFeat, Sequence as SeqFeat, Value
 
         feats = Features({
-            "image": ImageFeat(), "image_id": Value("string"),
+            "image": ImageFeat(), "image_id": Value("int64"), "source_id": Value("string"),
             "width": Value("int32"), "height": Value("int32"),
             "objects": {"bbox": SeqFeat(SeqFeat(Value("float32"))),
                         "category": SeqFeat(Value("int64")),
@@ -421,8 +472,44 @@ def main():
                         "rectangularity": SeqFeat(Value("float32"))},
             "n_instances": Value("int32"), "masks_rle": Value("string"),
         })
-        Dataset.from_list(records, features=feats).push_to_hub(args.out, private=args.private)
-        print(f"{sum(r['n_instances'] for r in records)} instances -> {args.out}", flush=True)
+        # Stream through an ArrowWriter (not Dataset.from_list/from_generator): from_list
+        # holds every decoded image in RAM; from_generator dill-fingerprints the callable
+        # and chokes on the live generator it closes over. The writer flushes to disk per
+        # batch, and from_file memory-maps it back for the push.
+        import tempfile
+
+        from datasets.arrow_writer import ArrowWriter
+
+        arrow_path = os.path.join(tempfile.mkdtemp(prefix="falcon-out-"), "data.arrow")
+        with ArrowWriter(features=feats, path=arrow_path, writer_batch_size=100) as writer:
+            for rec in iter_records():
+                writer.write(feats.encode_example(rec))
+            writer.finalize()
+        ds = Dataset.from_file(arrow_path)
+        ds.push_to_hub(args.out, private=args.private)
+        push_card(args.out, args.query, counters)
+        if args.json:
+            print(json.dumps(json_rows, indent=2), flush=True)
+    else:
+        rows = [plain(r) for r in iter_records()]
+        if args.json:
+            print(json.dumps(rows, indent=2), flush=True)
+        if args.out and args.out.endswith(".json"):
+            pathlib.Path(args.out).write_text(json.dumps(rows, indent=2))
+        elif args.out and args.out.endswith(".jsonl"):
+            pathlib.Path(args.out).write_text("".join(json.dumps(r) + "\n" for r in rows))
+        elif args.out:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+
+            pq.write_table(pa.Table.from_pylist(rows), args.out, compression="zstd")
+
+    wall = time.perf_counter() - t0
+    n = counters["images"]
+    print(f"\n{n} images in {wall:.1f}s ({n / max(wall, 1e-9):.2f} img/s)", flush=True)
+    if args.out:
+        print(f"{counters['instances']} instances -> {args.out}", flush=True)
+    if hub_out:
         print(f"\nNEXT: validate-hf-dataset.py {args.out} --bbox-format yolo", flush=True)
 
 

--- a/object-detection/falcon-perception.py
+++ b/object-detection/falcon-perception.py
@@ -472,12 +472,10 @@ def main():
                         "rectangularity": SeqFeat(Value("float32"))},
             "n_instances": Value("int32"), "masks_rle": Value("string"),
         })
-        # Stream through an ArrowWriter. The documented alternatives both fail here:
-        # Dataset.from_list holds every decoded image in RAM until the push, and BOTH
-        # Dataset.from_generator and IterableDataset.from_generator pickle the callable
-        # (tested), which raises on the live generator it closes over -- and would try
-        # to hash the loaded model if the generator were constructed inside. The writer
-        # flushes to disk per batch, and from_file memory-maps it back for the push.
+        # Stream through an ArrowWriter: accumulating records in RAM OOMs whole-corpus
+        # runs, and the from_generator APIs pickle their callable, which this closure
+        # (live generator, loaded model) cannot survive. The writer flushes to disk per
+        # batch; from_file memory-maps the result back for the push.
         import tempfile
 
         from datasets.arrow_writer import ArrowWriter

--- a/object-detection/falcon-perception.py
+++ b/object-detection/falcon-perception.py
@@ -472,10 +472,12 @@ def main():
                         "rectangularity": SeqFeat(Value("float32"))},
             "n_instances": Value("int32"), "masks_rle": Value("string"),
         })
-        # Stream through an ArrowWriter (not Dataset.from_list/from_generator): from_list
-        # holds every decoded image in RAM; from_generator dill-fingerprints the callable
-        # and chokes on the live generator it closes over. The writer flushes to disk per
-        # batch, and from_file memory-maps it back for the push.
+        # Stream through an ArrowWriter. The documented alternatives both fail here:
+        # Dataset.from_list holds every decoded image in RAM until the push, and BOTH
+        # Dataset.from_generator and IterableDataset.from_generator pickle the callable
+        # (tested), which raises on the live generator it closes over -- and would try
+        # to hash the loaded model if the generator were constructed inside. The writer
+        # flushes to disk per batch, and from_file memory-maps it back for the push.
         import tempfile
 
         from datasets.arrow_writer import ArrowWriter

--- a/object-detection/review-detections.py
+++ b/object-detection/review-detections.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "gradio>=6,<7",
+#   "datasets>=4.5.0",
+#   "pillow",
+# ]
+# ///
+"""Human triage for a detection dataset -> an accepted/rejected verdict per image or per box.
+
+A minimal keyboard-first review UI for the datasets the other scripts in this
+directory produce (zero-shot teacher labels are suggestions, not ground truth).
+Runs locally, opens your browser, writes every decision to a crash-safe journal,
+and pushes the reviewed dataset back to the Hub when you finish.
+
+    # quick first pass: accept/reject whole images (A / R keys) on a random sample
+    uv run review-detections.py you/plates-illustrations --limit 200 \
+        --out you/plates-illustrations-reviewed
+
+    # detail pass: click boxes to reject them, M flags a missed instance,
+    # hardest (least rectangular) images first
+    uv run review-detections.py you/plates-illustrations --mode boxes \
+        --out you/plates-illustrations-reviewed
+
+Modes:
+  quick  whole-image verdict. A=accept  R=reject  M=missed  arrows=skip/back.
+         Defaults to RANDOM order so the printed acceptance rate is an unbiased
+         sample statistic you can quote ("N% human-accepted, n=200").
+  boxes  click a box to toggle it rejected; same keys advance. Defaults to
+         rectangularity-ASCENDING order (irregular instances first), which is
+         where review effort pays best -- but is a biased sample: do not quote
+         this mode's acceptance rate.
+
+The journal (./review-journal.jsonl) is appended per decision; re-running with
+the same --journal resumes where you stopped. --out pushes rows that received a
+verdict, with a `review` column ({verdict, box_keep, missed}) alongside the
+original schema, so diff/retrain steps consume it unchanged.
+
+Needs an `image` column. Bucket outputs (falcon-perception-bucket.py) carry no
+images -- publish them joined to their source images first.
+"""
+
+import argparse
+import io
+import json
+import os
+import random
+import threading
+
+from fastapi.responses import HTMLResponse, Response
+
+DISPLAY_W = 980
+
+PAGE = """<!doctype html>
+<title>review-detections</title>
+<style>
+  body { margin:0; background:#181818; color:#ddd; font:14px system-ui; }
+  #bar { padding:8px 14px; display:flex; gap:18px; align-items:center; }
+  #bar b { color:#fff; } #keys { color:#888; margin-left:auto; }
+  #stage { position:relative; margin:0 auto; width:max-content; }
+  #img { display:block; }
+  .box { position:absolute; border:3px solid #ffd200; cursor:pointer; }
+  .box.rej { border-color:#f33; border-style:dashed; }
+  #flash { position:fixed; inset:0; display:none; align-items:center; justify-content:center;
+           font-size:80px; pointer-events:none; }
+</style>
+<div id=bar><b id=pos></b><span id=stats></span><span id=verdict></span><span id=keys></span></div>
+<div id=stage><img id=img><div id=boxes></div></div>
+<div id=flash></div>
+<script>
+const MODE = "__MODE__";  // substituted by the server
+document.getElementById("keys").textContent =
+  MODE === "quick" ? "A accept · R reject · M missed · ←/→ move · F finish"
+                   : "click box = toggle reject · A accept rest · R reject all · M missed · ←/→ · F finish";
+let idx = 0, total = 0, meta = null, rejected = new Set();
+
+async function load(i) {
+  const r = await fetch(`/meta/${i}`);
+  if (!r.ok) return;
+  meta = await r.json();
+  idx = meta.idx; total = meta.total; rejected = new Set(meta.rejected_boxes);
+  document.getElementById("img").src = `/img/${idx}`;
+  document.getElementById("pos").textContent = `${idx + 1} / ${total}`;
+  document.getElementById("stats").textContent = meta.stats;
+  document.getElementById("verdict").textContent = meta.verdict ? `decided: ${meta.verdict}` : "";
+  const holder = document.getElementById("boxes");
+  holder.innerHTML = "";
+  meta.boxes.forEach(([x0, y0, x1, y1], j) => {
+    const d = document.createElement("div");
+    d.className = "box" + (rejected.has(j) ? " rej" : "");
+    Object.assign(d.style, {left: x0 + "px", top: y0 + "px",
+                            width: (x1 - x0) + "px", height: (y1 - y0) + "px"});
+    if (MODE === "boxes") d.onclick = () => { rejected.has(j) ? rejected.delete(j) : rejected.add(j);
+                                              d.classList.toggle("rej"); };
+    holder.appendChild(d);
+  });
+}
+function flash(t, c) {
+  const f = document.getElementById("flash");
+  f.textContent = t; f.style.color = c; f.style.display = "flex";
+  setTimeout(() => f.style.display = "none", 180);
+}
+async function decide(verdict, missed) {
+  const box_keep = meta.boxes.map((_, j) => !rejected.has(j));
+  await fetch("/decide", {method: "POST", headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({idx, verdict, missed, box_keep, mode: MODE})});
+  flash(verdict === "accept" ? "✓" : verdict === "reject" ? "✗" : "?",
+        verdict === "accept" ? "#3c3" : "#f33");
+  load(idx + 1);
+}
+document.addEventListener("keydown", (e) => {
+  if (e.key === "ArrowRight") load(idx + 1);
+  else if (e.key === "ArrowLeft") load(idx - 1);
+  else if (e.key === "a" || e.key === "A") decide("accept", false);
+  else if (e.key === "r" || e.key === "R") decide("reject", false);
+  else if (e.key === "m" || e.key === "M") decide("accept", true);
+  else if (e.key === "f" || e.key === "F") {
+    fetch("/finish", {method: "POST"});
+    document.getElementById("keys").textContent = "finished — see the terminal; you can close this tab";
+  }
+});
+load(0);
+</script>
+"""
+
+
+def to_display_boxes(objects, width, height, scale):
+    out = []
+    for cx, cy, w, h in objects["bbox"]:
+        x0 = (cx - w / 2) * width * scale
+        y0 = (cy - h / 2) * height * scale
+        out.append([round(x0), round(y0), round(x0 + w * width * scale), round(y0 + h * height * scale)])
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("dataset")
+    p.add_argument("--split", default="train")
+    p.add_argument("--mode", default="quick", choices=["quick", "boxes"])
+    p.add_argument("--order", default=None, choices=["random", "rect"],
+                   help="default: random in quick mode (unbiased rate), rect in boxes mode")
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--journal", default="./review-journal.jsonl")
+    p.add_argument("--out", default=None, help="Hub repo id for the reviewed dataset")
+    p.add_argument("--private", action="store_true")
+    p.add_argument("--port", type=int, default=7860)
+    args = p.parse_args()
+    order = args.order or ("random" if args.mode == "quick" else "rect")
+
+    from datasets import load_dataset
+
+    ds = load_dataset(args.dataset, split=args.split)
+
+    def min_rect(i):
+        r = ds[i]["objects"]["rectangularity"]
+        return min(r) if r else 2.0  # boxless images last
+
+    ids = list(range(len(ds)))
+    if order == "random":
+        random.Random(args.seed).shuffle(ids)
+    else:
+        ids.sort(key=min_rect)
+    if args.limit:
+        ids = ids[: args.limit]
+
+    decisions = {}  # image_id -> journal record
+    if os.path.exists(args.journal):
+        with open(args.journal) as f:
+            for line in f:
+                rec = json.loads(line)
+                decisions[rec["image_id"]] = rec
+        print(f"resumed {len(decisions)} decisions from {args.journal}", flush=True)
+
+    img_cache = {}
+
+    def render(i):
+        if i not in img_cache:
+            im = ds[ids[i]]["image"].convert("RGB")
+            scale = min(DISPLAY_W / im.width, 1.0)
+            if scale < 1.0:
+                im = im.resize((round(im.width * scale), round(im.height * scale)))
+            buf = io.BytesIO()
+            im.save(buf, format="JPEG", quality=88)
+            img_cache[i] = (buf.getvalue(), scale)
+            if len(img_cache) > 32:
+                img_cache.pop(next(iter(img_cache)))
+        return img_cache[i]
+
+    import gradio as gr
+
+    app = gr.Server(title="review-detections")
+    done = threading.Event()
+
+    @app.get("/", response_class=HTMLResponse)
+    def page() -> str:
+        return PAGE.replace("__MODE__", args.mode)
+
+    @app.get("/img/{i}")
+    def img(i: int) -> Response:
+        return Response(content=render(i)[0], media_type="image/jpeg")
+
+    @app.get("/meta/{i}")
+    def meta(i: int) -> dict:
+        if not 0 <= i < len(ids):
+            return Response(status_code=404)
+        row = ds[ids[i]]
+        _, scale = render(i)
+        prior = decisions.get(row["image_id"])
+        n = len(decisions)
+        acc = sum(1 for d in decisions.values() if d["verdict"] == "accept")
+        return {
+            "idx": i, "total": len(ids),
+            "boxes": to_display_boxes(row["objects"], row["width"], row["height"], scale),
+            "verdict": prior["verdict"] if prior else None,
+            "rejected_boxes": [j for j, k in enumerate(prior["box_keep"]) if not k] if prior else [],
+            "stats": f"{n} decided · {acc / n:.0%} accepted" if n else "",
+        }
+
+    @app.post("/decide")
+    def decide(body: dict) -> dict:
+        row = ds[ids[body["idx"]]]
+        rec = {
+            "image_id": row["image_id"],
+            "mode": body["mode"], "verdict": body["verdict"],
+            "missed": bool(body.get("missed")), "box_keep": body.get("box_keep", []),
+        }
+        decisions[rec["image_id"]] = rec
+        with open(args.journal, "a") as f:
+            f.write(json.dumps(rec) + "\n")
+        return {"n": len(decisions)}
+
+    @app.post("/finish")
+    def finish() -> dict:
+        done.set()
+        return {"ok": True}
+
+    print(f"open http://127.0.0.1:{args.port}/   (F in the browser, or Ctrl-C here, to finish)", flush=True)
+    app.launch(server_port=args.port, inbrowser=True, quiet=True, prevent_thread_lock=True)
+    import signal
+
+    signal.signal(signal.SIGINT, lambda *_: done.set())  # gradio installs its own handler; override AFTER launch
+    done.wait()  # review happens in the browser
+
+    n = len(decisions)
+    if not n:
+        print("no decisions made", flush=True)
+        return
+    acc = sum(1 for d in decisions.values() if d["verdict"] == "accept")
+    print(f"\n{n} decided · {acc} accepted ({acc / n:.0%})"
+          + (" -- random-order sample, quotable" if order == "random" else " -- rect-ordered, biased sample"),
+          flush=True)
+
+    if args.out:
+        reviewed = ds.filter(lambda r: r["image_id"] in decisions)
+        reviewed = reviewed.map(lambda r: {"review": decisions[r["image_id"]]})
+        reviewed.push_to_hub(args.out, private=args.private)
+        print(f"{len(reviewed)} reviewed rows -> {args.out}", flush=True)
+
+
+main()

--- a/object-detection/review-detections.py
+++ b/object-detection/review-detections.py
@@ -3,42 +3,46 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #   "gradio>=6,<7",
+#   "fastapi",
 #   "datasets>=4.5.0",
 #   "pillow",
 # ]
 # ///
-"""Human triage for a detection dataset -> an accepted/rejected verdict per image or per box.
+"""Human triage for a detection dataset -> an accept/reject verdict per image or per box.
 
-A minimal keyboard-first review UI for the datasets the other scripts in this
-directory produce (zero-shot teacher labels are suggestions, not ground truth).
-Runs locally, opens your browser, writes every decision to a crash-safe journal,
-and pushes the reviewed dataset back to the Hub when you finish.
+A minimal keyboard-first review UI for datasets in THIS DIRECTORY'S schema
+(yolo-normalized `objects.bbox` + `image`, `image_id`, `width`, `height` -- what
+falcon-perception.py pushes; run convert-hf-dataset.py first for anything else).
+Zero-shot teacher labels are suggestions, not ground truth: this is where a
+human turns them into something you can quote. Runs locally, opens your
+browser, journals every decision, pushes the reviewed rows back to the Hub.
 
     # quick first pass: accept/reject whole images (A / R keys) on a random sample
     uv run review-detections.py you/plates-illustrations --limit 200 \
         --out you/plates-illustrations-reviewed
 
-    # detail pass: click boxes to reject them, M flags a missed instance,
-    # hardest (least rectangular) images first
+    # detail pass: click boxes to reject them individually
     uv run review-detections.py you/plates-illustrations --mode boxes \
         --out you/plates-illustrations-reviewed
 
 Modes:
-  quick  whole-image verdict. A=accept  R=reject  M=missed  arrows=skip/back.
-         Defaults to RANDOM order so the printed acceptance rate is an unbiased
-         sample statistic you can quote ("N% human-accepted, n=200").
-  boxes  click a box to toggle it rejected; same keys advance. Defaults to
-         rectangularity-ASCENDING order (irregular instances first), which is
-         where review effort pays best -- but is a biased sample: do not quote
-         this mode's acceptance rate.
+  quick  whole-image verdict. A=accept  R=reject  M=accept-but-teacher-missed-something
+         F=finish  arrows=skip/back. Defaults to RANDOM order, so the summary's
+         acceptance rate is an unbiased sample statistic you can quote.
+  boxes  click a box to toggle it rejected; A keeps the rest, R rejects the whole
+         image (all boxes). Defaults to rectangularity-ASCENDING order (irregular
+         instances first) -- best use of effort, but a biased sample: the summary
+         says so and its rate should not be quoted.
 
-The journal (./review-journal.jsonl) is appended per decision; re-running with
-the same --journal resumes where you stopped. --out pushes rows that received a
-verdict, with a `review` column ({verdict, box_keep, missed}) alongside the
-original schema, so diff/retrain steps consume it unchanged.
+Two numbers come out, measuring two different things: the ACCEPTANCE rate (are
+the boxes that were drawn correct?) and the MISSED rate (how often did the
+teacher skip an instance? -- the M key). Quote them separately; neither implies
+the other.
 
-Needs an `image` column. Bucket outputs (falcon-perception-bucket.py) carry no
-images -- publish them joined to their source images first.
+The journal (default ./review-<dataset>-<split>.jsonl) is appended per decision
+and tolerates a torn final line; re-running resumes at the first undecided image.
+--out pushes decided rows with a `review` column ({verdict, missed, box_keep,
+mode}) alongside the original schema.
 """
 
 import argparse
@@ -46,6 +50,7 @@ import io
 import json
 import os
 import random
+import signal
 import threading
 
 from fastapi.responses import HTMLResponse, Response
@@ -64,24 +69,26 @@ PAGE = """<!doctype html>
   .box.rej { border-color:#f33; border-style:dashed; }
   #flash { position:fixed; inset:0; display:none; align-items:center; justify-content:center;
            font-size:80px; pointer-events:none; }
+  #err { display:none; padding:6px 14px; background:#611; color:#fbb; }
 </style>
 <div id=bar><b id=pos></b><span id=stats></span><span id=verdict></span><span id=keys></span></div>
+<div id=err></div>
 <div id=stage><img id=img><div id=boxes></div></div>
 <div id=flash></div>
 <script>
 const MODE = "__MODE__";  // substituted by the server
 document.getElementById("keys").textContent =
   MODE === "quick" ? "A accept · R reject · M missed · ←/→ move · F finish"
-                   : "click box = toggle reject · A accept rest · R reject all · M missed · ←/→ · F finish";
-let idx = 0, total = 0, meta = null, rejected = new Set();
+                   : "click box = reject it · A accept rest · R reject all · M missed · ←/→ · F finish";
+let idx = 0, meta = null, rejected = new Set();
 
 async function load(i) {
   const r = await fetch(`/meta/${i}`);
   if (!r.ok) return;
   meta = await r.json();
-  idx = meta.idx; total = meta.total; rejected = new Set(meta.rejected_boxes);
+  idx = meta.idx; rejected = new Set(meta.rejected_boxes);
   document.getElementById("img").src = `/img/${idx}`;
-  document.getElementById("pos").textContent = `${idx + 1} / ${total}`;
+  document.getElementById("pos").textContent = `${idx + 1} / ${meta.total}`;
   document.getElementById("stats").textContent = meta.stats;
   document.getElementById("verdict").textContent = meta.verdict ? `decided: ${meta.verdict}` : "";
   const holder = document.getElementById("boxes");
@@ -102,11 +109,20 @@ function flash(t, c) {
   setTimeout(() => f.style.display = "none", 180);
 }
 async function decide(verdict, missed) {
-  const box_keep = meta.boxes.map((_, j) => !rejected.has(j));
-  await fetch("/decide", {method: "POST", headers: {"Content-Type": "application/json"},
+  if (!meta) return;
+  const box_keep = verdict === "reject" ? meta.boxes.map(() => false)
+                                        : meta.boxes.map((_, j) => !rejected.has(j));
+  const r = await fetch("/decide", {method: "POST", headers: {"Content-Type": "application/json"},
     body: JSON.stringify({idx, verdict, missed, box_keep, mode: MODE})});
-  flash(verdict === "accept" ? "✓" : verdict === "reject" ? "✗" : "?",
-        verdict === "accept" ? "#3c3" : "#f33");
+  if (!r.ok) {  // do NOT advance on failure -- the journal write did not happen
+    const e = document.getElementById("err");
+    e.textContent = `decision NOT saved (server error ${r.status}) — fix the problem and retry`;
+    e.style.display = "block";
+    return;
+  }
+  document.getElementById("err").style.display = "none";
+  flash(verdict === "accept" ? (missed ? "＋?" : "✓") : "✗",
+        verdict === "accept" ? (missed ? "#fa3" : "#3c3") : "#f33");
   load(idx + 1);
 }
 document.addEventListener("keydown", (e) => {
@@ -120,7 +136,7 @@ document.addEventListener("keydown", (e) => {
     document.getElementById("keys").textContent = "finished — see the terminal; you can close this tab";
   }
 });
-load(0);
+fetch("/start").then(r => r.json()).then(d => load(d.start));
 </script>
 """
 
@@ -143,36 +159,58 @@ def main():
                    help="default: random in quick mode (unbiased rate), rect in boxes mode")
     p.add_argument("--limit", type=int, default=None)
     p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--journal", default="./review-journal.jsonl")
+    p.add_argument("--journal", default=None,
+                   help="default: ./review-<dataset>-<split>.jsonl (scoped so runs don't mix)")
     p.add_argument("--out", default=None, help="Hub repo id for the reviewed dataset")
     p.add_argument("--private", action="store_true")
     p.add_argument("--port", type=int, default=7860)
     args = p.parse_args()
     order = args.order or ("random" if args.mode == "quick" else "rect")
+    journal_path = args.journal or f"./review-{args.dataset.replace('/', '--')}-{args.split}.jsonl"
 
-    from datasets import load_dataset
+    from datasets import Sequence, Value, load_dataset
 
     ds = load_dataset(args.dataset, split=args.split)
 
-    def min_rect(i):
-        r = ds[i]["objects"]["rectangularity"]
-        return min(r) if r else 2.0  # boxless images last
+    missing = [c for c in ("image", "image_id", "width", "height", "objects") if c not in ds.column_names]
+    if missing:
+        raise SystemExit(f"dataset is missing column(s) {missing} -- this tool reads the schema "
+                         "falcon-perception.py pushes; see the docstring.")
+
+    # a lightweight view for sorting and sniffing that never decodes the image column
+    meta_rows = ds.select_columns(["objects"])[:]["objects"]
+    for objects in meta_rows[: min(50, len(meta_rows))]:
+        if any(not (0 <= v <= 1.5) for box in objects["bbox"] for v in box):
+            raise SystemExit("objects.bbox does not look yolo-normalized (values outside [0,1]) -- "
+                             "run convert-hf-dataset.py --to yolo first.")
 
     ids = list(range(len(ds)))
     if order == "random":
         random.Random(args.seed).shuffle(ids)
+    elif "rectangularity" not in meta_rows[0]:
+        print("no rectangularity column -- falling back to random order", flush=True)
+        random.Random(args.seed).shuffle(ids)
     else:
-        ids.sort(key=min_rect)
+        ids.sort(key=lambda i: min(meta_rows[i]["rectangularity"]) if meta_rows[i]["rectangularity"] else 2.0)
     if args.limit:
         ids = ids[: args.limit]
 
-    decisions = {}  # image_id -> journal record
-    if os.path.exists(args.journal):
-        with open(args.journal) as f:
+    # decisions are keyed by DATASET ROW INDEX -- image_id repeats across
+    # concatenated per-class runs, so it cannot key a decision
+    decisions = {}
+    if os.path.exists(journal_path):
+        with open(journal_path) as f:
             for line in f:
-                rec = json.loads(line)
-                decisions[rec["image_id"]] = rec
-        print(f"resumed {len(decisions)} decisions from {args.journal}", flush=True)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:  # torn final line from a crash mid-append
+                    print("journal: skipped one torn line (crash recovery)", flush=True)
+                    continue
+                decisions[rec["row"]] = rec
+        print(f"resumed {len(decisions)} decisions from {journal_path}", flush=True)
 
     img_cache = {}
 
@@ -189,6 +227,14 @@ def main():
                 img_cache.pop(next(iter(img_cache)))
         return img_cache[i]
 
+    def stats_line():
+        n = len(decisions)
+        if not n:
+            return ""
+        acc = sum(1 for d in decisions.values() if d["verdict"] == "accept")
+        mis = sum(1 for d in decisions.values() if d["missed"])
+        return f"{n} decided · {acc / n:.0%} accepted · {mis} missed-flagged"
+
     import gradio as gr
 
     app = gr.Server(title="review-detections")
@@ -198,38 +244,49 @@ def main():
     def page() -> str:
         return PAGE.replace("__MODE__", args.mode)
 
+    @app.get("/start")
+    def start() -> dict:
+        first = next((i for i in range(len(ids)) if ids[i] not in decisions), 0)
+        return {"start": first}
+
     @app.get("/img/{i}")
     def img(i: int) -> Response:
+        if not 0 <= i < len(ids):
+            return Response(status_code=404)
         return Response(content=render(i)[0], media_type="image/jpeg")
 
     @app.get("/meta/{i}")
-    def meta(i: int) -> dict:
+    def meta(i: int) -> Response:
         if not 0 <= i < len(ids):
             return Response(status_code=404)
         row = ds[ids[i]]
         _, scale = render(i)
-        prior = decisions.get(row["image_id"])
-        n = len(decisions)
-        acc = sum(1 for d in decisions.values() if d["verdict"] == "accept")
-        return {
+        prior = decisions.get(ids[i])
+        payload = {
             "idx": i, "total": len(ids),
             "boxes": to_display_boxes(row["objects"], row["width"], row["height"], scale),
             "verdict": prior["verdict"] if prior else None,
             "rejected_boxes": [j for j, k in enumerate(prior["box_keep"]) if not k] if prior else [],
-            "stats": f"{n} decided · {acc / n:.0%} accepted" if n else "",
+            "stats": stats_line(),
         }
+        return Response(content=json.dumps(payload), media_type="application/json")
 
     @app.post("/decide")
     def decide(body: dict) -> dict:
-        row = ds[ids[body["idx"]]]
+        if not 0 <= body.get("idx", -1) < len(ids):
+            return Response(status_code=400)
+        row_idx = ids[body["idx"]]
         rec = {
-            "image_id": row["image_id"],
-            "mode": body["mode"], "verdict": body["verdict"],
-            "missed": bool(body.get("missed")), "box_keep": body.get("box_keep", []),
+            "row": row_idx, "image_id": ds[row_idx]["image_id"],
+            "dataset": args.dataset, "split": args.split,
+            "mode": body["mode"], "order": order, "verdict": body["verdict"],
+            "missed": bool(body.get("missed")), "box_keep": [bool(b) for b in body.get("box_keep", [])],
         }
-        decisions[rec["image_id"]] = rec
-        with open(args.journal, "a") as f:
+        with open(journal_path, "a") as f:  # journal FIRST -- only report saved if it is
             f.write(json.dumps(rec) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        decisions[row_idx] = rec
         return {"n": len(decisions)}
 
     @app.post("/finish")
@@ -239,23 +296,33 @@ def main():
 
     print(f"open http://127.0.0.1:{args.port}/   (F in the browser, or Ctrl-C here, to finish)", flush=True)
     app.launch(server_port=args.port, inbrowser=True, quiet=True, prevent_thread_lock=True)
-    import signal
-
     signal.signal(signal.SIGINT, lambda *_: done.set())  # gradio installs its own handler; override AFTER launch
     done.wait()  # review happens in the browser
+    signal.signal(signal.SIGINT, signal.default_int_handler)  # Ctrl-C must work again (e.g. to abort the push)
 
     n = len(decisions)
     if not n:
         print("no decisions made", flush=True)
         return
     acc = sum(1 for d in decisions.values() if d["verdict"] == "accept")
-    print(f"\n{n} decided · {acc} accepted ({acc / n:.0%})"
-          + (" -- random-order sample, quotable" if order == "random" else " -- rect-ordered, biased sample"),
+    mis = sum(1 for d in decisions.values() if d["missed"])
+    quotable = order == "random" and all(d["order"] == "random" for d in decisions.values())
+    print(f"\n{n} decided · {acc} accepted ({acc / n:.0%}) · {mis} with missed instances ({mis / n:.0%})",
+          flush=True)
+    print("acceptance rate is " + ("an unbiased random-order sample -- quotable"
+                                   if quotable else "from a non-random or mixed-order queue -- NOT quotable"),
           flush=True)
 
     if args.out:
-        reviewed = ds.filter(lambda r: r["image_id"] in decisions)
-        reviewed = reviewed.map(lambda r: {"review": decisions[r["image_id"]]})
+        rows = sorted(decisions)
+        reviewed = ds.select(rows)
+        feats = reviewed.features.copy()
+        feats["review"] = {"verdict": Value("string"), "missed": Value("bool"),
+                           "mode": Value("string"), "box_keep": Sequence(Value("bool"))}
+        reviewed = reviewed.map(
+            lambda r, i: {"review": {k: decisions[rows[i]][k] for k in ("verdict", "missed", "mode", "box_keep")}},
+            with_indices=True, features=feats,
+        )
         reviewed.push_to_hub(args.out, private=args.private)
         print(f"{len(reviewed)} reviewed rows -> {args.out}", flush=True)
 

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -62,7 +62,7 @@ Keep the inline dependency block valid (new deps install at runtime); update the
 
 ## Compose a pipeline
 
-Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model.
+Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model. One pipeline ships pre-assembled as its own skill: `object-detection` carries a `SKILL.md` covering the full no-labels→detector loop (zero-shot teacher labels → validate → convert → train a small Apache-licensed detector) — fetch it from the repo when that is the task.
 
 ## Pre-label, then review
 


### PR DESCRIPTION
Follow-up to #99, from two verification passes run after the merge:

1. a **/code-review high** of the merged commit (10 confirmed findings), and
2. a **clean-context agent validation**: pi + Qwen3.8-27B in an isolated HOME, given only the new `SKILL.md` + the `huggingface-vision-trainer` and `hf-cli` skills, drove the full no-labels→detector loop from the skill text alone — all five planted traps cleared, $1.45 compute, and the resulting D-FINE student scored **mAP@50 0.44 against withheld human gold** (`loc_beyond_words` val) with zero human labels.

## Fixes (review finding → change)

| Finding | Fix |
|---|---|
| `image_id` emitted as string → crashes transformers RT-DETR/D-FINE COCO prep (`ValueError: too many dimensions 'str'`) — hit live by the validation agent | int64 `stable_id()` (blake2b of key; stable across runs so per-class runs merge), original key kept as `source_id` |
| Whole-corpus run accumulates every decoded PIL image in RAM until the final push → OOM before anything lands | records stream through an `ArrowWriter` (from_generator is no good: dill can't fingerprint a callable closing over a live generator) |
| No dataset card → missing canonical `## Reproduction` stamp + `uv-script`/`hf-jobs` tags (the adoption meters) | `push_card()` per AGENTS.md, JOB_ID-gated |
| Bucket resume **destroys prior output** (part index restarts at 0, `put_files` overwrites) | part names derive from batch content, collision-free across resumes |
| Bucket `width`/`height` = thumbnail dims → downstream pixel conversions ~3× off | records SOURCE image dims (boxes are normalised, so frame-free) |
| Error rows write `objects=NULL` → `AttributeError` in `validate-hf-dataset.py` after publish | empty struct + `n_instances=0` + `masks_rle="[]"` (validates as a true negative) |
| `--format jsonl` silently disables resume (`completed_keys` only reads parquet) | early exit with a clear message unless `--no-resume` |
| No CUDA guard on the CUDA-only bucket script (repo convention) | `SystemExit` with pointer to `falcon-perception.py` |
| `rectangularity` mixes mask frame and fitted frame | box area measured in the RLE's own frame, both scripts |
| Bucket docstring example unrunnable (wrong filename, nonexistent `--include`); README examples use bare filenames not raw URLs (convention) | fixed; `$RAW` raw-URL form throughout |

## New: `object-detection/SKILL.md`

The full loop — sense-check class name → teacher labels on Jobs → validate → convert yolo→coco → train a small Apache detector (composes with `huggingface-vision-trainer`) → honest eval → publish with weak-label provenance. Every gotcha line in it is a measured failure (instruction queries return nothing; combined queries collapse; duplicate submissions racing one `--out`; SCHEDULING ≠ failure; `hf jobs wait`). Syncs to the Hub beside the scripts; `skills/uv-recipes/SKILL.md` and the root README point at it.

## Verified

- `py_compile` both scripts; superset gate ✅
- Live 1-image run of the changed output path: streamed push ✅, `image_id` int64 + `source_id` ✅, card content + tag gating ✅, `validate-hf-dataset.py` → VALID ✅
- **Not** GPU-run: the bucket-script changes (paged engine is CUDA-only) — code-reviewed only; a ~$0.50 a10g spot-check before merge would close that

Known, deliberately not fixed here: `--backend torch` on macOS ImportErrors (falcon-perception pins torch off-darwin) — low severity, needs an upstream pin change.

## Output schema change (heads-up)

`image_id` string→int64 and new `source_id` column. `diff-hf-datasets.py --id-column image_id` still matches (both sides descend from the same records); anything joining on the old string id should use `source_id` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H24esmXdt7YazNPzY7ECWU

---

## Live spot-check of the bucket script (2026-08-18, l4x1, ~$0.20)

Fixture bucket: 12 normal pages + 2 upscaled to 3000px + 1 corrupt file. Two runs against the branch code:

- **Resume does not destroy output**: run A (6 imgs → 2 content-named parts) then run B (`6 keys already done / 9 keys to process`) — A's parts survived byte-identical (same size + timestamp), 3 new parts added.
- **Source dims recorded**: the 3000px images carry `2175×3000` / `2172×3000`, not thumbnail dims.
- **Error row**: corrupt file → int `image_id`, empty objects struct, error message captured; published dataset passes `validate-hf-dataset.py` (**VALID**, W001 warnings only).
- **Guards**: jsonl-resume and no-CUDA both exit with clear messages (verified locally; the CUDA guard also needed an ImportError catch — torch is absent on darwin).
- **New fix found by the check**: first run against a nonexistent `--out` bucket 404-crashed in `completed_keys`; the script now auto-creates it (`private=True, exist_ok=True`).

Every changed code path in both scripts has now been executed.


---

## Added: `review-detections.py` (2026-08-18)

The correction loop's missing piece — a minimal keyboard-first human triage UI (gradio.Server + inline front-end, ~330 lines, one file). Quick mode (whole-image A/R/M on a random sample → **quotable acceptance + missed rates**) and boxes mode (click-to-reject per box, rectangularity-ascending queue). Frame math stays server-side — the client only ever receives display-pixel coordinates. JSONL journal (fsynced, torn-line tolerant, per-dataset scoped), resume at first undecided, pushes decided rows with a `review` column.

Reviewed at high effort (10 findings, all fixed — including a reproduced `datasets` cast crash on empty `box_keep` batches, row-index keying so concatenated per-class datasets can't cross-stamp decisions, and quotability guarding on the acceptance rate). Verified live: browser screenshot confirms overlay lands on the detection; boxless-first push, reject-all, bounds, resume, finish→push all exercised. The skill's with-human mode now points at it.

