### PR TITLE
classification: train-setfit.py — few-shot classifiers on CPU or GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 | **embeddings** | Embed text/images (auto-batch, prompt-aware); build a searchable Lance vector DB on the Hub | [`embeddings`](https://huggingface.co/datasets/uv-scripts/embeddings) |
 | **embeddings & atlas** | Embed a dataset; build an interactive map | [`build-atlas`](https://huggingface.co/datasets/uv-scripts/build-atlas) |
 | **data processing** | Filter / dedup / stats over large datasets | [`dataset-stats`](https://huggingface.co/datasets/uv-scripts/dataset-stats) · [`deduplication`](https://huggingface.co/datasets/uv-scripts/deduplication) |
-| **classification** | Fine-tune an encoder classifier (LFM2.5-Encoder, ModernBERT, …) or zero-shot classify with an LLM | [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
+| **classification** | Fine-tune an encoder classifier (LFM2.5-Encoder, ModernBERT, …), few-shot train one with SetFit on CPU, or zero-shot classify with an LLM | [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
 | **dataset creation** | Turn PDFs / image URLs into Hub datasets | [`dataset-creation`](https://huggingface.co/datasets/uv-scripts/dataset-creation) · [`iiif-tiles`](https://huggingface.co/datasets/uv-scripts/iiif-tiles) |
 | **synthetic data** | Generate datasets with LLMs | [`synthetic-data`](https://huggingface.co/datasets/uv-scripts/synthetic-data) |
 | **inference** | Run any open LLM / VLM over a dataset | [`vllm`](https://huggingface.co/datasets/uv-scripts/vllm) · [`openai-oss`](https://huggingface.co/datasets/uv-scripts/openai-oss) · [`transformers-inference`](https://huggingface.co/datasets/uv-scripts/transformers-inference) |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 
 **Built for agents, too.** Every recipe takes its arguments in the same `input output` order and runs from a URL, so an AI agent can pick a tool from its header and run it with no setup. On Jobs the agent runs in a sandbox: a throwaway disk, access limited to what the token's repo permissions allow, and a cost cap per job — not arbitrary code on your machine. (Hugging Face also ships an [`hf` CLI skill for agents](https://huggingface.co/docs/hub/agents-cli) for driving Jobs from an editor.) This repo also ships a ready-to-use **[`uv-recipes` agent skill](skills/uv-recipes/)** — point your agent at it to discover, run, and adapt recipes.
 
+For few-shot text classification, the focused **[`setfit-on-jobs` skill](skills/setfit-on-jobs/)** prepares a small labeled sample when needed, runs SetFit on Jobs, and verifies the resulting model.
+
 ## Recipes
 
 | Domain | What it does | On the Hub |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For few-shot text classification, the focused **[`setfit-on-jobs` skill](skills/
 | **embeddings** | Embed text/images (auto-batch, prompt-aware); build a searchable Lance vector DB on the Hub | [`embeddings`](https://huggingface.co/datasets/uv-scripts/embeddings) |
 | **embeddings & atlas** | Embed a dataset; build an interactive map | [`build-atlas`](https://huggingface.co/datasets/uv-scripts/build-atlas) |
 | **data processing** | Filter / dedup / stats over large datasets | [`dataset-stats`](https://huggingface.co/datasets/uv-scripts/dataset-stats) · [`deduplication`](https://huggingface.co/datasets/uv-scripts/deduplication) |
-| **classification** | Fine-tune an encoder classifier (LFM2.5-Encoder, ModernBERT, …), few-shot train one with SetFit on CPU, or zero-shot classify with an LLM | [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
+| **classification** | Fine-tune an encoder classifier (LFM2.5-Encoder, ModernBERT, …), few-shot train one with SetFit on CPU or GPU, or zero-shot classify with an LLM | [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
 | **dataset creation** | Turn PDFs / image URLs into Hub datasets | [`dataset-creation`](https://huggingface.co/datasets/uv-scripts/dataset-creation) · [`iiif-tiles`](https://huggingface.co/datasets/uv-scripts/iiif-tiles) |
 | **synthetic data** | Generate datasets with LLMs | [`synthetic-data`](https://huggingface.co/datasets/uv-scripts/synthetic-data) |
 | **inference** | Run any open LLM / VLM over a dataset | [`vllm`](https://huggingface.co/datasets/uv-scripts/vllm) · [`openai-oss`](https://huggingface.co/datasets/uv-scripts/openai-oss) · [`transformers-inference`](https://huggingface.co/datasets/uv-scripts/transformers-inference) |

--- a/classification/README.md
+++ b/classification/README.md
@@ -87,7 +87,7 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
 - **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
 - **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
-- **Rows with missing or blank labels are dropped**, with a count. A blank string is otherwise a perfectly valid class name.
+- **Rows with missing or blank labels are dropped**, including `ClassLabel`'s `-1` sentinel and numeric NaN, with a count. Plain integer `-1` remains a valid class. Empty labelled splits, fewer than two observed training classes, and missing or invalid text columns exit before model loading.
 
 ```bash
 # 8 labels per class, on CPU

--- a/classification/README.md
+++ b/classification/README.md
@@ -99,20 +99,44 @@ hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
   --body-model sentence-transformers/paraphrase-mpnet-base-v2
 ```
 
-### Measured on `ag_news`
+### Measured
 
-8 labels per class, 500 examples from the `test` split, seed 42:
+8 labels per class, seed 42, evaluated on each dataset's own held-out split (capped at 500
+examples, 1000 for banking77):
 
-| Body model | Flavor | Training | Accuracy | Macro F1 | Total job |
-|---|---|---|---|---|---|
-| `all-MiniLM-L6-v2` (22M) | `cpu-basic` | 118s | 0.804 | 0.807 | 193s |
-| `paraphrase-mpnet-base-v2` (110M) | `t4-small` | 20s | 0.788 | 0.792 | 129s |
-| `paraphrase-mpnet-base-v2` (110M) | `cpu-basic` | 915s | not measured | | 1015s |
+| Dataset | Classes | Labels used | Body | Flavor | Training | Accuracy | Macro F1 |
+|---|---|---|---|---|---|---|---|
+| [`SetFit/enron_spam`](https://huggingface.co/datasets/SetFit/enron_spam) | 2 | 16 | MiniLM-L6 | `cpu-basic` | 78s | 0.924 | 0.924 |
+| [`fancyzhx/ag_news`](https://huggingface.co/datasets/fancyzhx/ag_news) | 4 | 32 | MiniLM-L6 | `cpu-basic` | 118s | 0.804 | 0.807 |
+| [`legacy-datasets/banking77`](https://huggingface.co/datasets/legacy-datasets/banking77) | 77 | 616 | MiniLM-L6 | `t4-small` | 18s | 0.803 | 0.789 |
+| [`dair-ai/emotion`](https://huggingface.co/datasets/dair-ai/emotion) | 6 | 48 | MiniLM-L6 | `cpu-basic` | 216s | 0.370 | 0.325 |
 
-**These are single-seed numbers and do not rank the two models.** The 1.6pp difference is well
-inside the run-to-run variation of 8-example-per-class training — SetFit's own benchmarks report
-mean and standard deviation across ten seeds for exactly this reason. MiniLM is the default
-because it makes the CPU path practical, not because it scored higher here.
+**Single seed each — these do not rank models or predict your dataset.** Few-shot results vary
+substantially with which examples happen to get sampled; SetFit's own benchmarks report mean and
+standard deviation across ten seeds for exactly this reason. Run your own task before trusting
+any of these numbers.
+
+`emotion` is the honest counter-example: six overlapping affect classes are hard from 8 examples
+each, and swapping the body barely moved it (`bge-small` 0.418, `paraphrase-mpnet-base-v2` 0.410).
+SetFit's docs report **0.591 on this dataset with no labels at all**, using synthetic examples
+generated from the class names — so when classes are semantically well-named but hard to separate
+from a handful of samples, the zero-shot route may beat few-shot.
+
+### Many classes: watch the pair count
+
+SetFit trains on pairs drawn from every combination of training examples, so the pair count grows
+with the **square** of the training-set size — which is `--num-samples` x number of classes. The
+script logs the estimate before training starts:
+
+| Dataset | Strategy | Pairs | Steps |
+|---|---|---|---|
+| ag_news (4 classes x 8) | `oversampling` (default) | 768 | 48 |
+| banking77 (77 classes x 8) | `oversampling` (default) | 374,528 | 23,408 |
+| banking77 (77 classes x 8) | `undersampling` | 4,312 | 270 |
+
+At 77 classes the default would take roughly 15 hours on `cpu-basic`; `--sampling-strategy
+undersampling` finished in 18 seconds on a T4. Above 5,000 estimated steps the script warns and
+names the cheaper alternative.
 
 > **Note**: a SetFit model is a sentence-transformer body plus a scikit-learn head. Load it with
 > `SetFitModel.from_pretrained(repo)`, not `AutoModelForSequenceClassification`.

--- a/classification/README.md
+++ b/classification/README.md
@@ -85,6 +85,9 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **Single-label only.** A multi-label column exits with a pointer to `train-classifier.py`.
 - **Metrics match `train-classifier.py`** (accuracy + macro F1 on a held-out split), so the two rungs are directly comparable.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
+- **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
+- **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
+- **Rows with missing or blank labels are dropped**, with a count. A blank string is otherwise a perfectly valid class name.
 
 ```bash
 # 8 labels per class, on CPU
@@ -121,6 +124,33 @@ each, and swapping the body barely moved it (`bge-small` 0.418, `paraphrase-mpne
 SetFit's docs report **0.591 on this dataset with no labels at all**, using synthetic examples
 generated from the class names — so when classes are semantically well-named but hard to separate
 from a handful of samples, the zero-shot route may beat few-shot.
+
+### The majority class is the lower floor
+
+`dair-ai/emotion` is the cautionary case. This script scores **0.370** on it; the majority class
+is **0.352**, so a naive "did it beat the baseline" check passes. SetFit's own documentation
+reports **0.591 on the same dataset with no labels at all**, using examples templated from the
+class names. Swapping the body barely moves it (`bge-small` 0.418, `paraphrase-mpnet-base-v2`
+0.410), so this is the task resisting few-shot learning, not the model being wrong.
+
+The lesson generalises: before spending labels, measure what free costs. When classes are
+well-named but semantically entangled, zero-shot can win outright.
+
+### Real-world data: a worked failure
+
+`biglam/hansard_speech` (2.7M parliamentary speeches, predicting `party` from `speech`) is the
+case where none of the convenient properties hold, and it is instructive precisely because it
+produces no score:
+
+- **No held-out split**, so the eval set has to be carved from train — the numbers stop being
+  comparable to anything published.
+- **~9.5% of rows have a blank `party`**, which without the drop trains an `""` class.
+- **28 parties after cleaning, nine of which cannot supply 8 examples** (`Respect` 4,
+  `Independent SDP` 2, `Change UK` 1). The few-shot framing does not hold at any budget.
+- **1,878 steps at ~11s/step on CPU** — the script refuses it, projecting well past an hour.
+
+The model card discloses the first three automatically, so a run on messy data cannot quietly
+report a clean-looking number.
 
 ### Many classes: watch the pair count
 

--- a/classification/README.md
+++ b/classification/README.md
@@ -87,7 +87,7 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
 - **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
 - **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
-- **Rows with missing or blank labels are dropped**, including `ClassLabel`'s `-1` sentinel and numeric NaN, with a count. Plain integer `-1` remains a valid class. Empty labelled splits, fewer than two observed training classes, and missing or invalid text columns exit before model loading.
+- **Rows with missing or blank labels or texts are dropped**, with a count. Missing labels include `ClassLabel`'s `-1` sentinel and numeric NaN; plain integer `-1` remains a valid class. Splits with no usable labelled text, fewer than two observed training classes, and missing or non-string text columns exit before model loading.
 
 ```bash
 # 8 labels per class, on CPU

--- a/classification/README.md
+++ b/classification/README.md
@@ -1,6 +1,6 @@
 ---
 viewer: false
-tags: [uv-script, classification, fine-tuning, vllm, structured-outputs, gpu-required, hf-jobs]
+tags: [uv-script, classification, fine-tuning, few-shot, setfit, vllm, structured-outputs, hf-jobs]
 ---
 
 # Classification Scripts
@@ -10,11 +10,20 @@ Text classification on [HF Jobs](https://huggingface.co/docs/huggingface_hub/gui
 | Script | What it does |
 |--------|--------------|
 | [`train-classifier.py`](#fine-tune-a-classifier-train-classifierpy) | **Fine-tune** an encoder into a classifier (default: [LFM2.5-Encoder-350M](https://huggingface.co/LiquidAI/LFM2.5-Encoder-350M)) and push it to the Hub |
+| [`train-setfit.py`](#few-shot-with-setfit-train-setfitpy) | **Few-shot** train a classifier from 8-64 labels per class with [SetFit](https://github.com/huggingface/setfit) — runs on CPU |
 | [`classify-dataset.py`](#zero-shot-classification-classify-datasetpy) | **Zero-shot** classify a dataset with an instruction LLM (SmolLM3 + vLLM, structured outputs) |
 | `classify-dataset-sglang.py` | Zero-shot variant on SGLang (reasoning-aware `<think>` models) |
 
-Rule of thumb: zero-shot to bootstrap labels or for one-off jobs; fine-tune when you have
-(or have bootstrapped) a few thousand labels and want a small, fast, dedicated model.
+Pick by how many labels you have:
+
+| Labels you have | Use | Hardware |
+|---|---|---|
+| none | `classify-dataset.py` to bootstrap labels, or for one-off jobs | GPU |
+| ~8-64 per class | `train-setfit.py` | CPU |
+| a few thousand | `train-classifier.py` | GPU |
+
+The rungs chain: bootstrap labels with `classify-dataset.py`, review them, then train a small
+dedicated model on what you kept.
 
 ## Fine-tune a classifier (`train-classifier.py`)
 
@@ -64,6 +73,46 @@ metadata on datasets that lack it.
 produces a plain, vLLM-servable model — pair it with
 [`uv-scripts/vllm`](https://huggingface.co/datasets/uv-scripts/vllm)'s
 `classify-dataset.py` for large-scale batch inference with the model you just trained.
+
+## Few-shot with SetFit (`train-setfit.py`)
+
+Trains a [SetFit](https://github.com/huggingface/setfit) classifier from a handful of labelled
+examples per class. SetFit finetunes a sentence-transformer body on contrastive pairs, then fits a
+logistic regression head on the resulting embeddings — no GPU required.
+
+- **Default body**: [`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) (22M), chosen for CPU speed. Swap it with `--body-model`.
+- **Metrics match `train-classifier.py`** (accuracy + macro F1 on a held-out split), so the two rungs are directly comparable.
+- **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
+
+```bash
+# 8 labels per class, on CPU
+hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \
+  https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
+  fancyzhx/ag_news username/ag-news-setfit --num-samples 8
+
+# larger body on a GPU for the accuracy ceiling
+hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
+  https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
+  fancyzhx/ag_news username/ag-news-setfit \
+  --body-model sentence-transformers/paraphrase-mpnet-base-v2
+```
+
+### Measured on `ag_news`
+
+8 labels per class, 500 held-out eval examples, seed 42:
+
+| Body model | Flavor | Training | Accuracy | Macro F1 | Total job |
+|---|---|---|---|---|---|
+| `all-MiniLM-L6-v2` (22M) | `cpu-basic` | 204s | 0.826 | 0.819 | 285s |
+| `paraphrase-mpnet-base-v2` (110M) | `t4-small` | 32s | 0.862 | 0.857 | 205s |
+| `paraphrase-mpnet-base-v2` (110M) | `cpu-basic` | 915s | — | — | 1015s |
+
+Single seed on one dataset. Few-shot results vary substantially with which examples get sampled,
+so treat these as indicative — SetFit's own benchmarks report mean and standard deviation across
+several seeds.
+
+> **Note**: a SetFit model is a sentence-transformer body plus a scikit-learn head. Load it with
+> `SetFitModel.from_pretrained(repo)`, not `AutoModelForSequenceClassification`.
 
 ---
 

--- a/classification/README.md
+++ b/classification/README.md
@@ -81,6 +81,8 @@ examples per class. SetFit finetunes a sentence-transformer body on contrastive 
 logistic regression head on the resulting embeddings — no GPU required.
 
 - **Default body**: [`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) (22M), chosen for CPU speed. Swap it with `--body-model`.
+- **Evaluation split** follows the same precedence as `train-classifier.py`: `--eval-split` if given, else `validation`, else `test`, else a stratified carve-out of `--eval-fraction` from train.
+- **Single-label only.** A multi-label column exits with a pointer to `train-classifier.py`.
 - **Metrics match `train-classifier.py`** (accuracy + macro F1 on a held-out split), so the two rungs are directly comparable.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
 
@@ -99,17 +101,18 @@ hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
 
 ### Measured on `ag_news`
 
-8 labels per class, 500 held-out eval examples, seed 42:
+8 labels per class, 500 examples from the `test` split, seed 42:
 
 | Body model | Flavor | Training | Accuracy | Macro F1 | Total job |
 |---|---|---|---|---|---|
-| `all-MiniLM-L6-v2` (22M) | `cpu-basic` | 204s | 0.826 | 0.819 | 285s |
-| `paraphrase-mpnet-base-v2` (110M) | `t4-small` | 32s | 0.862 | 0.857 | 205s |
-| `paraphrase-mpnet-base-v2` (110M) | `cpu-basic` | 915s | — | — | 1015s |
+| `all-MiniLM-L6-v2` (22M) | `cpu-basic` | 118s | 0.804 | 0.807 | 193s |
+| `paraphrase-mpnet-base-v2` (110M) | `t4-small` | 20s | 0.788 | 0.792 | 129s |
+| `paraphrase-mpnet-base-v2` (110M) | `cpu-basic` | 915s | not measured | | 1015s |
 
-Single seed on one dataset. Few-shot results vary substantially with which examples get sampled,
-so treat these as indicative — SetFit's own benchmarks report mean and standard deviation across
-several seeds.
+**These are single-seed numbers and do not rank the two models.** The 1.6pp difference is well
+inside the run-to-run variation of 8-example-per-class training — SetFit's own benchmarks report
+mean and standard deviation across ten seeds for exactly this reason. MiniLM is the default
+because it makes the CPU path practical, not because it scored higher here.
 
 > **Note**: a SetFit model is a sentence-transformer body plus a scikit-learn head. Load it with
 > `SetFitModel.from_pretrained(repo)`, not `AutoModelForSequenceClassification`.

--- a/classification/README.md
+++ b/classification/README.md
@@ -92,6 +92,7 @@ training settings work on either; the recipe uses the available accelerator auto
 - **Every run reports a majority baseline.** The run warns when accuracy fails to beat it, or the gain is below five percentage points. That fixed threshold is a review heuristic, not a measured noise level or significance test.
 - **It estimates training time before starting.** The script times forward/backward passes on actual texts and hardware, then refuses training projected above `--max-minutes` (default 60). Setup, evaluation and upload take additional time. A measurement error can skip this guard; use Jobs `--timeout` to enforce a wall-clock limit.
 - **Rows with missing or blank labels or texts are dropped**, with a count. Missing labels include `ClassLabel`'s `-1` sentinel and numeric NaN; plain integer `-1` remains a valid class. Splits with no usable labelled text, fewer than two observed training classes, and missing or non-string text columns exit before model loading.
+- **`--private` verifies the output repository is private before training.** If the destination already exists publicly, choose a new repo or change its visibility first.
 
 ```bash
 # 8 labels per class, on CPU
@@ -104,6 +105,19 @@ hf jobs uv run --flavor t4-small --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit-gpu --num-samples 8
 ```
+
+### Choosing another body or longer context
+
+`--body-model` accepts a Sentence Transformer checkpoint. Set `--max-seq-length` within that
+model's supported context window; increasing it cannot extend a model's native limit or restore
+text already shortened during dataset preparation. Longer sequences can need a smaller
+`--batch-size` or more GPU memory. The recipe measures training cost on the selected hardware.
+
+Follow the body's task-prefix instructions when preparing inputs. For example,
+[`nomic-ai/modernbert-embed-base`](https://huggingface.co/nomic-ai/modernbert-embed-base)
+uses Nomic's task prefixes: classification inputs should begin with `classification: `.
+Include the same prefix during training, evaluation and inference. The recipe does not add it
+automatically. Retain the original texts and the preprocessing details with the model.
 
 ### Measured
 

--- a/classification/README.md
+++ b/classification/README.md
@@ -10,7 +10,7 @@ Text classification on [HF Jobs](https://huggingface.co/docs/huggingface_hub/gui
 | Script | What it does |
 |--------|--------------|
 | [`train-classifier.py`](#fine-tune-a-classifier-train-classifierpy) | **Fine-tune** an encoder into a classifier (default: [LFM2.5-Encoder-350M](https://huggingface.co/LiquidAI/LFM2.5-Encoder-350M)) and push it to the Hub |
-| [`train-setfit.py`](#few-shot-with-setfit-train-setfitpy) | **Few-shot** train a classifier from 8-64 labels per class with [SetFit](https://github.com/huggingface/setfit) — runs on CPU |
+| [`train-setfit.py`](#few-shot-with-setfit-train-setfitpy) | **Few-shot** train a classifier from 8-64 labels per class with [SetFit](https://github.com/huggingface/setfit) — runs on CPU or GPU |
 | [`classify-dataset.py`](#zero-shot-classification-classify-datasetpy) | **Zero-shot** classify a dataset with an instruction LLM (SmolLM3 + vLLM, structured outputs) |
 | `classify-dataset-sglang.py` | Zero-shot variant on SGLang (reasoning-aware `<think>` models) |
 
@@ -19,7 +19,7 @@ Pick by how many labels you have:
 | Labels you have | Use | Hardware |
 |---|---|---|
 | none | `classify-dataset.py` to bootstrap labels, or for one-off jobs | GPU |
-| ~8-64 per class | `train-setfit.py` | CPU |
+| ~8-64 per class | `train-setfit.py` | CPU supported; GPU for faster training |
 | a few thousand | `train-classifier.py` | GPU |
 
 The rungs chain: bootstrap labels with `classify-dataset.py`, review them, then train a small
@@ -78,7 +78,11 @@ produces a plain, vLLM-servable model — pair it with
 
 Trains a [SetFit](https://github.com/huggingface/setfit) classifier from a handful of labelled
 examples per class. SetFit finetunes a sentence-transformer body on contrastive pairs, then fits a
-logistic regression head on the resulting embeddings — no GPU required.
+logistic regression head on the resulting embeddings.
+
+**Runs on CPU or GPU.** CPU is practical for small few-shot experiments. Use a GPU for faster
+training, particularly with larger models, longer texts or more classes. The same model and
+training settings work on either; the recipe uses the available accelerator automatically.
 
 - **Default body**: [`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) (22M), chosen for CPU speed. Swap it with `--body-model`.
 - **Evaluation split** follows the same precedence as `train-classifier.py`: `--eval-split` if given, else `validation`, else `test`, else a stratified carve-out of `--eval-fraction` from train.
@@ -95,11 +99,10 @@ hf jobs uv run --flavor cpu-basic --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit --num-samples 8
 
-# Try a larger body on a GPU; compare quality on the same evaluation rows
+# Same model and training settings on a GPU for faster training
 hf jobs uv run --flavor t4-small --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
-  fancyzhx/ag_news username/ag-news-setfit \
-  --body-model sentence-transformers/paraphrase-mpnet-base-v2
+  fancyzhx/ag_news username/ag-news-setfit-gpu --num-samples 8
 ```
 
 ### Measured

--- a/classification/README.md
+++ b/classification/README.md
@@ -83,20 +83,20 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **Default body**: [`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) (22M), chosen for CPU speed. Swap it with `--body-model`.
 - **Evaluation split** follows the same precedence as `train-classifier.py`: `--eval-split` if given, else `validation`, else `test`, else a stratified carve-out of `--eval-fraction` from train.
 - **Single-label only.** A multi-label column exits with a pointer to `train-classifier.py`.
-- **Metrics match `train-classifier.py`** (accuracy + macro F1 on a held-out split), so the two rungs are directly comparable.
+- **Metrics match `train-classifier.py`** (accuracy + macro F1). Match evaluation rows and preprocessing when comparing runs.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
-- **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
-- **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
+- **Every run reports a majority baseline.** The run warns when accuracy fails to beat it, or the gain is below five percentage points. That fixed threshold is a review heuristic, not a measured noise level or significance test.
+- **It estimates training time before starting.** The script times forward/backward passes on actual texts and hardware, then refuses training projected above `--max-minutes` (default 60). Setup, evaluation and upload take additional time. A measurement error can skip this guard; use Jobs `--timeout` to enforce a wall-clock limit.
 - **Rows with missing or blank labels or texts are dropped**, with a count. Missing labels include `ClassLabel`'s `-1` sentinel and numeric NaN; plain integer `-1` remains a valid class. Splits with no usable labelled text, fewer than two observed training classes, and missing or non-string text columns exit before model loading.
 
 ```bash
 # 8 labels per class, on CPU
-hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \
+hf jobs uv run --flavor cpu-basic --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit --num-samples 8
 
-# larger body on a GPU for the accuracy ceiling
-hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
+# Try a larger body on a GPU; compare quality on the same evaluation rows
+hf jobs uv run --flavor t4-small --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit \
   --body-model sentence-transformers/paraphrase-mpnet-base-v2
@@ -119,22 +119,23 @@ substantially with which examples happen to get sampled; SetFit's own benchmarks
 standard deviation across ten seeds for exactly this reason. Run your own task before trusting
 any of these numbers.
 
-`emotion` is the honest counter-example: six overlapping affect classes are hard from 8 examples
-each, and swapping the body barely moved it (`bge-small` 0.418, `paraphrase-mpnet-base-v2` 0.410).
-SetFit's docs report **0.591 on this dataset with no labels at all**, using synthetic examples
-generated from the class names — so when classes are semantically well-named but hard to separate
-from a handful of samples, the zero-shot route may beat few-shot.
+### Compare more than the majority baseline
 
-### The majority class is the lower floor
+The `emotion` run reached **0.370** accuracy against a **0.352** majority baseline. Other
+single-seed body-model runs reached 0.418 (`bge-small`) and 0.410 (`paraphrase-mpnet-base-v2`).
+These results call for further evaluation; they do not establish a limit on the task or method.
 
-`dair-ai/emotion` is the cautionary case. This script scores **0.370** on it; the majority class
-is **0.352**, so a naive "did it beat the baseline" check passes. SetFit's own documentation
-reports **0.591 on the same dataset with no labels at all**, using examples templated from the
-class names. Swapping the body barely moves it (`bge-small` 0.418, `paraphrase-mpnet-base-v2`
-0.410), so this is the task resisting few-shot learning, not the model being wrong.
+SetFit's [zero-shot guide](https://huggingface.co/docs/setfit/how_to/zero_shot) reports **0.591**
+on emotion using BGE and training examples templated from the class names. It uses a different
+evaluation setup from the table above, so this is motivation for a matched comparison rather
+than a controlled comparison with this recipe. Templated training needs no labeled documents,
+but still uses compute.
 
-The lesson generalises: before spending labels, measure what free costs. When classes are
-well-named but semantically entangled, zero-shot can win outright.
+For your task, compare with a simple baseline such as TF-IDF plus logistic regression using
+the same training and evaluation rows. A zero-shot comparison can also be useful when class
+names describe the task well. Use repeated seeds and appropriate task metrics before drawing
+conclusions from small accuracy differences. This recipe trains and evaluates a supervised
+classifier; built-in templated zero-shot training is a separate possible extension.
 
 ### Real-world data: a worked failure
 
@@ -146,11 +147,12 @@ produces no score:
   comparable to anything published.
 - **~9.5% of rows have a blank `party`**, which without the drop trains an `""` class.
 - **28 parties after cleaning, nine of which cannot supply 8 examples** (`Respect` 4,
-  `Independent SDP` 2, `Change UK` 1). The few-shot framing does not hold at any budget.
+  `Independent SDP` 2, `Change UK` 1). The requested eight-example budget cannot be met for those classes.
 - **1,878 steps at ~11s/step on CPU** — the script refuses it, projecting well past an hour.
 
-The model card discloses the first three automatically, so a run on messy data cannot quietly
-report a clean-looking number.
+On completed runs, the model card discloses a carved evaluation split, per-class training counts
+and classes below the requested sample count. Dropped-row counts and measured truncation are
+reported in the logs; retain those logs alongside the model when documenting data preparation.
 
 ### Many classes: watch the pair count
 
@@ -165,8 +167,9 @@ script logs the estimate before training starts:
 | banking77 (77 classes x 8) | `undersampling` | 4,312 | 270 |
 
 At 77 classes the default would take roughly 15 hours on `cpu-basic`; `--sampling-strategy
-undersampling` finished in 18 seconds on a T4. Above 5,000 estimated steps the script warns and
-names the cheaper alternative.
+undersampling` finished in 18 seconds on a T4 in the recorded run. The script reports the pair
+and step counts, then measures step time to check `--max-minutes`. When it refuses training,
+it suggests undersampling where applicable and estimates whether that would fit the budget.
 
 > **Note**: a SetFit model is a sentence-transformer body plus a scikit-learn head. Load it with
 > `SetFitModel.from_pretrained(repo)`, not `AutoModelForSequenceClassification`.

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -1,0 +1,297 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "setfit>=1.2.0",
+#     "datasets>=4.0.0",
+#     "scikit-learn",
+#     "huggingface-hub",
+# ]
+# ///
+"""
+Few-shot text classification with SetFit — train on 8-64 labelled examples per class, on CPU.
+
+SetFit fine-tunes a sentence-transformer body with contrastive pairs, then fits a logistic
+regression head on the embeddings. With a handful of examples per class it reaches a useful
+classifier in minutes without a GPU, which makes it the cheap middle rung between zero-shot
+LLM labelling and a full encoder fine-tune (`train-classifier.py`).
+
+Run on HF Jobs (cpu-basic is enough; no GPU needed):
+
+    hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \\
+        https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \\
+        fancyzhx/ag_news username/ag-news-setfit \\
+        --num-samples 8
+
+Metrics match `train-classifier.py` (accuracy + macro F1 on a held-out split) so the two are
+directly comparable at equal eval settings.
+
+NOTE: a SetFit model is a sentence-transformer body plus a scikit-learn head. It loads with
+`SetFitModel.from_pretrained(repo)`, NOT `AutoModelForSequenceClassification`.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+# tqdm reads TQDM_DISABLE when it is imported, so this must be set before any third-party import
+# pulls tqdm in — setting it later has no effect. Jobs logs have no TTY, so progress bars arrive
+# as hundreds of carriage-return frames that bury the lines you actually want.
+os.environ.setdefault("TQDM_DISABLE", "1")
+
+import datasets
+import torch
+import transformers
+from datasets import Dataset, load_dataset
+from huggingface_hub import ModelCard, login
+from huggingface_hub.utils import disable_progress_bars
+from setfit import SetFitModel, Trainer, TrainingArguments, sample_dataset
+from sklearn.metrics import accuracy_score, f1_score
+
+
+
+def configure_logging() -> logging.Logger:
+    """Keep Jobs logs readable.
+
+    `basicConfig(level=INFO)` sets the ROOT logger, which switches on every library's INFO
+    output — on Jobs that means one line per HTTP request. Root stays at WARNING here and only
+    this script's logger is verbose. Progress bars are disabled because Jobs logs have no TTY:
+    tqdm's carriage-return frames arrive as hundreds of near-identical lines.
+    """
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    for noisy in ("httpx", "urllib3", "filelock", "huggingface_hub", "sentence_transformers"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    disable_progress_bars()
+    transformers.utils.logging.disable_progress_bar()
+    if hasattr(datasets, "disable_progress_bars"):
+        datasets.disable_progress_bars()
+
+    script_logger = logging.getLogger("train-setfit")
+    script_logger.setLevel(logging.INFO)
+    return script_logger
+
+
+logger = configure_logging()
+
+# MiniLM-L6 trains ~4.4x faster than paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for
+# 8 examples/class on ag_news) for 3.6pp less accuracy (0.826 vs 0.862). The CPU-first default
+# matters more here than the ceiling; pass --body-model with a GPU flavor for the ceiling.
+DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:
+    """Return human-readable class names, falling back to stringified label values."""
+    feature = dataset.features.get(label_column)
+    if hasattr(feature, "names"):
+        return list(feature.names)
+    distinct = sorted(set(dataset[label_column]))
+    return [str(value) for value in distinct]
+
+
+def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction, seed):
+    """Load the train split, and either the named eval split or a carved-out fraction."""
+    train_data = load_dataset(dataset_id, config, split=train_split)
+
+    if eval_split:
+        eval_data = load_dataset(dataset_id, config, split=eval_split)
+        return train_data, eval_data
+
+    logger.info("No --eval-split given; carving %.0f%% off the train split.", eval_fraction * 100)
+    parts = train_data.train_test_split(test_size=eval_fraction, seed=seed)
+    return parts["train"], parts["test"]
+
+
+def evaluate(model, eval_data, text_column, label_column, label_names) -> dict:
+    """Predict on the eval set and report the same metrics as train-classifier.py."""
+    texts = eval_data[text_column]
+    gold_raw = list(eval_data[label_column])
+
+    # The model was loaded with `labels=`, so it predicts label NAMES, while a ClassLabel column
+    # holds integer indices. Normalise the gold side to names so both sides are the same type.
+    gold = [label_names[value] if isinstance(value, int) else value for value in gold_raw]
+
+    started = time.time()
+    predictions = model.predict(texts)
+    elapsed = time.time() - started
+
+    # SetFit returns a tensor for int labels and a list for string labels.
+    if hasattr(predictions, "tolist"):
+        predictions = predictions.tolist()
+
+    return {
+        "accuracy": round(accuracy_score(gold, predictions), 4),
+        "f1_macro": round(f1_score(gold, predictions, average="macro", zero_division=0), 4),
+        "eval_examples": len(gold),
+        "predict_seconds": round(elapsed, 1),
+    }
+
+
+def build_card(args, label_names, metrics, train_size, train_seconds) -> str:
+    """Model card following the uv-scripts conventions (org credit, Jobs claim gated on JOB_ID)."""
+    on_jobs = os.environ.get("JOB_ID") is not None
+    provenance = (
+        "Produced on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/jobs) "
+        "with [`uv-scripts/classification`](https://huggingface.co/datasets/uv-scripts/classification)."
+        if on_jobs
+        else "Produced with [`uv-scripts/classification`](https://huggingface.co/datasets/uv-scripts/classification)."
+    )
+    metric_lines = "\n".join(
+        f"| {name} | {value} |" for name, value in metrics.items()
+    )
+    return f"""---
+tags:
+- setfit
+- text-classification
+- few-shot
+- uv-script
+{"- hf-jobs" if on_jobs else ""}
+library_name: setfit
+base_model: {args.body_model}
+---
+
+# {args.output_repo.split("/")[-1]}
+
+Few-shot text classifier trained with [SetFit](https://github.com/huggingface/setfit) on
+**{args.num_samples} examples per class** ({train_size} training examples total) from
+[`{args.input_dataset}`](https://huggingface.co/datasets/{args.input_dataset}).
+
+{provenance}
+
+## Results
+
+| Metric | Value |
+|---|---|
+{metric_lines}
+| training seconds | {round(train_seconds, 1)} |
+
+## Labels
+
+{", ".join(f"`{name}`" for name in label_names)}
+
+## Use it
+
+```python
+from setfit import SetFitModel
+
+model = SetFitModel.from_pretrained("{args.output_repo}")
+model.predict(["some text to classify"])
+```
+
+## Reproduce
+
+```bash
+hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \\
+  https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \\
+  {args.input_dataset} {args.output_repo} --num-samples {args.num_samples}
+```
+"""
+
+
+def main(args) -> None:
+    token = args.hf_token or os.environ.get("HF_TOKEN")
+    if not token:
+        sys.exit("No HF token. Pass --hf-token or run with --secrets HF_TOKEN.")
+    login(token=token)
+
+    logger.info("Loading %s", args.input_dataset)
+    train_pool, eval_data = split_train_eval(
+        args.input_dataset,
+        args.dataset_config,
+        args.train_split,
+        args.eval_split,
+        args.eval_fraction,
+        args.seed,
+    )
+
+    label_names = resolve_label_names(train_pool, args.label_column)
+    logger.info("Found %d classes: %s", len(label_names), label_names)
+
+    if args.max_eval_samples and len(eval_data) > args.max_eval_samples:
+        eval_data = eval_data.shuffle(seed=args.seed).select(range(args.max_eval_samples))
+        logger.info("Capped eval set at %d examples.", args.max_eval_samples)
+
+    train_data = sample_dataset(
+        train_pool, label_column=args.label_column, num_samples=args.num_samples, seed=args.seed
+    )
+    logger.info("Sampled %d training examples (%d per class).", len(train_data), args.num_samples)
+
+    logger.info("Loading body model %s", args.body_model)
+    model = SetFitModel.from_pretrained(args.body_model, labels=label_names)
+    model.model_body.max_seq_length = args.max_seq_length
+
+    # SetFit picks the accelerator itself; report what it chose so a run's logs are self-describing.
+    if torch.cuda.is_available():
+        logger.info("DEVICE: cuda (%s)", torch.cuda.get_device_name(0))
+    else:
+        logger.info("DEVICE: cpu")
+    logger.info("DEVICE: body model is on %s", model.model_body.device)
+
+    training_args = TrainingArguments(
+        batch_size=args.batch_size,
+        num_epochs=args.num_epochs,
+        seed=args.seed,
+        sampling_strategy=args.sampling_strategy,
+        report_to="none",
+        show_progress_bar=False,
+        logging_steps=10,
+    )
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_data,
+        column_mapping={args.text_column: "text", args.label_column: "label"},
+    )
+
+    started = time.time()
+    trainer.train()
+    train_seconds = time.time() - started
+    logger.info("Training finished in %.1fs", train_seconds)
+
+    metrics = evaluate(model, eval_data, args.text_column, args.label_column, label_names)
+    logger.info("Metrics: %s", metrics)
+
+    logger.info("Pushing to %s (private=%s)", args.output_repo, args.private)
+    model.push_to_hub(args.output_repo, private=args.private, token=token)
+    card = build_card(args, label_names, metrics, len(train_data), train_seconds)
+    ModelCard(card).push_to_hub(args.output_repo, token=token)
+
+    logger.info("Verifying reload from the Hub")
+    reloaded = SetFitModel.from_pretrained(args.output_repo, token=token)
+    sample_texts = eval_data[args.text_column][:4]
+    logger.info("Reloaded predictions: %s", reloaded.predict(sample_texts))
+    logger.info("Done: https://huggingface.co/%s", args.output_repo)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Few-shot text classification with SetFit")
+    parser.add_argument("input_dataset", help="Input dataset ID")
+    parser.add_argument("output_repo", help="Output model repo ID (username/model-name)")
+    parser.add_argument("--body-model", default=DEFAULT_BODY, help=f"Sentence-transformer body (default: {DEFAULT_BODY})")
+    parser.add_argument("--dataset-config", help="Dataset config name")
+    parser.add_argument("--text-column", default="text", help="Text column (default: text)")
+    parser.add_argument("--label-column", default="label", help="Label column (default: label)")
+    parser.add_argument("--train-split", default="train", help="Train split (default: train)")
+    parser.add_argument("--eval-split", help="Eval split (default: carve --eval-fraction off train)")
+    parser.add_argument("--eval-fraction", type=float, default=0.1, help="Eval fraction if no eval split (default: 0.1)")
+    parser.add_argument("--max-eval-samples", type=int, default=2000, help="Cap eval examples (default: 2000)")
+    parser.add_argument("--num-samples", type=int, default=8, help="Labelled examples per class (default: 8)")
+    parser.add_argument("--num-epochs", type=int, default=1, help="Epochs (default: 1)")
+    parser.add_argument("--sampling-strategy", default="oversampling",
+                        choices=["oversampling", "undersampling", "unique"],
+                        help="Contrastive pair sampling (default: oversampling)")
+    parser.add_argument("--batch-size", type=int, default=16, help="Batch size (default: 16)")
+    parser.add_argument("--max-seq-length", type=int, default=256, help="Max sequence length (default: 256)")
+    parser.add_argument("--seed", type=int, default=42, help="Seed (default: 42)")
+    parser.add_argument("--private", action="store_true", help="Make the output model repo private")
+    parser.add_argument("--hf-token", help="HF token (or set HF_TOKEN)")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -210,9 +210,21 @@ def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction,
     # Stratify when the labels are typed, so a rare class cannot vanish from a small carve.
     feature = train_data.features.get(label_column)
     stratify = label_column if isinstance(feature, ClassLabel) else None
-    parts = train_data.train_test_split(
-        test_size=eval_fraction, seed=seed, stratify_by_column=stratify
-    )
+
+    try:
+        parts = train_data.train_test_split(
+            test_size=eval_fraction, seed=seed, stratify_by_column=stratify
+        )
+    except ValueError as error:
+        # Stratification needs at least two members of every class, so it fails on exactly the
+        # singleton classes it is meant to protect. An unstratified split is worse but usable;
+        # crashing is not.
+        logger.warning(
+            "Could not stratify the carve-out (%s). Falling back to an unstratified split — a "
+            "very rare class may be absent from the eval set.",
+            error,
+        )
+        parts = train_data.train_test_split(test_size=eval_fraction, seed=seed)
     return parts["train"], parts["test"]
 
 
@@ -329,10 +341,13 @@ def estimate_training_steps(per_class, batch_size, num_epochs, strategy) -> tupl
     total = sum(counts)
 
     # SetFit's shuffle_combinations defaults to replacement=True, i.e. np.triu_indices(n, 0) —
-    # the DIAGONAL is included, and those `total` self-pairs all count as positive. Verified
-    # against SetFit's own "Num unique pairs" on five runs: 2x4 -> 40, 4x8 -> 528, 2x8 -> 144,
-    # 3x8 -> 384, 77x8 -> 374,528. Negatives are cross-class, so they exclude the diagonal and
-    # must be computed from the combinations WITHOUT it.
+    # the DIAGONAL is included, and those `total` self-pairs all count as positive. Negatives are
+    # cross-class, so they exclude the diagonal and must be computed from the combinations
+    # WITHOUT it. Verified against SetFit's own reported "Num unique pairs", which is the
+    # POST-strategy total, so the strategy matters when reading these:
+    #   oversampling:  2x4 -> 40 · 2x8 -> 144 · 3x8 -> 384 · 4x8 -> 768 · 77x8 -> 374,528
+    #   undersampling: 4x8 -> 288
+    #   unique:        4x8 -> 528
     same_class_pairs = sum(comb(count, 2) for count in counts)
     positive = same_class_pairs + total
     negative = comb(total, 2) - same_class_pairs
@@ -393,6 +408,14 @@ def build_reproduce_command(args) -> str:
         flags.append(f"--max-eval-samples {args.max_eval_samples}")
     if args.eval_fraction != 0.1:
         flags.append(f"--eval-fraction {args.eval_fraction}")
+    # Without these the published command either stops at the refusal gate or publishes to a
+    # different visibility than the run it describes.
+    if args.max_minutes != 60:
+        flags.append(f"--max-minutes {args.max_minutes}")
+    if args.allow_slow_training:
+        flags.append("--allow-slow-training")
+    if args.private:
+        flags.append("--private")
 
     # --num-samples is the defining knob, so always show it even at its default.
     if f"--num-samples {args.num_samples}" not in flags:
@@ -579,7 +602,13 @@ def main(args) -> None:
         logger.info("DEVICE: cpu")
     logger.info("DEVICE: body model is on %s", model.model_body.device)
 
-    warn_on_truncation(model, train_data[args.text_column], args.max_seq_length)
+    # Sample the POOL and the eval set, not the few-shot training slice — that slice can be
+    # as small as 16 texts, and eval documents are truncated at predict time too.
+    warn_on_truncation(
+        model,
+        list(train_pool[args.text_column][:200]) + list(eval_data[args.text_column][:200]),
+        args.max_seq_length,
+    )
 
     projected = project_training_seconds(model, train_data[args.text_column], args.batch_size, steps)
     logger.info("Projected training time: %.0f min (%d steps).", projected / 60, steps)
@@ -588,7 +617,9 @@ def main(args) -> None:
             per_class, args.batch_size, args.num_epochs, "undersampling"
         )
         cheaper_minutes = projected / 60 * cheaper_steps / max(steps, 1)
-        if cheaper_minutes <= args.max_minutes:
+        if args.sampling_strategy == "undersampling":
+            suggestion = "  (already on the cheapest sampling strategy)"
+        elif cheaper_minutes <= args.max_minutes:
             suggestion = (
                 f"  --sampling-strategy undersampling  ->  {cheaper_steps} steps "
                 f"(~{cheaper_minutes:.0f} min, within budget)"
@@ -655,10 +686,6 @@ def main(args) -> None:
     else:
         logger.info("Beats the majority-class floor by %.1f points.", lift * 100)
 
-    logger.warning(
-        "The majority class is the LOWER floor. Before trusting this model, compare it against "
-        "zero-shot with no labels at all — on some tasks that wins outright."
-    )
 
     logger.info("Pushing to %s (private=%s)", args.output_repo, args.private)
     model.push_to_hub(args.output_repo, private=args.private, token=token)

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -5,6 +5,8 @@
 #     "datasets>=4.0.0",
 #     "scikit-learn",
 #     "huggingface-hub",
+#     "torch",
+#     "transformers",
 # ]
 # ///
 """
@@ -34,6 +36,7 @@ import logging
 import os
 import sys
 import time
+from collections import Counter
 
 # tqdm reads TQDM_DISABLE when it is imported, so this must be set before any third-party import
 # pulls tqdm in — setting it later has no effect. Jobs logs have no TTY, so progress bars arrive
@@ -43,8 +46,8 @@ os.environ.setdefault("TQDM_DISABLE", "1")
 import datasets
 import torch
 import transformers
-from datasets import Dataset, load_dataset
-from huggingface_hub import ModelCard, login
+from datasets import ClassLabel, Dataset, Value, load_dataset
+from huggingface_hub import HfApi, ModelCard, login
 from huggingface_hub.utils import disable_progress_bars
 from setfit import SetFitModel, Trainer, TrainingArguments, sample_dataset
 from sklearn.metrics import accuracy_score, f1_score
@@ -79,42 +82,118 @@ def configure_logging() -> logging.Logger:
 
 logger = configure_logging()
 
-# MiniLM-L6 trains ~4.4x faster than paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for
-# 8 examples/class on ag_news) for 3.6pp less accuracy (0.826 vs 0.862). The CPU-first default
-# matters more here than the ceiling; pass --body-model with a GPU flavor for the ceiling.
+# MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
+# paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
+# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788 respectively,
+# a gap well inside single-seed few-shot noise. Pass --body-model to try a larger body.
+SCRIPT_URL = (
+    "https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py"
+)
+
 DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 
-def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:
-    """Return human-readable class names, falling back to stringified label values."""
+def check_label_column(dataset: Dataset, label_column: str) -> None:
+    """Fail early and clearly on a missing or multi-label column."""
+    if label_column not in dataset.column_names:
+        sys.exit(
+            f"Label column '{label_column}' not found. Columns are: {dataset.column_names}. "
+            "Pass --label-column."
+        )
+
+    # A Sequence/list feature carries an inner `feature`; that is the multi-label shape.
     feature = dataset.features.get(label_column)
-    if hasattr(feature, "names"):
+    if getattr(feature, "feature", None) is not None:
+        sys.exit(
+            f"Label column '{label_column}' is multi-label (a list per row). "
+            "train-setfit.py is single-label only — use train-classifier.py, which "
+            "auto-detects multi-label and tunes per-label thresholds."
+        )
+    if isinstance(dataset[label_column][0], list):
+        sys.exit(
+            f"Label column '{label_column}' holds lists (multi-label). "
+            "Use train-classifier.py instead."
+        )
+
+
+def normalise_label_column(dataset: Dataset, label_column: str) -> Dataset:
+    """Make the label column safe for SetFit's positional label mapping.
+
+    SetFit maps an integer prediction through `model.labels` BY POSITION, so integers are only
+    safe when they really are indices — which is true for a ClassLabel column and nothing else.
+    Any other integer column holds arbitrary values (1-indexed, sparse, or negative), so it is
+    stringified and the head learns the label text directly. Without this, a -1/0/1 column
+    decodes through Python's negative indexing and silently mislabels everything while the
+    metrics still look correct.
+    """
+    feature = dataset.features.get(label_column)
+    if isinstance(feature, ClassLabel):
+        return dataset
+    # cast_column, not map: map re-casts its output back to the column's EXISTING feature, so
+    # returning str() from a map over an int64 column silently converts straight back to int64.
+    return dataset.cast_column(label_column, Value("string"))
+
+
+def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:
+    """Return the class names, in the order SetFit should map predictions through."""
+    feature = dataset.features.get(label_column)
+    if isinstance(feature, ClassLabel):
         return list(feature.names)
-    distinct = sorted(set(dataset[label_column]))
-    return [str(value) for value in distinct]
+    return sorted(set(dataset[label_column]))
 
 
-def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction, seed):
-    """Load the train split, and either the named eval split or a carved-out fraction."""
+def pick_eval_split(dataset_id, config, train_split, requested):
+    """Resolve which split to evaluate on, matching train-classifier.py's precedence."""
+    if requested:
+        if requested == train_split:
+            sys.exit(
+                f"--eval-split and --train-split are both '{requested}'. Evaluating on the "
+                "training data would report a meaningless score."
+            )
+        return requested
+
+    # Same auto-detect order as the sibling, so both scripts evaluate on the same split by
+    # default and their reported metrics really are comparable.
+    available = datasets.get_dataset_split_names(dataset_id, config)
+    for candidate in ("validation", "test"):
+        if candidate in available and candidate != train_split:
+            logger.info("Using the '%s' split for evaluation.", candidate)
+            return candidate
+    return None
+
+
+def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction, seed, label_column):
+    """Load the train split, and either the named eval split or a stratified carve-out."""
     train_data = load_dataset(dataset_id, config, split=train_split)
 
     if eval_split:
         eval_data = load_dataset(dataset_id, config, split=eval_split)
         return train_data, eval_data
 
-    logger.info("No --eval-split given; carving %.0f%% off the train split.", eval_fraction * 100)
-    parts = train_data.train_test_split(test_size=eval_fraction, seed=seed)
+    logger.info("No eval split found; carving %.0f%% off the train split.", eval_fraction * 100)
+    # Stratify when the labels are typed, so a rare class cannot vanish from a small carve.
+    feature = train_data.features.get(label_column)
+    stratify = label_column if isinstance(feature, ClassLabel) else None
+    parts = train_data.train_test_split(
+        test_size=eval_fraction, seed=seed, stratify_by_column=stratify
+    )
     return parts["train"], parts["test"]
 
 
 def evaluate(model, eval_data, text_column, label_column, label_names) -> dict:
     """Predict on the eval set and report the same metrics as train-classifier.py."""
-    texts = eval_data[text_column]
+    # None in the text column would crash model.encode after training has already been paid for.
+    texts = [str(text) for text in eval_data[text_column]]
     gold_raw = list(eval_data[label_column])
 
-    # The model was loaded with `labels=`, so it predicts label NAMES, while a ClassLabel column
-    # holds integer indices. Normalise the gold side to names so both sides are the same type.
-    gold = [label_names[value] if isinstance(value, int) else value for value in gold_raw]
+    # The model predicts label NAMES. Decode the gold side using the EVAL set's own feature —
+    # a named --eval-split can order its ClassLabel differently from the train split, and
+    # decoding through train-derived names would silently score against the wrong table.
+    feature = eval_data.features.get(label_column)
+    if isinstance(feature, ClassLabel):
+        gold = [feature.int2str(int(value)) for value in gold_raw]
+    else:
+        gold = [str(value) for value in gold_raw]
 
     started = time.time()
     predictions = model.predict(texts)
@@ -132,7 +211,53 @@ def evaluate(model, eval_data, text_column, label_column, label_names) -> dict:
     }
 
 
-def build_card(args, label_names, metrics, train_size, train_seconds) -> str:
+def build_reproduce_command(args) -> str:
+    """Rebuild the exact invocation, so the card's command produces the card's model.
+
+    Only non-default flags are appended, keeping the command short while staying faithful.
+    """
+    flavor = "t4-small" if torch.cuda.is_available() else "cpu-basic"
+    parts = [
+        f"hf jobs uv run --flavor {flavor} --secrets HF_TOKEN \\",
+        f"  {SCRIPT_URL} \\",
+        f"  {args.input_dataset} {args.output_repo} \\",
+    ]
+
+    flags = []
+    if args.body_model != DEFAULT_BODY:
+        flags.append(f"--body-model {args.body_model}")
+    if args.dataset_config:
+        flags.append(f"--dataset-config {args.dataset_config}")
+    if args.text_column != "text":
+        flags.append(f"--text-column {args.text_column}")
+    if args.label_column != "label":
+        flags.append(f"--label-column {args.label_column}")
+    if args.train_split != "train":
+        flags.append(f"--train-split {args.train_split}")
+    if args.eval_split:
+        flags.append(f"--eval-split {args.eval_split}")
+    if args.num_samples != 8:
+        flags.append(f"--num-samples {args.num_samples}")
+    if args.num_epochs != 1:
+        flags.append(f"--num-epochs {args.num_epochs}")
+    if args.batch_size != 16:
+        flags.append(f"--batch-size {args.batch_size}")
+    if args.max_seq_length != 256:
+        flags.append(f"--max-seq-length {args.max_seq_length}")
+    if args.sampling_strategy != "oversampling":
+        flags.append(f"--sampling-strategy {args.sampling_strategy}")
+    if args.seed != 42:
+        flags.append(f"--seed {args.seed}")
+
+    # --num-samples is the defining knob, so always show it even at its default.
+    if f"--num-samples {args.num_samples}" not in flags:
+        flags.insert(0, f"--num-samples {args.num_samples}")
+
+    parts.append("  " + " ".join(flags))
+    return "\n".join(parts)
+
+
+def build_card(args, label_names, metrics, per_class, train_seconds) -> str:
     """Model card following the uv-scripts conventions (org credit, Jobs claim gated on JOB_ID)."""
     on_jobs = os.environ.get("JOB_ID") is not None
     provenance = (
@@ -141,24 +266,30 @@ def build_card(args, label_names, metrics, train_size, train_seconds) -> str:
         if on_jobs
         else "Produced with [`uv-scripts/classification`](https://huggingface.co/datasets/uv-scripts/classification)."
     )
-    metric_lines = "\n".join(
-        f"| {name} | {value} |" for name, value in metrics.items()
-    )
+
+    tags = ["setfit", "text-classification", "few-shot", "uv-script"]
+    if on_jobs:
+        tags.append("hf-jobs")
+    tag_lines = "\n".join(f"- {tag}" for tag in tags)
+
+    metric_lines = "\n".join(f"| {name} | {value} |" for name, value in metrics.items())
+    train_size = sum(per_class.values())
+    counts = ", ".join(f"`{name}`: {count}" for name, count in per_class.items())
+
     return f"""---
 tags:
-- setfit
-- text-classification
-- few-shot
-- uv-script
-{"- hf-jobs" if on_jobs else ""}
+{tag_lines}
 library_name: setfit
+pipeline_tag: text-classification
 base_model: {args.body_model}
+datasets:
+- {args.input_dataset}
 ---
 
 # {args.output_repo.split("/")[-1]}
 
 Few-shot text classifier trained with [SetFit](https://github.com/huggingface/setfit) on
-**{args.num_samples} examples per class** ({train_size} training examples total) from
+**up to {args.num_samples} examples per class** ({train_size} training examples in total) from
 [`{args.input_dataset}`](https://huggingface.co/datasets/{args.input_dataset}).
 
 {provenance}
@@ -169,6 +300,10 @@ Few-shot text classifier trained with [SetFit](https://github.com/huggingface/se
 |---|---|
 {metric_lines}
 | training seconds | {round(train_seconds, 1)} |
+
+## Training examples per class
+
+{counts}
 
 ## Labels
 
@@ -183,12 +318,13 @@ model = SetFitModel.from_pretrained("{args.output_repo}")
 model.predict(["some text to classify"])
 ```
 
-## Reproduce
+## Reproduction
+
+Produced by [`train-setfit.py`]({SCRIPT_URL}) from
+[`uv-scripts/classification`](https://huggingface.co/datasets/uv-scripts/classification):
 
 ```bash
-hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \\
-  https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \\
-  {args.input_dataset} {args.output_repo} --num-samples {args.num_samples}
+{build_reproduce_command(args)}
 ```
 """
 
@@ -199,27 +335,52 @@ def main(args) -> None:
         sys.exit("No HF token. Pass --hf-token or run with --secrets HF_TOKEN.")
     login(token=token)
 
+    # Prove we can write the output repo BEFORE paying for training. A permissions failure
+    # after trainer.train() costs the whole run and leaves no artifact behind.
+    HfApi(token=token).create_repo(
+        args.output_repo, repo_type="model", private=args.private, exist_ok=True
+    )
+
     logger.info("Loading %s", args.input_dataset)
+    eval_split = pick_eval_split(
+        args.input_dataset, args.dataset_config, args.train_split, args.eval_split
+    )
     train_pool, eval_data = split_train_eval(
         args.input_dataset,
         args.dataset_config,
         args.train_split,
-        args.eval_split,
+        eval_split,
         args.eval_fraction,
         args.seed,
+        args.label_column,
     )
+
+    check_label_column(train_pool, args.label_column)
+    train_pool = normalise_label_column(train_pool, args.label_column)
+    eval_data = normalise_label_column(eval_data, args.label_column)
 
     label_names = resolve_label_names(train_pool, args.label_column)
     logger.info("Found %d classes: %s", len(label_names), label_names)
+    if len(label_names) < 2:
+        sys.exit(f"Only one class found in '{args.label_column}'. A classifier needs two or more.")
 
     if args.max_eval_samples and len(eval_data) > args.max_eval_samples:
         eval_data = eval_data.shuffle(seed=args.seed).select(range(args.max_eval_samples))
         logger.info("Capped eval set at %d examples.", args.max_eval_samples)
 
+    # sample_dataset calls .to_pandas() on the whole pool, which would OOM a cpu-basic job on a
+    # multi-million-row dataset. Capping first keeps the CPU path viable; the cap samples
+    # randomly, so a very rare class can be thinned by it.
+    if args.max_train_pool and len(train_pool) > args.max_train_pool:
+        train_pool = train_pool.shuffle(seed=args.seed).select(range(args.max_train_pool))
+        logger.info("Capped train pool at %d rows before sampling.", args.max_train_pool)
+
     train_data = sample_dataset(
         train_pool, label_column=args.label_column, num_samples=args.num_samples, seed=args.seed
     )
-    logger.info("Sampled %d training examples (%d per class).", len(train_data), args.num_samples)
+    # sample_dataset takes AT MOST num_samples per class, so report what was actually drawn.
+    per_class = dict(sorted(Counter(train_data[args.label_column]).items()))
+    logger.info("Sampled %d training examples; per class: %s", len(train_data), per_class)
 
     logger.info("Loading body model %s", args.body_model)
     model = SetFitModel.from_pretrained(args.body_model, labels=label_names)
@@ -258,7 +419,7 @@ def main(args) -> None:
 
     logger.info("Pushing to %s (private=%s)", args.output_repo, args.private)
     model.push_to_hub(args.output_repo, private=args.private, token=token)
-    card = build_card(args, label_names, metrics, len(train_data), train_seconds)
+    card = build_card(args, label_names, metrics, per_class, train_seconds)
     ModelCard(card).push_to_hub(args.output_repo, token=token)
 
     logger.info("Verifying reload from the Hub")
@@ -277,9 +438,17 @@ def parse_args():
     parser.add_argument("--text-column", default="text", help="Text column (default: text)")
     parser.add_argument("--label-column", default="label", help="Label column (default: label)")
     parser.add_argument("--train-split", default="train", help="Train split (default: train)")
-    parser.add_argument("--eval-split", help="Eval split (default: carve --eval-fraction off train)")
+    parser.add_argument(
+        "--eval-split",
+        help="Eval split. Default: validation, else test, else carve --eval-fraction off "
+             "train. A slice such as train[:10%] is NOT checked for overlap with training.",
+    )
     parser.add_argument("--eval-fraction", type=float, default=0.1, help="Eval fraction if no eval split (default: 0.1)")
     parser.add_argument("--max-eval-samples", type=int, default=2000, help="Cap eval examples (default: 2000)")
+    parser.add_argument(
+        "--max-train-pool", type=int, default=200_000,
+        help="Cap the pool before per-class sampling (default: 200000)",
+    )
     parser.add_argument("--num-samples", type=int, default=8, help="Labelled examples per class (default: 8)")
     parser.add_argument("--num-epochs", type=int, default=1, help="Epochs (default: 1)")
     parser.add_argument("--sampling-strategy", default="oversampling",

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -92,7 +92,8 @@ SCRIPT_URL = (
 NOISE_BAND = 0.05
 
 # Applied to the measured step time. Covers what the measurement omits — optimizer update,
-# pair-batch assembly, data loading — measured at 5% (CPU) and 22% (GPU) against real runs.
+# pair-batch assembly, data loading. Raw shortfall against real runs of the same config:
+# ~5% on cpu-basic (two independent configs agreed) and 37% on t4-small.
 MEASUREMENT_MARGIN = 1.35
 
 
@@ -351,7 +352,7 @@ def measure_step_seconds(model, texts, batch_size: int) -> float:
     return sorted(timings)[1]
 
 
-def project_training_seconds(model, texts, batch_size: int, steps: int, args_max_seq_hint: int) -> float:
+def project_training_seconds(model, texts, batch_size: int, steps: int, max_seq_length: int) -> float:
     """Project total training time from a measured step.
 
     Step count alone cannot bound runtime: measured cost per step ranged from 0.07s (short
@@ -361,11 +362,18 @@ def project_training_seconds(model, texts, batch_size: int, steps: int, args_max
     try:
         measured = measure_step_seconds(model, texts, batch_size)
         # The measurement covers forward+backward, which is most of a step but not all of it: the
-        # optimizer update, pair-batch assembly and data loading are not included. Measured
-        # shortfall against real runs of the same config was 5% on cpu-basic (2.384 vs 2.508) and
-        # 22% on t4-small (0.068 vs 0.0875). MEASUREMENT_MARGIN covers both, because a gate should
-        # err towards over-estimating — the cost of that is an --allow-slow-training flag, while
-        # the cost of under-estimating is the multi-hour job this exists to prevent.
+        # optimizer update, pair-batch assembly and data loading are not included. Raw shortfall
+        # against real runs of the same config, measured AFTER the full-batch fix:
+        #   2-class cpu-basic  8.01 vs 8.41 actual   -5%
+        #   4-class cpu-basic  2.39 vs 2.51 actual   -5%
+        #   4-class t4-small   0.055 vs 0.0875       -37%
+        # The margin leaves CPU over-reading by ~28%, which is the side a refusal gate should err
+        # on, and leaves GPU under-reading by ~15%. That GPU looseness is accepted, but NOT
+        # because GPU runs never approach the budget — 200 classes at 8/class is ~159k steps,
+        # nearly four hours on a T4, so they certainly do. It is accepted because a 15% under-read
+        # only changes the verdict within 15% of the boundary, and the failure there is a job that
+        # runs modestly over the budget the user set, not the multi-hour runaway this exists to
+        # catch. Far from the boundary the answer is the same either way.
         per_step = measured * MEASUREMENT_MARGIN
         logger.info(
             "Measured %.3fs per training step (forward+backward); using %.3fs with margin.",
@@ -377,7 +385,7 @@ def project_training_seconds(model, texts, batch_size: int, steps: int, args_max
         torch.cuda.empty_cache()
         sys.exit(
             f"Out of GPU memory timing a single training step at --batch-size {batch_size} and "
-            f"--max-seq-length {args_max_seq_hint}. Training would fail the same way. Lower "
+            f"--max-seq-length {max_seq_length}. Training would fail the same way. Lower "
             "--batch-size or --max-seq-length, or use a larger flavor."
         )
     except Exception as error:

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -37,6 +37,7 @@ import os
 import sys
 import time
 from collections import Counter
+from math import ceil, comb
 
 # tqdm reads TQDM_DISABLE when it is imported, so this must be set before any third-party import
 # pulls tqdm in — setting it later has no effect. Jobs logs have no TTY, so progress bars arrive
@@ -211,6 +212,30 @@ def evaluate(model, eval_data, text_column, label_column, label_names) -> dict:
     }
 
 
+def estimate_training_steps(per_class, batch_size, num_epochs, strategy) -> tuple[int, int]:
+    """Return (contrastive pairs, optimizer steps) for one run, before any training happens.
+
+    SetFit builds pairs from every combination of training examples, so the count grows with the
+    SQUARE of the training-set size — and the training set is num_samples x number of classes.
+    A 77-class dataset at 8 examples per class is 374k pairs under the default strategy, which
+    is hours of CPU time. Knowing that before the job starts is worth a few lines of arithmetic.
+    """
+    counts = list(per_class.values())
+    total = sum(counts)
+    positive = sum(comb(count, 2) for count in counts)
+    negative = comb(total, 2) - positive
+
+    if strategy == "oversampling":
+        pairs = 2 * max(positive, negative)
+    elif strategy == "undersampling":
+        pairs = 2 * min(positive, negative)
+    else:  # "unique"
+        pairs = positive + negative
+
+    steps = ceil(pairs / batch_size) * num_epochs
+    return pairs, steps
+
+
 def build_reproduce_command(args) -> str:
     """Rebuild the exact invocation, so the card's command produces the card's model.
 
@@ -379,8 +404,31 @@ def main(args) -> None:
         train_pool, label_column=args.label_column, num_samples=args.num_samples, seed=args.seed
     )
     # sample_dataset takes AT MOST num_samples per class, so report what was actually drawn.
-    per_class = dict(sorted(Counter(train_data[args.label_column]).items()))
+    # Keys go through the class names, or a ClassLabel column reports bare indices.
+    counts = sorted(Counter(train_data[args.label_column]).items())
+    feature = train_data.features.get(args.label_column)
+    if isinstance(feature, ClassLabel):
+        per_class = {feature.int2str(int(value)): count for value, count in counts}
+    else:
+        per_class = {str(value): count for value, count in counts}
     logger.info("Sampled %d training examples; per class: %s", len(train_data), per_class)
+
+    pairs, steps = estimate_training_steps(
+        per_class, args.batch_size, args.num_epochs, args.sampling_strategy
+    )
+    logger.info(
+        "Contrastive pairs: %d -> %d optimizer steps (%s).", pairs, steps, args.sampling_strategy
+    )
+    if steps > 5_000 and args.sampling_strategy != "undersampling":
+        _, cheaper = estimate_training_steps(
+            per_class, args.batch_size, args.num_epochs, "undersampling"
+        )
+        logger.warning(
+            "That is a lot of steps. Pair count grows with the SQUARE of the training set, so "
+            "many classes get expensive fast. --sampling-strategy undersampling would need %d "
+            "steps instead; fewer --num-samples or a GPU flavor also help.",
+            cheaper,
+        )
 
     logger.info("Loading body model %s", args.body_model)
     model = SetFitModel.from_pretrained(args.body_model, labels=label_names)

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -33,8 +33,8 @@ NOTE: a SetFit model is a sentence-transformer body plus a scikit-learn head. It
 
 import argparse
 import logging
-import random
 import os
+import random
 import sys
 import time
 from collections import Counter
@@ -53,7 +53,6 @@ from huggingface_hub import HfApi, ModelCard, login
 from huggingface_hub.utils import disable_progress_bars
 from setfit import SetFitModel, Trainer, TrainingArguments, sample_dataset
 from sklearn.metrics import accuracy_score, f1_score
-
 
 
 def configure_logging() -> logging.Logger:
@@ -84,10 +83,6 @@ def configure_logging() -> logging.Logger:
 
 logger = configure_logging()
 
-# MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
-# paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
-# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788 respectively,
-# a gap well inside single-seed few-shot noise. Pass --body-model to try a larger body.
 SCRIPT_URL = (
     "https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py"
 )
@@ -100,6 +95,10 @@ NOISE_BAND = 0.05
 # not derived; see project_training_seconds.
 STEP_COST_FACTOR = 5
 
+# MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
+# paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
+# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788, a gap well
+# inside single-seed few-shot noise. Pass --body-model to try a larger body.
 DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 
@@ -214,7 +213,7 @@ def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction,
     return parts["train"], parts["test"]
 
 
-def evaluate(model, eval_data, text_column, label_column, label_names) -> dict:
+def evaluate(model, eval_data, text_column, label_column) -> dict:
     """Predict on the eval set and report the same metrics as train-classifier.py."""
     # None in the text column would crash model.encode after training has already been paid for.
     texts = [str(text) for text in eval_data[text_column]]
@@ -349,6 +348,14 @@ def build_reproduce_command(args) -> str:
         flags.append(f"--sampling-strategy {args.sampling_strategy}")
     if args.seed != 42:
         flags.append(f"--seed {args.seed}")
+    # These three change which rows are trained on or scored, so a command without them
+    # reproduces a different model and a different number.
+    if args.max_train_pool != 200_000:
+        flags.append(f"--max-train-pool {args.max_train_pool}")
+    if args.max_eval_samples != 2000:
+        flags.append(f"--max-eval-samples {args.max_eval_samples}")
+    if args.eval_fraction != 0.1:
+        flags.append(f"--eval-fraction {args.eval_fraction}")
 
     # --num-samples is the defining knob, so always show it even at its default.
     if f"--num-samples {args.num_samples}" not in flags:
@@ -358,7 +365,7 @@ def build_reproduce_command(args) -> str:
     return "\n".join(parts)
 
 
-def build_card(args, label_names, metrics, per_class, train_seconds) -> str:
+def build_card(args, label_names, metrics, per_class, train_seconds, eval_split) -> str:
     """Model card following the uv-scripts conventions (org credit, Jobs claim gated on JOB_ID)."""
     on_jobs = os.environ.get("JOB_ID") is not None
     provenance = (
@@ -376,6 +383,27 @@ def build_card(args, label_names, metrics, per_class, train_seconds) -> str:
     metric_lines = "\n".join(f"| {name} | {value} |" for name, value in metrics.items())
     train_size = sum(per_class.values())
     counts = ", ".join(f"`{name}`: {count}" for name, count in per_class.items())
+
+    # Disclose the two things that most often make a headline number misleading.
+    caveats = []
+    short = {name: n for name, n in per_class.items() if n < args.num_samples}
+    if short:
+        caveats.append(
+            f"**{len(short)} of {len(per_class)} classes had fewer than {args.num_samples} "
+            f"examples available** ({', '.join(f'`{k}`: {v}' for k, v in short.items())}). "
+            "The few-shot budget was not met for those classes."
+        )
+    if not eval_split:
+        caveats.append(
+            f"**No held-out split existed, so {args.eval_fraction:.0%} was carved out of train.** "
+            "These numbers are not comparable with published results on this dataset."
+        )
+    caveats.append(
+        f"Accuracy is reported against a majority-class baseline of "
+        f"`{metrics['majority_baseline']}`. The majority class is the LOWER floor — zero-shot "
+        "with no labels wins outright on some tasks and is the comparison that matters."
+    )
+    caveat_block = "\n".join(f"- {c}" for c in caveats)
 
     return f"""---
 tags:
@@ -405,6 +433,10 @@ Few-shot text classifier trained with [SetFit](https://github.com/huggingface/se
 ## Training examples per class
 
 {counts}
+
+## Read this before trusting the numbers
+
+{caveat_block}
 
 ## Labels
 
@@ -537,7 +569,6 @@ def main(args) -> None:
             f"or pass --allow-slow-training."
         )
 
-
     training_args = TrainingArguments(
         batch_size=args.batch_size,
         num_epochs=args.num_epochs,
@@ -559,7 +590,7 @@ def main(args) -> None:
     train_seconds = time.time() - started
     logger.info("Training finished in %.1fs", train_seconds)
 
-    metrics = evaluate(model, eval_data, args.text_column, args.label_column, label_names)
+    metrics = evaluate(model, eval_data, args.text_column, args.label_column)
     logger.info("Metrics: %s", metrics)
 
     # Two floors matter, and the majority class is only the lower one. Single-seed few-shot
@@ -592,7 +623,7 @@ def main(args) -> None:
 
     logger.info("Pushing to %s (private=%s)", args.output_repo, args.private)
     model.push_to_hub(args.output_repo, private=args.private, token=token)
-    card = build_card(args, label_names, metrics, per_class, train_seconds)
+    card = build_card(args, label_names, metrics, per_class, train_seconds, eval_split)
     ModelCard(card).push_to_hub(args.output_repo, token=token)
 
     logger.info("Verifying reload from the Hub")

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -38,7 +38,7 @@ import random
 import sys
 import time
 from collections import Counter
-from math import ceil, comb
+from math import ceil, comb, isnan
 
 # tqdm reads TQDM_DISABLE when it is imported, so this must be set before any third-party import
 # pulls tqdm in — setting it later has no effect. Jobs logs have no TTY, so progress bars arrive
@@ -106,6 +106,8 @@ DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 def check_label_column(dataset: Dataset, label_column: str) -> None:
     """Fail early and clearly on a missing or multi-label column."""
+    if not len(dataset):
+        sys.exit("Dataset split is empty. Supply a non-empty labelled split.")
     if label_column not in dataset.column_names:
         sys.exit(
             f"Label column '{label_column}' not found. Columns are: {dataset.column_names}. "
@@ -153,13 +155,18 @@ def drop_unlabelled_rows(dataset: Dataset, label_column: str, split_name: str) -
     right default — an unlabelled row is not a class, and keeping it teaches the model to
     predict "no label".
     """
-    def has_label(example) -> bool:
-        value = example[label_column]
+    feature = dataset.features.get(label_column)
+
+    def has_label(value) -> bool:
         if value is None:
+            return False
+        if isinstance(feature, ClassLabel) and value == -1:
+            return False
+        if isinstance(value, float) and isnan(value):
             return False
         return not (isinstance(value, str) and not value.strip())
 
-    kept = dataset.filter(has_label)
+    kept = dataset.filter(has_label, input_columns=[label_column])
     dropped = len(dataset) - len(kept)
     if dropped:
         logger.warning(
@@ -167,6 +174,26 @@ def drop_unlabelled_rows(dataset: Dataset, label_column: str, split_name: str) -
             dropped, split_name, label_column, len(kept),
         )
     return kept
+
+
+def prepare_split(dataset, text_column, label_column, split_name):
+    """Validate both splits before loading a model or paying for training."""
+    check_label_column(dataset, label_column)
+    if text_column not in dataset.column_names:
+        sys.exit(
+            f"Text column '{text_column}' not found in {split_name}. "
+            f"Columns are: {dataset.column_names}. Pass --text-column."
+        )
+    # Check missing labels before casting: a float NaN otherwise becomes the class "nan".
+    dataset = drop_unlabelled_rows(dataset, label_column, split_name)
+    if not len(dataset):
+        sys.exit(f"No labelled rows remain in {split_name} after removing missing labels.")
+    if any(not isinstance(text, str) or not text.strip() for text in dataset[text_column]):
+        sys.exit(
+            f"Text column '{text_column}' in {split_name} contains null, blank or non-string "
+            "values. Clean the text column before training."
+        )
+    return normalise_label_column(dataset, label_column)
 
 
 def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:
@@ -206,13 +233,18 @@ def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction,
         return train_data, eval_data
 
     logger.info("No eval split found; carving %.0f%% off the train split.", eval_fraction * 100)
-    # Stratify when the labels are typed, so a rare class cannot vanish from a small carve.
-    feature = train_data.features.get(label_column)
-    stratify = label_column if isinstance(feature, ClassLabel) else None
+    check_label_column(train_data, label_column)
+    train_data = drop_unlabelled_rows(train_data, label_column, "train")
+    if len(train_data) < 2:
+        sys.exit("Need at least two labelled rows to carve out an evaluation split.")
+    # Encode plain labels as well, so string/int columns get the same stratification guarantee.
+    train_data = normalise_label_column(train_data, label_column)
+    if not isinstance(train_data.features[label_column], ClassLabel):
+        train_data = train_data.class_encode_column(label_column)
 
     try:
         parts = train_data.train_test_split(
-            test_size=eval_fraction, seed=seed, stratify_by_column=stratify
+            test_size=eval_fraction, seed=seed, stratify_by_column=label_column
         )
     except ValueError as error:
         # Stratification needs at least two members of every class, so it fails on exactly the
@@ -220,7 +252,7 @@ def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction,
         # crashing is not.
         logger.warning(
             "Could not stratify the carve-out (%s). Falling back to an unstratified split — a "
-            "very rare class may be absent from the eval set.",
+            "very rare class may be absent from either split.",
             error,
         )
         parts = train_data.train_test_split(test_size=eval_fraction, seed=seed)
@@ -616,11 +648,8 @@ def main(args) -> None:
         args.label_column,
     )
 
-    check_label_column(train_pool, args.label_column)
-    train_pool = normalise_label_column(train_pool, args.label_column)
-    eval_data = normalise_label_column(eval_data, args.label_column)
-
-    # Cap BEFORE filtering. Both caps are O(1) selects while the blank-label filter is a full
+    # Cap before final validation (a carved split already needed a pass over labels).
+    # Both caps are O(1) selects while the blank-label filter is a full
     # scan, and on a 2.4M-row corpus that ordering was eight minutes of preflight before a single
     # training step. sample_dataset also calls .to_pandas() on whatever pool it is handed, which
     # would OOM a cpu-basic job outright. The cap samples randomly, so a very rare class can be
@@ -632,13 +661,13 @@ def main(args) -> None:
         eval_data = eval_data.shuffle(seed=args.seed).select(range(args.max_eval_samples))
         logger.info("Capped eval set at %d examples.", args.max_eval_samples)
 
-    train_pool = drop_unlabelled_rows(train_pool, args.label_column, "train")
-    eval_data = drop_unlabelled_rows(eval_data, args.label_column, "eval")
+    train_pool = prepare_split(train_pool, args.text_column, args.label_column, "train")
+    eval_data = prepare_split(eval_data, args.text_column, args.label_column, "eval")
 
     label_names = resolve_label_names(train_pool, args.label_column)
     logger.info("Found %d classes: %s", len(label_names), label_names)
-    if len(label_names) < 2:
-        sys.exit(f"Only one class found in '{args.label_column}'. A classifier needs two or more.")
+    if len(set(train_pool[args.label_column])) < 2:
+        sys.exit(f"Fewer than two observed classes in '{args.label_column}'. A classifier needs two or more.")
 
     train_data = sample_dataset(
         train_pool, label_column=args.label_column, num_samples=args.num_samples, seed=args.seed
@@ -648,7 +677,9 @@ def main(args) -> None:
     counts = sorted(Counter(train_data[args.label_column]).items())
     feature = train_data.features.get(args.label_column)
     if isinstance(feature, ClassLabel):
-        per_class = {feature.int2str(int(value)): count for value, count in counts}
+        # Keep the full positional label table, but disclose declared classes with no examples.
+        per_class = dict.fromkeys(label_names, 0)
+        per_class.update({feature.int2str(int(value)): count for value, count in counts})
     else:
         per_class = {str(value): count for value, count in counts}
     logger.info("Sampled %d training examples; per class: %s", len(train_data), per_class)
@@ -782,7 +813,7 @@ def parse_args():
     parser.add_argument(
         "--eval-split",
         help="Eval split. Default: validation, else test, else carve --eval-fraction off "
-             "train. A slice such as train[:10%] is NOT checked for overlap with training.",
+             "train. A slice such as train[:10%%] is NOT checked for overlap with training.",
     )
     parser.add_argument("--eval-fraction", type=float, default=0.1, help="Eval fraction if no eval split (default: 0.1)")
     parser.add_argument("--max-eval-samples", type=int, default=2000, help="Cap eval examples (default: 2000)")

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -91,6 +91,10 @@ SCRIPT_URL = (
 # models on one dataset), so any lift smaller than this is not evidence of anything.
 NOISE_BAND = 0.05
 
+# Applied to the measured step time. Covers what the measurement omits — optimizer update,
+# pair-batch assembly, data loading — measured at 5% (CPU) and 22% (GPU) against real runs.
+MEASUREMENT_MARGIN = 1.35
+
 
 # MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
 # paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
@@ -267,7 +271,10 @@ def warn_on_truncation(model, texts, max_seq_length: int) -> None:
     letting it be discovered in the scores.
     """
     tokenizer = model.model_body.tokenizer
-    sample = list(texts)[:200]
+    # No internal cap: the caller decides the sample, and it deliberately mixes train and eval.
+    # An earlier version re-sliced to the first 200 here, which meant the eval texts appended by
+    # the caller were never actually looked at.
+    sample = list(texts)
     lengths = [
         len(tokenizer.encode(text, truncation=False, add_special_tokens=True)) for text in sample
     ]
@@ -298,9 +305,17 @@ def measure_step_seconds(model, texts, batch_size: int) -> float:
     """
     body = model.model_body
     device = body.device
-    sample = random.sample(list(texts), min(2 * batch_size, len(texts)))
+    pool = list(texts)
+    rng = random.Random(0)
 
-    def one_step() -> None:
+    def draw() -> list:
+        # A real step always sees 2 x batch_size texts because pairs are drawn WITH repetition.
+        # Sampling min(2*batch_size, len(pool)) instead measured a short batch whenever the
+        # few-shot set was smaller than a batch — a 2-class 8-shot run at the default batch size
+        # measured half a step and projected it as a whole one.
+        return rng.choices(pool, k=2 * batch_size)
+
+    def one_step(sample) -> None:
         features = body.tokenize(sample)
         # tokenize() does not return tensors for every key, so move only what can move.
         features = {
@@ -314,13 +329,17 @@ def measure_step_seconds(model, texts, batch_size: int) -> float:
     was_training = body.training
     body.train()
     try:
-        one_step()  # warmup: first pass pays kernel/thread setup, not per-step cost
+        one_step(draw())  # warmup: first pass pays kernel/thread setup, not per-step cost
         timings = []
         for _ in range(3):
+            # Draw a FRESH batch each time. Reusing one sample collapses timing noise but not
+            # batch-composition noise, and padded length drives cost — on a corpus mixing short
+            # interjections with long speeches, one unlucky draw sets the whole estimate.
+            sample = draw()
             if torch.cuda.is_available():
                 torch.cuda.synchronize()  # CUDA is async; without this we time the launch only
             started = time.time()
-            one_step()
+            one_step(sample)
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
             timings.append(time.time() - started)
@@ -332,7 +351,7 @@ def measure_step_seconds(model, texts, batch_size: int) -> float:
     return sorted(timings)[1]
 
 
-def project_training_seconds(model, texts, batch_size: int, steps: int) -> float:
+def project_training_seconds(model, texts, batch_size: int, steps: int, args_max_seq_hint: int) -> float:
     """Project total training time from a measured step.
 
     Step count alone cannot bound runtime: measured cost per step ranged from 0.07s (short
@@ -344,16 +363,27 @@ def project_training_seconds(model, texts, batch_size: int, steps: int) -> float
         # The measurement covers forward+backward, which is most of a step but not all of it: the
         # optimizer update, pair-batch assembly and data loading are not included. Measured
         # shortfall against real runs of the same config was 5% on cpu-basic (2.384 vs 2.508) and
-        # 22% on t4-small (0.068 vs 0.0875). The margin covers both, because a refusal gate should
+        # 22% on t4-small (0.068 vs 0.0875). MEASUREMENT_MARGIN covers both, because a gate should
         # err towards over-estimating — the cost of that is an --allow-slow-training flag, while
         # the cost of under-estimating is the multi-hour job this exists to prevent.
-        per_step = measured * 1.25
+        per_step = measured * MEASUREMENT_MARGIN
         logger.info(
             "Measured %.3fs per training step (forward+backward); using %.3fs with margin.",
             measured, per_step,
         )
+    except torch.cuda.OutOfMemoryError:
+        # A step that will not fit now will not fit in training either. Fail here, cheaply and
+        # clearly, rather than proceeding on a fragmented allocator and OOMing mid-run.
+        torch.cuda.empty_cache()
+        sys.exit(
+            f"Out of GPU memory timing a single training step at --batch-size {batch_size} and "
+            f"--max-seq-length {args_max_seq_hint}. Training would fail the same way. Lower "
+            "--batch-size or --max-seq-length, or use a larger flavor."
+        )
     except Exception as error:
-        # Never let the guard's own failure block a legitimate run.
+        # Any other failure of the guard itself must not block a legitimate run.
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
         logger.warning("Could not time a training step (%s); skipping the time budget.", error)
         return 0.0
     return per_step * steps
@@ -640,7 +670,9 @@ def main(args) -> None:
         args.max_seq_length,
     )
 
-    projected = project_training_seconds(model, train_data[args.text_column], args.batch_size, steps)
+    projected = project_training_seconds(
+        model, train_data[args.text_column], args.batch_size, steps, args.max_seq_length
+    )
     if projected:
         logger.info("Projected training time: %.0f min (%d steps).", projected / 60, steps)
     if projected and projected / 60 > args.max_minutes and not args.allow_slow_training:

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -91,12 +91,6 @@ SCRIPT_URL = (
 # models on one dataset), so any lift smaller than this is not evidence of anything.
 NOISE_BAND = 0.05
 
-# Training-step cost as a multiple of encoding the same texts — measured, not derived, and
-# device-dependent because GPU encodes are dominated by launch overhead rather than compute.
-# CPU: predicted 1.50 s/step at factor 3 against 2.42 actual -> 4.8. GPU: factor 5 projected
-# 31 min against 17.7 actual -> 2.9. See project_training_seconds.
-STEP_COST_FACTOR_CPU = 5
-STEP_COST_FACTOR_GPU = 3
 
 # MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
 # paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
@@ -290,42 +284,78 @@ def warn_on_truncation(model, texts, max_seq_length: int) -> None:
     )
 
 
-def project_training_seconds(model, texts, batch_size: int, steps: int) -> float:
-    """Time real encodes on real texts, then project the whole run.
+def measure_step_seconds(model, texts, batch_size: int) -> float:
+    """Time a real forward+backward on real texts, on the hardware that will train.
 
-    Step count alone cannot bound runtime: across measured runs one step ranged from 0.07s (short
-    utterances on a T4) to 11.2s (long parliamentary speeches on CPU), a 160x spread driven by
-    hardware and document length. A 2,055-step job cleared a 5,000-step budget and then ran for
-    six hours. So measure.
+    Earlier versions timed an ENCODE and multiplied by a constant standing in for the backward
+    pass. That constant had to be fitted per device (5 on CPU, 3 on GPU) and each value rested on
+    a single observation — the same one-datapoint reasoning that produced two other wrong guards
+    today. A training step is a forward and a backward over 2 x batch_size texts, so time exactly
+    that instead and delete the constant.
 
-    Two things the first version of this got wrong, both worth six times the answer:
-    the FIRST encode pays torch warmup and thread setup, and taking texts[:n] samples whatever
-    happens to be at the top of the corpus. Warm up first, then time a random draw.
-
-    A training step pushes batch_size PAIRS (2 x batch_size texts) through forward and backward.
-    Theory says backward is about twice forward, giving a factor of three — but measured against
-    a real run (ag_news, MiniLM, cpu-basic: predicted 1.50 s/step, actual 2.42) that under-reads
-    by nearly 40%. STEP_COST_FACTOR is set from that measurement, and deliberately rounded up:
-    this is a refusal gate, so over-estimating merely prompts --allow-slow-training, while
-    under-estimating waves through the six-hour job the gate exists to stop.
+    The loss here is a stand-in, not SetFit's CoSENTLoss: cost is dominated by the transformer
+    forward and backward over the batch, not by the scalar reduction on top.
     """
-    pool = list(texts)
-    sample_size = min(max(2 * batch_size, 2), len(pool))
-    rng = random.Random(0)
-    warmup = rng.sample(pool, sample_size)
-    timed = rng.sample(pool, sample_size)
+    body = model.model_body
+    device = body.device
+    sample = random.sample(list(texts), min(2 * batch_size, len(texts)))
 
-    # Discarded: the first encode is dominated by one-off setup, not by the texts.
-    model.model_body.encode(warmup, batch_size=batch_size, show_progress_bar=False)
+    def one_step() -> None:
+        features = body.tokenize(sample)
+        # tokenize() does not return tensors for every key, so move only what can move.
+        features = {
+            key: value.to(device) if hasattr(value, "to") else value
+            for key, value in features.items()
+        }
+        embeddings = body(features)["sentence_embedding"]
+        embeddings.pow(2).mean().backward()
+        body.zero_grad(set_to_none=True)
 
-    started = time.time()
-    model.model_body.encode(timed, batch_size=batch_size, show_progress_bar=False)
-    encode_seconds = time.time() - started
+    was_training = body.training
+    body.train()
+    try:
+        one_step()  # warmup: first pass pays kernel/thread setup, not per-step cost
+        timings = []
+        for _ in range(3):
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()  # CUDA is async; without this we time the launch only
+            started = time.time()
+            one_step()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            timings.append(time.time() - started)
+    finally:
+        body.zero_grad(set_to_none=True)
+        if not was_training:
+            body.eval()
 
-    factor = STEP_COST_FACTOR_GPU if torch.cuda.is_available() else STEP_COST_FACTOR_CPU
-    per_step = encode_seconds * factor
-    logger.info("Measured %.2fs to encode %d texts -> ~%.1fs per step.",
-                encode_seconds, sample_size, per_step)
+    return sorted(timings)[1]
+
+
+def project_training_seconds(model, texts, batch_size: int, steps: int) -> float:
+    """Project total training time from a measured step.
+
+    Step count alone cannot bound runtime: measured cost per step ranged from 0.07s (short
+    utterances on a T4) to 11.2s (long speeches on CPU), a 160x spread driven by hardware and
+    document length. A 2,055-step job cleared a 5,000-step budget and then ran for six hours.
+    """
+    try:
+        measured = measure_step_seconds(model, texts, batch_size)
+        # The measurement covers forward+backward, which is most of a step but not all of it: the
+        # optimizer update, pair-batch assembly and data loading are not included. Measured
+        # shortfall against real runs of the same config was 5% on cpu-basic (2.384 vs 2.508) and
+        # 22% on t4-small (0.068 vs 0.0875). The margin covers both, because a refusal gate should
+        # err towards over-estimating — the cost of that is an --allow-slow-training flag, while
+        # the cost of under-estimating is the multi-hour job this exists to prevent.
+        per_step = measured * 1.25
+        logger.info(
+            "Measured %.3fs per training step (forward+backward); using %.3fs with margin.",
+            measured, per_step,
+        )
+    except Exception as error:
+        # Never let the guard's own failure block a legitimate run.
+        logger.warning("Could not time a training step (%s); skipping the time budget.", error)
+        return 0.0
     return per_step * steps
 
 
@@ -611,8 +641,9 @@ def main(args) -> None:
     )
 
     projected = project_training_seconds(model, train_data[args.text_column], args.batch_size, steps)
-    logger.info("Projected training time: %.0f min (%d steps).", projected / 60, steps)
-    if projected / 60 > args.max_minutes and not args.allow_slow_training:
+    if projected:
+        logger.info("Projected training time: %.0f min (%d steps).", projected / 60, steps)
+    if projected and projected / 60 > args.max_minutes and not args.allow_slow_training:
         _, cheaper_steps = estimate_training_steps(
             per_class, args.batch_size, args.num_epochs, "undersampling"
         )

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -33,6 +33,7 @@ NOTE: a SetFit model is a sentence-transformer body plus a scikit-learn head. It
 
 import argparse
 import logging
+import random
 import os
 import sys
 import time
@@ -91,6 +92,14 @@ SCRIPT_URL = (
     "https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py"
 )
 
+# Single-seed few-shot accuracy moves by roughly this much on its own (measured across body
+# models on one dataset), so any lift smaller than this is not evidence of anything.
+NOISE_BAND = 0.05
+
+# Training-step cost as a multiple of encoding the same texts. Calibrated on a measured run,
+# not derived; see project_training_seconds.
+STEP_COST_FACTOR = 5
+
 DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 
@@ -133,6 +142,30 @@ def normalise_label_column(dataset: Dataset, label_column: str) -> Dataset:
     # cast_column, not map: map re-casts its output back to the column's EXISTING feature, so
     # returning str() from a map over an int64 column silently converts straight back to int64.
     return dataset.cast_column(label_column, Value("string"))
+
+
+def drop_unlabelled_rows(dataset: Dataset, label_column: str, split_name: str) -> Dataset:
+    """Remove rows whose label is missing or blank.
+
+    Real-world catalogue data carries missing values, and a blank string is silently a valid
+    class name: biglam/hansard_speech trains a "" party class unless this runs. Dropping is the
+    right default — an unlabelled row is not a class, and keeping it teaches the model to
+    predict "no label".
+    """
+    def has_label(example) -> bool:
+        value = example[label_column]
+        if value is None:
+            return False
+        return not (isinstance(value, str) and not value.strip())
+
+    kept = dataset.filter(has_label)
+    dropped = len(dataset) - len(kept)
+    if dropped:
+        logger.warning(
+            "Dropped %d %s rows with a missing or blank '%s' (%d remain).",
+            dropped, split_name, label_column, len(kept),
+        )
+    return kept
 
 
 def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:
@@ -204,12 +237,55 @@ def evaluate(model, eval_data, text_column, label_column, label_names) -> dict:
     if hasattr(predictions, "tolist"):
         predictions = predictions.tolist()
 
+    # The majority-class rate is the floor any classifier must clear to be worth having. Without
+    # it a number like 0.37 reads as "a model"; against a 0.35 floor it reads as "nothing learned".
+    majority = Counter(gold).most_common(1)[0][1] / len(gold)
+
     return {
         "accuracy": round(accuracy_score(gold, predictions), 4),
+        "majority_baseline": round(majority, 4),
         "f1_macro": round(f1_score(gold, predictions, average="macro", zero_division=0), 4),
         "eval_examples": len(gold),
         "predict_seconds": round(elapsed, 1),
     }
+
+
+def project_training_seconds(model, texts, batch_size: int, steps: int) -> float:
+    """Time real encodes on real texts, then project the whole run.
+
+    Step count alone cannot bound runtime: across measured runs one step ranged from 0.07s (short
+    utterances on a T4) to 11.2s (long parliamentary speeches on CPU), a 160x spread driven by
+    hardware and document length. A 2,055-step job cleared a 5,000-step budget and then ran for
+    six hours. So measure.
+
+    Two things the first version of this got wrong, both worth six times the answer:
+    the FIRST encode pays torch warmup and thread setup, and taking texts[:n] samples whatever
+    happens to be at the top of the corpus. Warm up first, then time a random draw.
+
+    A training step pushes batch_size PAIRS (2 x batch_size texts) through forward and backward.
+    Theory says backward is about twice forward, giving a factor of three — but measured against
+    a real run (ag_news, MiniLM, cpu-basic: predicted 1.50 s/step, actual 2.42) that under-reads
+    by nearly 40%. STEP_COST_FACTOR is set from that measurement, and deliberately rounded up:
+    this is a refusal gate, so over-estimating merely prompts --allow-slow-training, while
+    under-estimating waves through the six-hour job the gate exists to stop.
+    """
+    pool = list(texts)
+    sample_size = min(max(2 * batch_size, 2), len(pool))
+    rng = random.Random(0)
+    warmup = rng.sample(pool, sample_size)
+    timed = rng.sample(pool, sample_size)
+
+    # Discarded: the first encode is dominated by one-off setup, not by the texts.
+    model.model_body.encode(warmup, batch_size=batch_size, show_progress_bar=False)
+
+    started = time.time()
+    model.model_body.encode(timed, batch_size=batch_size, show_progress_bar=False)
+    encode_seconds = time.time() - started
+
+    per_step = encode_seconds * STEP_COST_FACTOR
+    logger.info("Measured %.2fs to encode %d texts -> ~%.1fs per step.",
+                encode_seconds, sample_size, per_step)
+    return per_step * steps
 
 
 def estimate_training_steps(per_class, batch_size, num_epochs, strategy) -> tuple[int, int]:
@@ -384,21 +460,25 @@ def main(args) -> None:
     train_pool = normalise_label_column(train_pool, args.label_column)
     eval_data = normalise_label_column(eval_data, args.label_column)
 
-    label_names = resolve_label_names(train_pool, args.label_column)
-    logger.info("Found %d classes: %s", len(label_names), label_names)
-    if len(label_names) < 2:
-        sys.exit(f"Only one class found in '{args.label_column}'. A classifier needs two or more.")
-
+    # Cap BEFORE filtering. Both caps are O(1) selects while the blank-label filter is a full
+    # scan, and on a 2.4M-row corpus that ordering was eight minutes of preflight before a single
+    # training step. sample_dataset also calls .to_pandas() on whatever pool it is handed, which
+    # would OOM a cpu-basic job outright. The cap samples randomly, so a very rare class can be
+    # thinned by it.
+    if args.max_train_pool and len(train_pool) > args.max_train_pool:
+        train_pool = train_pool.shuffle(seed=args.seed).select(range(args.max_train_pool))
+        logger.info("Capped train pool at %d rows before sampling.", args.max_train_pool)
     if args.max_eval_samples and len(eval_data) > args.max_eval_samples:
         eval_data = eval_data.shuffle(seed=args.seed).select(range(args.max_eval_samples))
         logger.info("Capped eval set at %d examples.", args.max_eval_samples)
 
-    # sample_dataset calls .to_pandas() on the whole pool, which would OOM a cpu-basic job on a
-    # multi-million-row dataset. Capping first keeps the CPU path viable; the cap samples
-    # randomly, so a very rare class can be thinned by it.
-    if args.max_train_pool and len(train_pool) > args.max_train_pool:
-        train_pool = train_pool.shuffle(seed=args.seed).select(range(args.max_train_pool))
-        logger.info("Capped train pool at %d rows before sampling.", args.max_train_pool)
+    train_pool = drop_unlabelled_rows(train_pool, args.label_column, "train")
+    eval_data = drop_unlabelled_rows(eval_data, args.label_column, "eval")
+
+    label_names = resolve_label_names(train_pool, args.label_column)
+    logger.info("Found %d classes: %s", len(label_names), label_names)
+    if len(label_names) < 2:
+        sys.exit(f"Only one class found in '{args.label_column}'. A classifier needs two or more.")
 
     train_data = sample_dataset(
         train_pool, label_column=args.label_column, num_samples=args.num_samples, seed=args.seed
@@ -419,17 +499,6 @@ def main(args) -> None:
     logger.info(
         "Contrastive pairs: %d -> %d optimizer steps (%s).", pairs, steps, args.sampling_strategy
     )
-    if steps > 5_000 and args.sampling_strategy != "undersampling":
-        _, cheaper = estimate_training_steps(
-            per_class, args.batch_size, args.num_epochs, "undersampling"
-        )
-        logger.warning(
-            "That is a lot of steps. Pair count grows with the SQUARE of the training set, so "
-            "many classes get expensive fast. --sampling-strategy undersampling would need %d "
-            "steps instead; fewer --num-samples or a GPU flavor also help.",
-            cheaper,
-        )
-
     logger.info("Loading body model %s", args.body_model)
     model = SetFitModel.from_pretrained(args.body_model, labels=label_names)
     model.model_body.max_seq_length = args.max_seq_length
@@ -440,6 +509,34 @@ def main(args) -> None:
     else:
         logger.info("DEVICE: cpu")
     logger.info("DEVICE: body model is on %s", model.model_body.device)
+
+    projected = project_training_seconds(model, train_data[args.text_column], args.batch_size, steps)
+    logger.info("Projected training time: %.0f min (%d steps).", projected / 60, steps)
+    if projected / 60 > args.max_minutes and not args.allow_slow_training:
+        _, cheaper_steps = estimate_training_steps(
+            per_class, args.batch_size, args.num_epochs, "undersampling"
+        )
+        cheaper_minutes = projected / 60 * cheaper_steps / max(steps, 1)
+        if cheaper_minutes <= args.max_minutes:
+            suggestion = (
+                f"  --sampling-strategy undersampling  ->  {cheaper_steps} steps "
+                f"(~{cheaper_minutes:.0f} min, within budget)"
+            )
+        else:
+            suggestion = (
+                f"  --sampling-strategy undersampling  ->  {cheaper_steps} steps "
+                f"(~{cheaper_minutes:.0f} min — still over budget on this hardware)"
+            )
+        sys.exit(
+            f"Refusing to start: projected {projected / 60:.0f} min of training exceeds "
+            f"--max-minutes ({args.max_minutes}).\n"
+            f"Measured on this hardware with your actual texts, so it accounts for both the pair "
+            f"count and how long your documents are.\n"
+            f"{suggestion}\n"
+            f"  or lower --num-samples / --max-seq-length, use a GPU flavor, "
+            f"or pass --allow-slow-training."
+        )
+
 
     training_args = TrainingArguments(
         batch_size=args.batch_size,
@@ -464,6 +561,34 @@ def main(args) -> None:
 
     metrics = evaluate(model, eval_data, args.text_column, args.label_column, label_names)
     logger.info("Metrics: %s", metrics)
+
+    # Two floors matter, and the majority class is only the lower one. Single-seed few-shot
+    # results move by ~5 points on their own, so a lift inside that band is not a result.
+    # The floor that actually binds is the free zero-shot arm: on dair-ai/emotion this script
+    # scores 0.370 against a 0.352 majority — passing a naive check — while SetFit's templated
+    # zero-shot, which needs no labels at all, scores 0.591.
+    lift = metrics["accuracy"] - metrics["majority_baseline"]
+    if lift <= 0:
+        logger.warning(
+            "BELOW FLOOR: accuracy %.3f does not beat always predicting the majority class "
+            "(%.3f). This model is not worth deploying.",
+            metrics["accuracy"], metrics["majority_baseline"],
+        )
+    elif lift < NOISE_BAND:
+        logger.warning(
+            "WITHIN NOISE OF FLOOR: accuracy %.3f versus a %.3f majority class is only %.1f "
+            "points, and single-seed few-shot results vary by about %.0f. Treat this as 'no "
+            "signal demonstrated', not as a working classifier. Re-run with other seeds before "
+            "believing it.",
+            metrics["accuracy"], metrics["majority_baseline"], lift * 100, NOISE_BAND * 100,
+        )
+    else:
+        logger.info("Beats the majority-class floor by %.1f points.", lift * 100)
+
+    logger.warning(
+        "The majority class is the LOWER floor. Before trusting this model, compare it against "
+        "zero-shot with no labels at all — on some tasks that wins outright."
+    )
 
     logger.info("Pushing to %s (private=%s)", args.output_repo, args.private)
     model.push_to_hub(args.output_repo, private=args.private, token=token)
@@ -505,6 +630,10 @@ def parse_args():
     parser.add_argument("--batch-size", type=int, default=16, help="Batch size (default: 16)")
     parser.add_argument("--max-seq-length", type=int, default=256, help="Max sequence length (default: 256)")
     parser.add_argument("--seed", type=int, default=42, help="Seed (default: 42)")
+    parser.add_argument("--max-minutes", type=int, default=60,
+                        help="Refuse to start if projected training exceeds this (default: 60)")
+    parser.add_argument("--allow-slow-training", action="store_true",
+                        help="Override the --max-minutes refusal")
     parser.add_argument("--private", action="store_true", help="Make the output model repo private")
     parser.add_argument("--hf-token", help="HF token (or set HF_TOKEN)")
     return parser.parse_args()

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -188,12 +188,25 @@ def prepare_split(dataset, text_column, label_column, split_name):
     dataset = drop_unlabelled_rows(dataset, label_column, split_name)
     if not len(dataset):
         sys.exit(f"No labelled rows remain in {split_name} after removing missing labels.")
-    if any(not isinstance(text, str) or not text.strip() for text in dataset[text_column]):
-        sys.exit(
-            f"Text column '{text_column}' in {split_name} contains null, blank or non-string "
-            "values. Clean the text column before training."
+    def has_text(text):
+        if text is None:
+            return False
+        if not isinstance(text, str):
+            sys.exit(
+                f"Text column '{text_column}' in {split_name} contains non-string values. "
+                "Clean the text column before training."
+            )
+        return bool(text.strip())
+
+    kept = dataset.filter(has_text, input_columns=[text_column])
+    if len(kept) < len(dataset):
+        logger.warning(
+            "Dropped %d %s rows with missing or blank '%s' (%d remain).",
+            len(dataset) - len(kept), split_name, text_column, len(kept),
         )
-    return normalise_label_column(dataset, label_column)
+    if not len(kept):
+        sys.exit(f"No usable text rows remain in {split_name} after removing missing texts.")
+    return normalise_label_column(kept, label_column)
 
 
 def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -91,9 +91,12 @@ SCRIPT_URL = (
 # models on one dataset), so any lift smaller than this is not evidence of anything.
 NOISE_BAND = 0.05
 
-# Training-step cost as a multiple of encoding the same texts. Calibrated on a measured run,
-# not derived; see project_training_seconds.
-STEP_COST_FACTOR = 5
+# Training-step cost as a multiple of encoding the same texts — measured, not derived, and
+# device-dependent because GPU encodes are dominated by launch overhead rather than compute.
+# CPU: predicted 1.50 s/step at factor 3 against 2.42 actual -> 4.8. GPU: factor 5 projected
+# 31 min against 17.7 actual -> 2.9. See project_training_seconds.
+STEP_COST_FACTOR_CPU = 5
+STEP_COST_FACTOR_GPU = 3
 
 # MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
 # paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
@@ -249,6 +252,32 @@ def evaluate(model, eval_data, text_column, label_column) -> dict:
     }
 
 
+def warn_on_truncation(model, texts, max_seq_length: int) -> None:
+    """Say how much of the corpus is being cut off.
+
+    Truncation is silent and its consequence is not uniform: for short utterances it never fires,
+    while for long documents it can remove the very span that carries the label. The 256-token
+    default is right for the former and wrong for the latter, so measure and report rather than
+    letting it be discovered in the scores.
+    """
+    tokenizer = model.model_body.tokenizer
+    sample = list(texts)[:200]
+    lengths = [
+        len(tokenizer.encode(text, truncation=False, add_special_tokens=True)) for text in sample
+    ]
+    over = [n for n in lengths if n > max_seq_length]
+    if not over:
+        return
+
+    median_over = sorted(over)[len(over) // 2]
+    logger.warning(
+        "%d of %d sampled documents exceed --max-seq-length %d (median of those: %d tokens). "
+        "Everything past the limit is discarded before training and before prediction. If the "
+        "signal for your labels sits late in the document, raise --max-seq-length.",
+        len(over), len(sample), max_seq_length, median_over,
+    )
+
+
 def project_training_seconds(model, texts, batch_size: int, steps: int) -> float:
     """Time real encodes on real texts, then project the whole run.
 
@@ -281,7 +310,8 @@ def project_training_seconds(model, texts, batch_size: int, steps: int) -> float
     model.model_body.encode(timed, batch_size=batch_size, show_progress_bar=False)
     encode_seconds = time.time() - started
 
-    per_step = encode_seconds * STEP_COST_FACTOR
+    factor = STEP_COST_FACTOR_GPU if torch.cuda.is_available() else STEP_COST_FACTOR_CPU
+    per_step = encode_seconds * factor
     logger.info("Measured %.2fs to encode %d texts -> ~%.1fs per step.",
                 encode_seconds, sample_size, per_step)
     return per_step * steps
@@ -297,8 +327,15 @@ def estimate_training_steps(per_class, batch_size, num_epochs, strategy) -> tupl
     """
     counts = list(per_class.values())
     total = sum(counts)
-    positive = sum(comb(count, 2) for count in counts)
-    negative = comb(total, 2) - positive
+
+    # SetFit's shuffle_combinations defaults to replacement=True, i.e. np.triu_indices(n, 0) —
+    # the DIAGONAL is included, and those `total` self-pairs all count as positive. Verified
+    # against SetFit's own "Num unique pairs" on five runs: 2x4 -> 40, 4x8 -> 528, 2x8 -> 144,
+    # 3x8 -> 384, 77x8 -> 374,528. Negatives are cross-class, so they exclude the diagonal and
+    # must be computed from the combinations WITHOUT it.
+    same_class_pairs = sum(comb(count, 2) for count in counts)
+    positive = same_class_pairs + total
+    negative = comb(total, 2) - same_class_pairs
 
     if strategy == "oversampling":
         pairs = 2 * max(positive, negative)
@@ -541,6 +578,8 @@ def main(args) -> None:
     else:
         logger.info("DEVICE: cpu")
     logger.info("DEVICE: body model is on %s", model.model_body.device)
+
+    warn_on_truncation(model, train_data[args.text_column], args.max_seq_length)
 
     projected = project_training_seconds(model, train_data[args.text_column], args.batch_size, steps)
     logger.info("Projected training time: %.0f min (%d steps).", projected / 60, steps)

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -10,19 +10,22 @@
 # ]
 # ///
 """
-Few-shot text classification with SetFit — train on 8-64 labelled examples per class, on CPU.
+Few-shot text classification with SetFit — train on 8-64 labelled examples per class, on CPU or GPU.
 
 SetFit fine-tunes a sentence-transformer body with contrastive pairs, then fits a logistic
-regression head on the embeddings. With a handful of examples per class it reaches a useful
-classifier in minutes without a GPU, which makes it the cheap middle rung between zero-shot
-LLM labelling and a full encoder fine-tune (`train-classifier.py`).
+regression head on the embeddings. It supports small labelled datasets between zero-shot LLM
+labelling and a full encoder fine-tune (`train-classifier.py`). CPU is practical for small
+experiments; use a GPU for faster training, particularly with larger models, longer texts or
+more classes.
 
-Run on HF Jobs (cpu-basic is enough; no GPU needed):
+Run a small experiment on HF Jobs:
 
     hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \\
         https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \\
         fancyzhx/ag_news username/ag-news-setfit \\
         --num-samples 8
+
+For faster training with the same model and settings, change --flavor to t4-small.
 
 Metrics match `train-classifier.py` (accuracy + macro F1 on a held-out split) so the two are
 directly comparable at equal eval settings.

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -335,7 +335,8 @@ def warn_on_truncation(model, texts, max_seq_length: int) -> None:
     logger.warning(
         "%d of %d sampled documents exceed --max-seq-length %d (median of those: %d tokens). "
         "Everything past the limit is discarded before training and before prediction. If the "
-        "signal for your labels sits late in the document, raise --max-seq-length.",
+        "signal for your labels sits late in the document, raise --max-seq-length within the "
+        "body model's supported context window, or choose a longer-context --body-model.",
         len(over), len(sample), max_seq_length, median_over,
     )
 
@@ -480,11 +481,15 @@ def estimate_training_steps(per_class, batch_size, num_epochs, strategy) -> tupl
 
 
 def build_reproduce_command(args) -> str:
-    """Rebuild the exact invocation, so the card's command produces the card's model.
+    """Rebuild recipe options for Jobs, preserving the recorded accelerator when available.
 
     Only non-default flags are appended, keeping the command short while staying faithful.
+    Outside Jobs, the hardware flavor is a suggested default rather than an exact record.
     """
     flavor = "t4-small" if torch.cuda.is_available() else "cpu-basic"
+    accelerator = os.environ.get("ACCELERATOR", "").strip()
+    if os.environ.get("JOB_ID") and accelerator.lower() not in ("", "none"):
+        flavor = accelerator
     parts = [
         f"hf jobs uv run --flavor {flavor} --secrets HF_TOKEN \\",
         f"  {SCRIPT_URL} \\",
@@ -647,9 +652,15 @@ def main(args) -> None:
 
     # Prove we can write the output repo BEFORE paying for training. A permissions failure
     # after trainer.train() costs the whole run and leaves no artifact behind.
-    HfApi(token=token).create_repo(
+    api = HfApi(token=token)
+    api.create_repo(
         args.output_repo, repo_type="model", private=args.private, exist_ok=True
     )
+    if args.private and not api.model_info(args.output_repo).private:
+        sys.exit(
+            f"Output repo '{args.output_repo}' is public. --private does not change an existing "
+            "repo's visibility. Choose a new output repo or make that repo private before training."
+        )
 
     logger.info("Loading %s", args.input_dataset)
     eval_split = pick_eval_split(

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -87,8 +87,8 @@ SCRIPT_URL = (
     "https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py"
 )
 
-# Single-seed few-shot accuracy moves by roughly this much on its own (measured across body
-# models on one dataset), so any lift smaller than this is not evidence of anything.
+# Fixed threshold for prompting review of a small gain over the majority baseline.
+# This is a heuristic, not an estimate of seed variance or statistical significance.
 NOISE_BAND = 0.05
 
 # Applied to the measured step time. Covers what the measurement omits — optimizer update,
@@ -99,8 +99,8 @@ MEASUREMENT_MARGIN = 1.35
 
 # MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
 # paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
-# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788, a gap well
-# inside single-seed few-shot noise. Pass --body-model to try a larger body.
+# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788 in single-seed
+# runs, which do not establish a reliable ranking. Pass --body-model to try a larger body.
 DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 
@@ -573,8 +573,9 @@ def build_card(args, label_names, metrics, per_class, train_seconds, eval_split)
         )
     caveats.append(
         f"Accuracy is reported against a majority-class baseline of "
-        f"`{metrics['majority_baseline']}`. The majority class is the LOWER floor — zero-shot "
-        "with no labels wins outright on some tasks and is the comparison that matters."
+        f"`{metrics['majority_baseline']}`. Also compare with a simple trained baseline on "
+        "the same rows, and consider a zero-shot comparison where suitable. A small "
+        "single-seed gain does not establish reliable improvement."
     )
     caveat_block = "\n".join(f"- {c}" for c in caveats)
 
@@ -778,11 +779,8 @@ def main(args) -> None:
     metrics = evaluate(model, eval_data, args.text_column, args.label_column)
     logger.info("Metrics: %s", metrics)
 
-    # Two floors matter, and the majority class is only the lower one. Single-seed few-shot
-    # results move by ~5 points on their own, so a lift inside that band is not a result.
-    # The floor that actually binds is the free zero-shot arm: on dair-ai/emotion this script
-    # scores 0.370 against a 0.352 majority — passing a naive check — while SetFit's templated
-    # zero-shot, which needs no labels at all, scores 0.591.
+    # A majority baseline is a useful first comparison. A small gain triggers review;
+    # the fixed threshold does not determine whether the difference is significant.
     lift = metrics["accuracy"] - metrics["majority_baseline"]
     if lift <= 0:
         logger.warning(
@@ -792,10 +790,10 @@ def main(args) -> None:
         )
     elif lift < NOISE_BAND:
         logger.warning(
-            "WITHIN NOISE OF FLOOR: accuracy %.3f versus a %.3f majority class is only %.1f "
-            "points, and single-seed few-shot results vary by about %.0f. Treat this as 'no "
-            "signal demonstrated', not as a working classifier. Re-run with other seeds before "
-            "believing it.",
+            "SMALL GAIN OVER BASELINE: accuracy %.3f versus a %.3f majority class is only %.1f "
+            "points, below the %.0f-point review threshold. This threshold is a heuristic, "
+            "not a significance test. Evaluate other seeds and matched baselines before "
+            "drawing conclusions.",
             metrics["accuracy"], metrics["majority_baseline"], lift * 100, NOISE_BAND * 100,
         )
     else:

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: setfit-on-jobs
+description: Train and evaluate a single-label SetFit text classifier using Hugging Face Jobs, preparing a small labeled Hub dataset from supplied documents when needed, then return a verified Hub model and inference example. Use for few-shot text classification or when the user explicitly requests SetFit on Jobs.
+---
+
+# SetFit on Hugging Face Jobs
+
+Train a Hub-hosted SetFit model with a bounded run and an honest evaluation. Start from labeled text or prepare a small labeled sample from supplied documents. Keep the task to one classification schema and one train/evaluate cycle; taxonomy discovery, automatic active-learning loops and corpus-wide annotation are separate workflows.
+
+## Prepare a small dataset when labels are missing
+
+Inspect representative documents and use the user's categories and definitions. If categories are unspecified or overlap materially, resolve that before assigning labels. Label a bounded sample of actual documents with the agent or a zero-shot teacher; preserve source IDs, original source locations/revisions, label origin and the labeling instructions. Leave genuinely ambiguous examples for review rather than forcing them into a class. Do not substitute invented class-description sentences for real documents or describe agent-labeled training as zero-shot SetFit.
+
+Reserve evaluation documents before labeling or sampling training rows. Prefer independently reviewed evaluation labels. If the agent labels both splits, explicitly report student–agent agreement; do not call those labels human ground truth. The current recipe requires labeled evaluation data: it has no skip-evaluation or unlabeled-inference mode. Without suitable evaluation labels, prepare candidates and explain the missing prerequisite instead of manufacturing an accuracy score.
+
+Prepare a small Hub dataset with `text`, `label` and source IDs, plus explicit train/validation splits and a card describing label provenance. Use the user's namespace and intended visibility; preserve the source corpus. Local files or documents in a bucket need only yield this small training/evaluation sample—the full corpus can stay where it is. Extract text first if inputs are PDFs or other document formats. Bucket mounts alone do not extract documents or create labels; this recipe's supported handoff is a Hub dataset ID and its output is a model, not corpus annotations.
+
+## Check the inputs
+
+Inspect the dataset config, text and label columns, splits and missing values before launching a Job. Compute class counts from the saved rows and check they sum to each split's size. This recipe supports one label per text. Labels may be human or model generated; record their origin. Evaluation against synthetic labels measures agreement with those labels, not independent human accuracy.
+
+Choose a held-out labeled split explicitly. The recipe otherwise prefers validation, then test, then carves training data. Check related documents and duplicates do not cross the evaluation boundary. For repeated experiments, use validation for decisions and reserve test for the final assessment.
+
+Measure text lengths with the selected body's tokenizer and check language suitability. Report truncation only when measured lengths exceed the configured limit; do not turn a possible limitation into an observed finding. The default English MiniLM body and 256-token truncation may not suit other languages or decisions requiring a whole document. Disclose material truncation or choose suitable settings within the budget.
+
+## Run the existing recipe
+
+Use the tested recipe rather than recreating SetFit training code. The executable link below pins a tested revision. The canonical recipe is https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py; verify it includes the pinned revision's input-validation fixes before switching to the mirror:
+
+https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py
+
+Read its help for flags and check `hf jobs uv run --help` if needed. A small first run can use `cpu-basic`; adapt sample counts, body model and hardware to the data and user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
+
+Example for a small pilot (replace the output namespace):
+
+```bash
+hf jobs uv run --flavor cpu-basic --timeout 10m --detach --secrets HF_TOKEN \
+  https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py \
+  fancyzhx/ag_news YOUR_NAMESPACE/ag-news-setfit \
+  --eval-split test --num-samples 8 --max-eval-samples 200 \
+  --sampling-strategy undersampling --max-minutes 5 --private
+```
+
+Use the requested output visibility. The destination is a model repo. Pass credentials through Jobs secrets. Record the source revision and actual invocation; preserve sampled row IDs and seed when reproducing a comparison.
+
+Inspect both `hf jobs logs` and `hf jobs inspect`: submission or a closed log stream does not establish completion. Keep retries within the authorized budget. A runtime guard refusal is a reason to reduce the workload or explain the limitation; do not silently override it or increase hardware. Stop after the requested run rather than starting an automatic tuning loop.
+
+## Evaluate and hand off
+
+Report actual training examples per class, evaluation size, accuracy, macro F1 and a majority baseline on the same evaluation rows. For an initial usefulness assessment, compare with TF-IDF plus logistic regression when practical. Match the exact training and evaluation rows; a baseline trained on more labels answers a different question. Additional zero-shot comparisons are optional, not part of every SetFit run.
+
+Derive any confusion matrix and error examples from that model's saved predictions and evaluation row IDs. The diagonal divided by the matrix total must match its accuracy. If only aggregate metrics are available, report that limit rather than inventing diagnostics. Inspect a few errors when predictions are available, and disclose dropped rows, missing classes and the limitations of a small single-seed evaluation.
+
+Verify the uploaded model reloads and predicts the expected label names. SetFit has a sentence-transformer body and classification head; load it with `SetFitModel.from_pretrained`, not `AutoModelForSequenceClassification`:
+
+```python
+from setfit import SetFitModel
+
+model = SetFitModel.from_pretrained("YOUR_NAMESPACE/ag-news-setfit")
+print(model.predict(["The team won the championship."]))
+```
+
+Return the model and Job links, exact command, measured results, short inference example and a concrete recommendation about suitability. Verify artifact links exist and, for private outputs, check visibility through authenticated metadata. A working training run and useful classification quality are separate findings.

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -23,6 +23,8 @@ Choose a held-out labeled split explicitly. The recipe otherwise prefers validat
 
 Measure text lengths with the selected body's tokenizer and check language suitability. Report truncation only when measured lengths exceed the configured limit; do not turn a possible limitation into an observed finding. The default English MiniLM body and 256-token truncation may not suit other languages or decisions requiring a whole document. Disclose material truncation or choose suitable settings within the budget.
 
+Keep `--max-seq-length` within the chosen body's supported context window. If prepared inputs were already shortened, restore the original text before testing longer context. Follow the body's task-prefix instructions consistently across training, evaluation and inference; the recipe does not add prefixes automatically. Record these preprocessing requirements in the handoff.
+
 ## Run the existing recipe
 
 Use the tested recipe rather than recreating SetFit training code. The executable link below pins a tested revision. The canonical recipe is https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py; verify it includes the pinned revision's input-validation fixes before switching to the mirror:

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -29,7 +29,7 @@ Keep `--max-seq-length` within the chosen body's supported context window. If pr
 
 Use the tested recipe rather than recreating SetFit training code. The executable link below pins a tested revision. The canonical recipe is https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py; verify it includes the pinned revision's input-validation fixes before switching to the mirror:
 
-https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py
+https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/11e6ae6250a2ae3dc67cd074679a6da70cac13b0/classification/train-setfit.py
 
 Read its help for flags and check `hf jobs uv run --help` if needed. CPU is practical for small experiments; use a GPU for faster training, particularly with larger models, longer texts or more classes. A small first run can use `cpu-basic`; changing to `t4-small` accelerates the same model and training settings. Choose hardware within the user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
 
@@ -37,7 +37,7 @@ Example for a small pilot (replace the output namespace):
 
 ```bash
 hf jobs uv run --flavor cpu-basic --timeout 10m --detach --secrets HF_TOKEN \
-  https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py \
+  https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/11e6ae6250a2ae3dc67cd074679a6da70cac13b0/classification/train-setfit.py \
   fancyzhx/ag_news YOUR_NAMESPACE/ag-news-setfit \
   --eval-split test --num-samples 8 --max-eval-samples 200 \
   --sampling-strategy undersampling --max-minutes 5 --private

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -29,7 +29,7 @@ Use the tested recipe rather than recreating SetFit training code. The executabl
 
 https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py
 
-Read its help for flags and check `hf jobs uv run --help` if needed. A small first run can use `cpu-basic`; adapt sample counts, body model and hardware to the data and user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
+Read its help for flags and check `hf jobs uv run --help` if needed. CPU is practical for small experiments; use a GPU for faster training, particularly with larger models, longer texts or more classes. A small first run can use `cpu-basic`; changing to `t4-small` accelerates the same model and training settings. Choose hardware within the user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
 
 Example for a small pilot (replace the output namespace):
 

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -62,7 +62,7 @@ Keep the inline dependency block valid (new deps install at runtime); update the
 
 ## Compose a pipeline
 
-Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model. One pipeline ships pre-assembled as its own skill: `object-detection` carries a `SKILL.md` covering the full no-labels→detector loop (zero-shot teacher labels → validate → convert → train a small Apache-licensed detector) — fetch it from the repo when that is the task.
+Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model. For a small single-label text classifier, use the focused [setfit-on-jobs skill](../setfit-on-jobs/SKILL.md): it can prepare an agent-labeled sample, run SetFit on Jobs, and evaluate and reload the model. One pipeline ships pre-assembled as its own skill: `object-detection` carries a `SKILL.md` covering the full no-labels→detector loop (zero-shot teacher labels → validate → convert → train a small Apache-licensed detector) — fetch it from the repo when that is the task.
 
 ## Pre-label, then review
 

--- a/tests/test_train_setfit.py
+++ b/tests/test_train_setfit.py
@@ -1,0 +1,115 @@
+"""Data preflight regressions; no Hub access or model downloads required.
+
+Run with the recipe dependencies and pytest installed:
+    python -m pytest tests/test_train_setfit.py
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from datasets import ClassLabel, Dataset, Features, Value
+
+SCRIPT = Path(__file__).resolve().parents[1] / "classification" / "train-setfit.py"
+spec = importlib.util.spec_from_file_location("train_setfit", SCRIPT)
+recipe = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recipe)
+
+
+def typed_dataset(labels):
+    return Dataset.from_dict(
+        {"text": [f"document {i}" for i in range(len(labels))], "label": labels},
+        features=Features({"text": Value("string"), "label": ClassLabel(names=["a", "b", "c"])}),
+    )
+
+
+def test_missing_classlabel_is_dropped_without_remapping():
+    cleaned = recipe.prepare_split(typed_dataset([0, -1, 2, None]), "text", "label", "train")
+    assert list(cleaned["label"]) == [0, 2]
+    assert recipe.resolve_label_names(cleaned, "label") == ["a", "b", "c"]
+
+
+def test_plain_negative_integer_is_a_real_class():
+    data = Dataset.from_dict({"text": ["a", "b", "c"], "label": [-1, 0, 1]})
+    assert list(recipe.prepare_split(data, "text", "label", "train")["label"]) == ["-1", "0", "1"]
+
+
+def test_nan_is_removed_before_string_cast():
+    data = Dataset.from_dict({"text": ["a", "b", "c"], "label": [1.0, float("nan"), 2.0]})
+    cleaned = recipe.prepare_split(data, "text", "label", "train")
+    assert len(cleaned) == 2
+    assert "nan" not in cleaned["label"]
+
+
+@pytest.mark.parametrize("labels", [[], [None, None], ["", " "]])
+def test_empty_or_unlabelled_split_is_rejected(labels):
+    data = Dataset.from_dict({"text": ["document"] * len(labels), "label": labels})
+    with pytest.raises(SystemExit, match="empty|No labelled rows"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("text", [None, "", " ", 12])
+def test_invalid_text_is_rejected_before_training(text):
+    data = Dataset.from_dict({"text": [text], "label": ["a"]})
+    with pytest.raises(SystemExit, match="Clean the text column"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("column", ["text", "label"])
+def test_missing_columns_are_actionable(column):
+    data = Dataset.from_dict({"text": ["document"], "label": ["a"]}).remove_columns(column)
+    with pytest.raises(SystemExit, match=f"--{column}-column"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+def test_multilabel_eval_is_rejected():
+    data = Dataset.from_dict({"text": ["document"], "label": [["a", "b"]]})
+    with pytest.raises(SystemExit, match="multi-label"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("labels", [["a", "a", "b", "b"], [-1, -1, 2, 2]])
+def test_plain_labels_get_stratified_disjoint_carve(monkeypatch, labels):
+    data = Dataset.from_dict({"text": ["one", "two", "three", "four"], "label": labels})
+    monkeypatch.setattr(recipe, "load_dataset", lambda *args, **kwargs: data)
+    train, evaluation = recipe.split_train_eval("fixture", None, "train", None, 0.5, 2, "label")
+    assert len(set(train["label"])) == len(set(evaluation["label"])) == 2
+    assert set(train["text"]).isdisjoint(evaluation["text"])
+    assert set(train.features["label"].names) == {str(label) for label in labels}
+
+
+def test_carve_drops_missing_classlabel_before_stratifying(monkeypatch):
+    data = typed_dataset([0, 0, 2, 2, -1, None])
+    monkeypatch.setattr(recipe, "load_dataset", lambda *args, **kwargs: data)
+    train, evaluation = recipe.split_train_eval("fixture", None, "train", None, 0.5, 2, "label")
+    assert len(train) == len(evaluation) == 2
+    assert set(train["label"]) == set(evaluation["label"]) == {0, 2}
+
+
+def test_one_observed_class_stops_before_model_loading(monkeypatch):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "fixture", "user/model", "--hf-token", "fake"])
+    monkeypatch.setattr(recipe, "login", Mock())
+    monkeypatch.setattr(recipe, "HfApi", Mock())
+    monkeypatch.setattr(recipe, "pick_eval_split", lambda *args: "test")
+    monkeypatch.setattr(recipe, "split_train_eval", lambda *args: (typed_dataset([2, 2]), typed_dataset([0, 2])))
+    load_model = Mock()
+    monkeypatch.setattr(recipe.SetFitModel, "from_pretrained", load_model)
+    with pytest.raises(SystemExit, match="two observed classes"):
+        recipe.main(recipe.parse_args())
+    load_model.assert_not_called()
+
+
+def test_evaluation_decodes_its_own_classlabel_table():
+    evaluation = typed_dataset([2, 0])
+    model = Mock()
+    model.predict.return_value = ["c", "a"]
+    assert recipe.evaluate(model, evaluation, "text", "label")["accuracy"] == 1.0
+
+
+def test_help_renders_slice_example(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "--help"])
+    with pytest.raises(SystemExit) as result:
+        recipe.parse_args()
+    assert result.value.code == 0
+    assert "train[:10%]" in capsys.readouterr().out

--- a/tests/test_train_setfit.py
+++ b/tests/test_train_setfit.py
@@ -49,9 +49,23 @@ def test_empty_or_unlabelled_split_is_rejected(labels):
         recipe.prepare_split(data, "text", "label", "eval")
 
 
-@pytest.mark.parametrize("text", [None, "", " ", 12])
-def test_invalid_text_is_rejected_before_training(text):
+@pytest.mark.parametrize("text", [None, "", " "])
+def test_empty_text_split_is_rejected_before_training(text):
     data = Dataset.from_dict({"text": [text], "label": ["a"]})
+    with pytest.raises(SystemExit, match="No usable text rows"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("text", [None, "", " "])
+def test_missing_text_is_dropped_without_rejecting_usable_rows(text):
+    data = Dataset.from_dict({"text": [text, "a real document"], "label": ["a", "b"]})
+    cleaned = recipe.prepare_split(data, "text", "label", "eval")
+    assert list(cleaned["text"]) == ["a real document"]
+    assert list(cleaned["label"]) == ["b"]
+
+
+def test_non_string_text_is_rejected_before_training():
+    data = Dataset.from_dict({"text": [12], "label": ["a"]})
     with pytest.raises(SystemExit, match="Clean the text column"):
         recipe.prepare_split(data, "text", "label", "eval")
 

--- a/tests/test_train_setfit.py
+++ b/tests/test_train_setfit.py
@@ -127,3 +127,39 @@ def test_help_renders_slice_example(monkeypatch, capsys):
         recipe.parse_args()
     assert result.value.code == 0
     assert "train[:10%]" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("job_id", "accelerator", "cuda", "expected"),
+    [
+        ("job-123", "l40sx1", True, "l40sx1"),
+        ("job-123", "a100-large", True, "a100-large"),
+        ("job-123", "none", False, "cpu-basic"),
+        ("job-123", "", False, "cpu-basic"),
+        ("", "l40sx1", True, "t4-small"),
+    ],
+)
+def test_reproduction_preserves_jobs_gpu_flavor(monkeypatch, job_id, accelerator, cuda, expected):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "fixture", "user/model"])
+    monkeypatch.setenv("JOB_ID", job_id)
+    monkeypatch.setenv("ACCELERATOR", accelerator)
+    monkeypatch.setattr(recipe.torch.cuda, "is_available", lambda: cuda)
+    command = recipe.build_reproduce_command(recipe.parse_args())
+    assert command.startswith(f"hf jobs uv run --flavor {expected} --secrets HF_TOKEN")
+
+
+@pytest.mark.parametrize("is_private", [False, True])
+def test_private_destination_visibility_checked_before_loading_data(monkeypatch, is_private):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "fixture", "user/model", "--private", "--hf-token", "fake"])
+    monkeypatch.setattr(recipe, "login", Mock())
+    api = Mock()
+    api.model_info.return_value.private = is_private
+    monkeypatch.setattr(recipe, "HfApi", Mock(return_value=api))
+    load_data = Mock(side_effect=RuntimeError("data loading reached"))
+    monkeypatch.setattr(recipe, "pick_eval_split", load_data)
+    error = RuntimeError if is_private else SystemExit
+    message = "data loading reached" if is_private else "is public"
+    with pytest.raises(error, match=message):
+        recipe.main(recipe.parse_args())
+    assert load_data.call_count == int(is_private)
+    api.create_repo.assert_called_once_with("user/model", repo_type="model", private=True, exist_ok=True)


### PR DESCRIPTION
Adds `classification/train-setfit.py` for single-label text classification from small labeled datasets. The recipe samples examples per class, fine-tunes a Sentence Transformer with SetFit, fits a logistic-regression head, and uploads an evaluated Hub model. It runs on CPU or GPU; CPU suits small experiments, while GPU speeds up larger models and longer inputs.

The recipe validates both splits, drops missing labels and blank texts with counts, preserves label mappings, and uses an explicit evaluation split or a stratified carve-out. It reports accuracy, macro F1, per-class training counts and a majority baseline. A measured training-time estimate can refuse expensive runs; Jobs `--timeout` provides the wall-clock limit. The five-point gain warning is documented as a review heuristic.

Private runs verify the destination is actually private before loading data. Model-card reproduction commands retain the Jobs accelerator when available. Documentation covers model context limits and consistent task prefixes when switching embedding backbones.

Includes a focused `setfit-on-jobs` skill that prepares a small source-linked labeled sample when needed, runs the recipe, compares appropriate baselines and verifies saved-model predictions. The root README and recipe-discovery skill link to it.

Validation:

- 29 regression tests covering data validation, label mapping, split handling, CLI help, private destinations and reproduction hardware.
- End-to-end CPU and GPU runs covering training, held-out evaluation, private Hub upload and model reload; independent checks reproduce saved predictions and metrics.
- Paired 512/2,048-token execution checks with a longer-context Sentence Transformer, using matching training/evaluation rows and preprocessing requirements.
- CLI help, Ruff E4/E7/E9/F, skill validation, whitespace checks and the Hub superset gate pass. All four existing classification mirror files are retained.

The README's measured examples are bounded single-seed results, not general performance guarantees. The supported scope is supervised few-shot training and evaluation; baseline comparisons remain part of assessing usefulness on a particular task.
