### PR TITLE
ocr: tesseract-ocr — annotate None-default params as `X | None`

### DIFF
--- a/ocr/tesseract-ocr.py
+++ b/ocr/tesseract-ocr.py
@@ -313,9 +313,9 @@ def main(
     psm: int = 3,
     oem: int = 3,
     num_workers: int = 0,
-    hf_token: str = None,
+    hf_token: str | None = None,
     split: str = "train",
-    max_samples: int = None,
+    max_samples: int | None = None,
     private: bool = False,
     shuffle: bool = False,
     seed: int = 42,
@@ -323,7 +323,7 @@ def main(
     overwrite: bool = False,
     dry_run: bool = False,
     verbose: bool = False,
-    config: str = None,
+    config: str | None = None,
     create_pr: bool = False,
 ):
     """Process images from an HF dataset through Tesseract OCR."""


### PR DESCRIPTION
## What

Three parameters in `main()` were annotated `str` / `int` but default to `None`:

| line | before | after |
|---|---|---|
| 316 | `hf_token: str = None` | `hf_token: str \| None = None` |
| 318 | `max_samples: int = None` | `max_samples: int \| None = None` |
| 326 | `config: str = None` | `config: str \| None = None` |

No behaviour change — all three are truthiness-guarded (`hf_token or os.environ...`, `if max_samples:`, `if config`). The script is `requires-python >= 3.10`, so `X | None` is used rather than `Optional[X]` (matches ruff `UP045`).

## How found

ty 0.0.75 shipped experimental PEP 723 script support ([astral-sh/ty#691](https://github.com/astral-sh/ty/issues/691#issuecomment-5451839483)): with `TY_UV=scripts`, ty calls uv to sync the script's inline deps and type-checks against them. On this file it goes from 11 diagnostics (7 bogus `unresolved-import`) to these 4 real ones.

## Verify

```
TY_UV=scripts uvx ty@0.0.75 check ocr/tesseract-ocr.py   # → All checks passed!
```
(needs uv ≥ 0.12.3; if `uvx` can't find 0.0.75, a `exclude-newer` in your uv config is hiding it — add `--no-config`)

Same `X = None` pattern exists in ~30 other scripts in the repo; this PR is deliberately limited to one file. Follow-ups per script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
