### PR TITLE
object-detection: category as ClassLabel(names=[query]) + measured Jobs flavor rule

### DIFF
--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -311,14 +311,17 @@ Anything ending `.json`, `.jsonl` or `.parquet` is written locally; anything els
 `falcon-perception-bucket.py` reads images from an HF bucket and writes resumable parquet parts back to a bucket — kill it and re-run the same command, done keys are skipped. Publish once at the end to use the rest of this directory:
 
 ```python
-from datasets import load_dataset
-load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
-             split="train").push_to_hub("you/bl-masks")
+from datasets import ClassLabel, Sequence, load_dataset
+ds = load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
+                  split="train")
+feats = ds.features.copy()  # parquet stores category as bare ints; name the class
+feats["objects"]["category"] = Sequence(ClassLabel(names=[ds[0]["query"]]))
+ds.cast(feats).push_to_hub("you/bl-masks")
 ```
 
 ### Output columns
 
-`objects.bbox` (`yolo`), `objects.category`, `objects.area`, `objects.rectangularity`, plus `image`, `image_id` (int64 — COCO-style trainers require an integer id), `source_id` (the original key), `width`, `height`, `n_instances`, and `masks_rle` (COCO RLE — segmentation rides along; the bbox scripts ignore it).
+`objects.bbox` (`yolo`), `objects.category` (a `ClassLabel` named after the query), `objects.area`, `objects.rectangularity`, plus `image`, `image_id` (int64 — COCO-style trainers require an integer id), `source_id` (the original key), `width`, `height`, `n_instances`, and `masks_rle` (COCO RLE — segmentation rides along; the bbox scripts ignore it).
 
 ### Train on the output
 

--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -312,11 +312,11 @@ Anything ending `.json`, `.jsonl` or `.parquet` is written locally; anything els
 
 ```python
 from datasets import ClassLabel, Sequence, load_dataset
-ds = load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
+ds = load_dataset("parquet", data_files="hf://buckets/<namespace>/<bucket>/part-*.parquet",
                   split="train")
 feats = ds.features.copy()  # parquet stores category as bare ints; name the class
 feats["objects"]["category"] = Sequence(ClassLabel(names=[ds[0]["query"]]))
-ds.cast(feats).push_to_hub("you/bl-masks")
+ds.cast(feats).push_to_hub("<namespace>/<dataset>")  # a dataset repo, distinct from the bucket
 ```
 
 ### Output columns

--- a/object-detection/SKILL.md
+++ b/object-detection/SKILL.md
@@ -40,8 +40,9 @@ or plain CPU (slow, but fine for 3 images). Run the check wherever is practical 
 uv run https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
   --dataset <USER>/<IMAGES> --limit 3 --query photograph --preview
 
-# or the same check as a small job (previews don't persist on Jobs — push a tiny dataset instead):
-hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
+# or the same check as a small job (previews don't persist on Jobs — push a tiny dataset instead).
+# l4x1 is the cheapest flavor that fits the engine (see step 2's flavor rule):
+hf jobs uv run --flavor l4x1 --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/object-detection/raw/main/falcon-perception.py \
   --dataset <USER>/<IMAGES> --limit 3 --query photograph --out <USER>/<NAME>-check --private
 ```
@@ -69,12 +70,40 @@ hf jobs uv run --flavor a10g-large --secrets HF_TOKEN --timeout 2h \
   --dataset <USER>/<IMAGES> --query photograph --out <USER>/<NAME>-photograph --private
 ```
 
-- Avoid `a10g-small` — the engine sizes itself from the GPU and ignores host RAM, so it gets
-  OOM-killed. `hf jobs hardware` lists current options and prices.
-- One job per class (step 1's rule). Merge per-class outputs by concatenating the `objects` entries of
-  rows with the same `image_id`.
-- Output schema: `objects.bbox` in **YOLO format** (normalized center x, y, w, h), `objects.category`,
-  `objects.area`, `objects.rectangularity`, plus `image`, `image_id`, `width`, `height`.
+- Flavor rule (all three failures measured): the engine needs a **24 GB-VRAM GPU** (16 GB T4s
+  CUDA-OOM during prefill) and **more than 15 GB host RAM** (the engine sizes itself from the GPU
+  and ignores host RAM, so `t4-small` and `a10g-small` are OOMKilled before the first image).
+  `hf jobs hardware --json` lists every flavor's `ram`, accelerator and price — `l4x1` is the
+  cheapest fit (fine for the step-1 check); `a10g-large` is faster for a corpus pass.
+- One job per class (step 1's rule). Every run labels its boxes `category` 0 in a single-name
+  `ClassLabel`, so a naive concat collapses the classes — renumber each run to its index in a
+  combined `ClassLabel` when merging. Rows align on `image_id` (every run contains every image):
+
+  ```python
+  from datasets import ClassLabel, Sequence, load_dataset
+
+  names = ["illustration", "map"]
+  parts = [load_dataset(f"<USER>/<NAME>-{n}", split="train") for n in names]
+  extra = [dict(zip(ds["image_id"], ds["objects"])) for ds in parts[1:]]
+
+  def merge(row):
+      o = {k: list(v) for k, v in row["objects"].items()}
+      for i, run in enumerate(extra, start=1):
+          r = run[row["image_id"]]
+          o["bbox"] += r["bbox"]; o["area"] += r["area"]
+          o["rectangularity"] += r["rectangularity"]
+          o["category"] += [i] * len(r["bbox"])
+      return {"objects": o, "n_instances": len(o["bbox"])}
+
+  feats = parts[0].features.copy()
+  feats["objects"]["category"] = Sequence(ClassLabel(names=names))
+  merged = parts[0].map(merge, features=feats)
+  ```
+
+  (`masks_rle` concatenates the same way if you need the masks.)
+- Output schema: `objects.bbox` in **YOLO format** (normalized center x, y, w, h), `objects.category`
+  (a `ClassLabel` named after the query), `objects.area`, `objects.rectangularity`, plus `image`,
+  `image_id`, `width`, `height`.
 - There are **no confidence scores** (the model has none). `rectangularity` (mask area ÷ box area) is the
   triage proxy: values near 0 are usually junk, 0.785 is a circle, 1.0 a full rectangle.
 - Submit with `--detach` (returns the job id immediately), then block on completion with

--- a/object-detection/falcon-perception-bucket.py
+++ b/object-detection/falcon-perception-bucket.py
@@ -27,13 +27,13 @@ run resumable (`completed_keys` reads the done-set back from `__source_key`).
 To hand the result to the rest of this directory, publish it once at the end:
 
     from datasets import ClassLabel, Sequence, load_dataset
-    ds = load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
+    ds = load_dataset("parquet", data_files="hf://buckets/<namespace>/<bucket>/part-*.parquet",
                       split="train")
     feats = ds.features.copy()  # parquet stores category as bare ints; name the class
     feats["objects"]["category"] = Sequence(ClassLabel(names=[ds[0]["query"]]))
-    ds.cast(feats).push_to_hub("you/bl-masks")
+    ds.cast(feats).push_to_hub("<namespace>/<dataset>")  # a dataset repo, distinct from the bucket
 
-    uv run validate-hf-dataset.py you/bl-masks --bbox-format yolo
+    uv run validate-hf-dataset.py <namespace>/<dataset> --bbox-format yolo
 
 Note the parts carry `width`/`height` but no `image` column (the images stay in
 the source bucket), so pass --image-column accordingly if a downstream script

--- a/object-detection/falcon-perception-bucket.py
+++ b/object-detection/falcon-perception-bucket.py
@@ -26,9 +26,12 @@ Output is parquet parts in a BUCKET, not a dataset repo — that is what makes t
 run resumable (`completed_keys` reads the done-set back from `__source_key`).
 To hand the result to the rest of this directory, publish it once at the end:
 
-    from datasets import load_dataset
-    load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
-                 split="train").push_to_hub("you/bl-masks")
+    from datasets import ClassLabel, Sequence, load_dataset
+    ds = load_dataset("parquet", data_files="hf://buckets/you/bl-masks/part-*.parquet",
+                      split="train")
+    feats = ds.features.copy()  # parquet stores category as bare ints; name the class
+    feats["objects"]["category"] = Sequence(ClassLabel(names=[ds[0]["query"]]))
+    ds.cast(feats).push_to_hub("you/bl-masks")
 
     uv run validate-hf-dataset.py you/bl-masks --bbox-format yolo
 
@@ -40,8 +43,9 @@ GOTCHAS (all measured, none in the model card):
   * --query is a CLASS NAME. "illustration" works; "the illustration, excluding
     captions" returns nothing.
   * torch.compile breaks on per-image dynamic shapes -> compile is OFF here.
-  * engine_config_for_gpu() sizes from the GPU and ignores host RAM; on
-    a10g-small it gets OOMKilled (exit 137) before processing anything.
+  * engine_config_for_gpu() sizes from the GPU and ignores host RAM; the 15 GB
+    flavors (t4-small, a10g-small) get OOMKilled (exit 137) before processing
+    anything -- pick >15 GB `ram` from `hf jobs hardware --json`.
     cudagraph is off by default here for the same reason.
   * xy in the output is the NORMALISED CENTRE, not a corner.
 """
@@ -73,7 +77,9 @@ SCHEMA = pa.schema([
     ("height", pa.int32()),
     ("objects", pa.struct([
         ("bbox", pa.list_(pa.list_(pa.float32()))),   # yolo: cx, cy, w, h normalised
-        ("category", pa.list_(pa.int64())),           # single class per run, by design
+        ("category", pa.list_(pa.int64())),           # single class per run; the class NAME
+                                                      # is the `query` column — cast to
+                                                      # ClassLabel at publish (see docstring)
         ("area", pa.list_(pa.float32())),
         ("rectangularity", pa.list_(pa.float32())),   # triage proxy — no confidence score exists
     ])),

--- a/object-detection/falcon-perception.py
+++ b/object-detection/falcon-perception.py
@@ -65,8 +65,10 @@ MEASURED LIMITS -- not guesses; each one cost a failed run:
   * torch.compile is OFF. Per-image dynamic shapes break Inductor
     ("ValueError: Exponent must be non-negative" after symbolic-shape recursion).
   * CUDA graphs are OFF by default. engine_config_for_gpu() sizes itself from the
-    GPU and ignores host RAM; on a10g-small the container is OOMKilled (exit 137)
-    before one image is processed. Use a10g-large, or pass --cudagraph knowingly.
+    GPU and ignores host RAM; on the 15 GB-host-RAM flavors (t4-small, a10g-small
+    -- both measured) the container is OOMKilled (exit 137) before one image is
+    processed. Pick a flavor with >15 GB `ram` from `hf jobs hardware --json`,
+    or pass --cudagraph knowingly.
 """
 
 import argparse
@@ -250,8 +252,9 @@ tags:
 {counters["images"]} images, {counters["instances"]} instances. Labels are **zero-shot weak
 labels** from [Falcon-Perception](https://huggingface.co/tiiuae/Falcon-Perception) -- no human
 annotated anything, and recall against human truth is unmeasured. `objects.bbox` is `yolo`
-format (normalised centre x, y, w, h); `objects.rectangularity` (mask area / box area) is the
-triage proxy -- the model emits no confidence scores.
+format (normalised centre x, y, w, h); `objects.category` is a `ClassLabel` named `{query}`;
+`objects.rectangularity` (mask area / box area) is the triage proxy -- the model emits no
+confidence scores.
 
 ## Reproduction
 
@@ -461,13 +464,15 @@ def main():
     hub_out = args.out and not args.out.endswith((".json", ".jsonl", ".parquet"))
 
     if hub_out:
-        from datasets import Dataset, Features, Image as ImageFeat, Sequence as SeqFeat, Value
+        from datasets import ClassLabel, Dataset, Features, Image as ImageFeat, Sequence as SeqFeat, Value
 
         feats = Features({
             "image": ImageFeat(), "image_id": Value("int64"), "source_id": Value("string"),
             "width": Value("int32"), "height": Value("int32"),
+            # category is a ClassLabel named after the query, so the class name travels
+            # with the dataset (viewer, trainers, id2label) instead of a bare 0.
             "objects": {"bbox": SeqFeat(SeqFeat(Value("float32"))),
-                        "category": SeqFeat(Value("int64")),
+                        "category": SeqFeat(ClassLabel(names=[args.query])),
                         "area": SeqFeat(Value("float32")),
                         "rectangularity": SeqFeat(Value("float32"))},
             "n_instances": Value("int32"), "masks_rle": Value("string"),


### PR DESCRIPTION
Follow-up to #101 (PR A from the agreed queue).

## What

- **`falcon-perception.py`**: `objects.category` is now a `ClassLabel` named after the query, so the class name travels with the dataset (viewer, trainers' `id2label`) instead of a bare `0`. Card text updated to say so.
- **`falcon-perception-bucket.py`**: parquet parts keep `int64` category (parquet has no ClassLabel; the class name is the `query` column). The publish snippet in the docstring + README now casts to `ClassLabel` at push time.
- **`SKILL.md`**: the multi-class merge is now shown as code — every run emits `category` 0, so a naive concat collapses the classes; the snippet renumbers each run to its index in a combined `ClassLabel`.
- **Measured Jobs flavor rule** (found by this PR's smoke tests): the engine needs a **24 GB-VRAM GPU** (T4 CUDA-OOMs during prefill: `batch_size=2, total_tokens=5924, alloc=13.81GB`) and **>15 GB host RAM** (`t4-small`/`a10g-small` OOMKilled before the first image). The step-1 job example used `t4-small`, which never worked — now `l4x1`, the cheapest fit per `hf jobs hardware --json`. Skill + both docstrings state the rule.

## Verified live

| Check | How | Result |
|---|---|---|
| Teacher push carries ClassLabel | `l4x1` job → `skilltest-classlabel-check` | `List(ClassLabel(names=['photograph']))` ✅ |
| ClassLabel survives yolo→coco convert | `cpu-basic` job, unmodified `convert-hf-dataset.py` | feature intact, no cast-back needed ✅ |
| SKILL merge snippet renumbers | `cpu-basic` job, snippet verbatim | combined ClassLabel + `[0…,1…]` categories ✅ |
| Bucket publish cast | snippet run against real fixcheck parts → `skilltest-classlabel-bucket-pub` | ✅ (plus schema-exact local parquet incl. empty rows) |
| t4-small / t4-medium failures | Jobs runs | host-RAM OOMKill / CUDA prefill OOM (documented) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H24esmXdt7YazNPzY7ECWU