### PR TITLE
fix(classification): harden SetFit inputs and add Jobs skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ A self-contained, pinned script is easy to run and reuse, for a few reasons:
 
 **Built for agents, too.** Every recipe takes its arguments in the same `input output` order and runs from a URL, so an AI agent can pick a tool from its header and run it with no setup. On Jobs the agent runs in a sandbox: a throwaway disk, access limited to what the token's repo permissions allow, and a cost cap per job — not arbitrary code on your machine. (Hugging Face also ships an [`hf` CLI skill for agents](https://huggingface.co/docs/hub/agents-cli) for driving Jobs from an editor.) This repo also ships a ready-to-use **[`uv-recipes` agent skill](skills/uv-recipes/)** — point your agent at it to discover, run, and adapt recipes.
 
+For few-shot text classification, the focused **[`setfit-on-jobs` skill](skills/setfit-on-jobs/)** prepares a small labeled sample when needed, runs SetFit on Jobs, and verifies the resulting model.
+
 ## Recipes
 
 | Domain | What it does | On the Hub |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For few-shot text classification, the focused **[`setfit-on-jobs` skill](skills/
 | **embeddings** | Embed text/images (auto-batch, prompt-aware); build a searchable Lance vector DB on the Hub | [`embeddings`](https://huggingface.co/datasets/uv-scripts/embeddings) |
 | **embeddings & atlas** | Embed a dataset; build an interactive map | [`build-atlas`](https://huggingface.co/datasets/uv-scripts/build-atlas) |
 | **data processing** | Filter / dedup / stats over large datasets | [`dataset-stats`](https://huggingface.co/datasets/uv-scripts/dataset-stats) · [`deduplication`](https://huggingface.co/datasets/uv-scripts/deduplication) |
-| **classification** | Fine-tune an encoder classifier (LFM2.5-Encoder, ModernBERT, …), few-shot train one with SetFit on CPU, or zero-shot classify with an LLM | [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
+| **classification** | Fine-tune an encoder classifier (LFM2.5-Encoder, ModernBERT, …), few-shot train one with SetFit on CPU or GPU, or zero-shot classify with an LLM | [`classification`](https://huggingface.co/datasets/uv-scripts/classification) |
 | **dataset creation** | Turn PDFs / image URLs into Hub datasets | [`dataset-creation`](https://huggingface.co/datasets/uv-scripts/dataset-creation) · [`iiif-tiles`](https://huggingface.co/datasets/uv-scripts/iiif-tiles) |
 | **synthetic data** | Generate datasets with LLMs | [`synthetic-data`](https://huggingface.co/datasets/uv-scripts/synthetic-data) |
 | **inference** | Run any open LLM / VLM over a dataset | [`vllm`](https://huggingface.co/datasets/uv-scripts/vllm) · [`openai-oss`](https://huggingface.co/datasets/uv-scripts/openai-oss) · [`transformers-inference`](https://huggingface.co/datasets/uv-scripts/transformers-inference) |

--- a/classification/README.md
+++ b/classification/README.md
@@ -87,7 +87,7 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
 - **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
 - **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
-- **Rows with missing or blank labels are dropped**, with a count. A blank string is otherwise a perfectly valid class name.
+- **Rows with missing or blank labels are dropped**, including `ClassLabel`'s `-1` sentinel and numeric NaN, with a count. Plain integer `-1` remains a valid class. Empty labelled splits, fewer than two observed training classes, and missing or invalid text columns exit before model loading.
 
 ```bash
 # 8 labels per class, on CPU

--- a/classification/README.md
+++ b/classification/README.md
@@ -87,7 +87,7 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
 - **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
 - **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
-- **Rows with missing or blank labels are dropped**, including `ClassLabel`'s `-1` sentinel and numeric NaN, with a count. Plain integer `-1` remains a valid class. Empty labelled splits, fewer than two observed training classes, and missing or invalid text columns exit before model loading.
+- **Rows with missing or blank labels or texts are dropped**, with a count. Missing labels include `ClassLabel`'s `-1` sentinel and numeric NaN; plain integer `-1` remains a valid class. Splits with no usable labelled text, fewer than two observed training classes, and missing or non-string text columns exit before model loading.
 
 ```bash
 # 8 labels per class, on CPU

--- a/classification/README.md
+++ b/classification/README.md
@@ -92,6 +92,7 @@ training settings work on either; the recipe uses the available accelerator auto
 - **Every run reports a majority baseline.** The run warns when accuracy fails to beat it, or the gain is below five percentage points. That fixed threshold is a review heuristic, not a measured noise level or significance test.
 - **It estimates training time before starting.** The script times forward/backward passes on actual texts and hardware, then refuses training projected above `--max-minutes` (default 60). Setup, evaluation and upload take additional time. A measurement error can skip this guard; use Jobs `--timeout` to enforce a wall-clock limit.
 - **Rows with missing or blank labels or texts are dropped**, with a count. Missing labels include `ClassLabel`'s `-1` sentinel and numeric NaN; plain integer `-1` remains a valid class. Splits with no usable labelled text, fewer than two observed training classes, and missing or non-string text columns exit before model loading.
+- **`--private` verifies the output repository is private before training.** If the destination already exists publicly, choose a new repo or change its visibility first.
 
 ```bash
 # 8 labels per class, on CPU
@@ -104,6 +105,19 @@ hf jobs uv run --flavor t4-small --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit-gpu --num-samples 8
 ```
+
+### Choosing another body or longer context
+
+`--body-model` accepts a Sentence Transformer checkpoint. Set `--max-seq-length` within that
+model's supported context window; increasing it cannot extend a model's native limit or restore
+text already shortened during dataset preparation. Longer sequences can need a smaller
+`--batch-size` or more GPU memory. The recipe measures training cost on the selected hardware.
+
+Follow the body's task-prefix instructions when preparing inputs. For example,
+[`nomic-ai/modernbert-embed-base`](https://huggingface.co/nomic-ai/modernbert-embed-base)
+uses Nomic's task prefixes: classification inputs should begin with `classification: `.
+Include the same prefix during training, evaluation and inference. The recipe does not add it
+automatically. Retain the original texts and the preprocessing details with the model.
 
 ### Measured
 

--- a/classification/README.md
+++ b/classification/README.md
@@ -10,7 +10,7 @@ Text classification on [HF Jobs](https://huggingface.co/docs/huggingface_hub/gui
 | Script | What it does |
 |--------|--------------|
 | [`train-classifier.py`](#fine-tune-a-classifier-train-classifierpy) | **Fine-tune** an encoder into a classifier (default: [LFM2.5-Encoder-350M](https://huggingface.co/LiquidAI/LFM2.5-Encoder-350M)) and push it to the Hub |
-| [`train-setfit.py`](#few-shot-with-setfit-train-setfitpy) | **Few-shot** train a classifier from 8-64 labels per class with [SetFit](https://github.com/huggingface/setfit) — runs on CPU |
+| [`train-setfit.py`](#few-shot-with-setfit-train-setfitpy) | **Few-shot** train a classifier from 8-64 labels per class with [SetFit](https://github.com/huggingface/setfit) — runs on CPU or GPU |
 | [`classify-dataset.py`](#zero-shot-classification-classify-datasetpy) | **Zero-shot** classify a dataset with an instruction LLM (SmolLM3 + vLLM, structured outputs) |
 | `classify-dataset-sglang.py` | Zero-shot variant on SGLang (reasoning-aware `<think>` models) |
 
@@ -19,7 +19,7 @@ Pick by how many labels you have:
 | Labels you have | Use | Hardware |
 |---|---|---|
 | none | `classify-dataset.py` to bootstrap labels, or for one-off jobs | GPU |
-| ~8-64 per class | `train-setfit.py` | CPU |
+| ~8-64 per class | `train-setfit.py` | CPU supported; GPU for faster training |
 | a few thousand | `train-classifier.py` | GPU |
 
 The rungs chain: bootstrap labels with `classify-dataset.py`, review them, then train a small
@@ -78,7 +78,11 @@ produces a plain, vLLM-servable model — pair it with
 
 Trains a [SetFit](https://github.com/huggingface/setfit) classifier from a handful of labelled
 examples per class. SetFit finetunes a sentence-transformer body on contrastive pairs, then fits a
-logistic regression head on the resulting embeddings — no GPU required.
+logistic regression head on the resulting embeddings.
+
+**Runs on CPU or GPU.** CPU is practical for small few-shot experiments. Use a GPU for faster
+training, particularly with larger models, longer texts or more classes. The same model and
+training settings work on either; the recipe uses the available accelerator automatically.
 
 - **Default body**: [`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) (22M), chosen for CPU speed. Swap it with `--body-model`.
 - **Evaluation split** follows the same precedence as `train-classifier.py`: `--eval-split` if given, else `validation`, else `test`, else a stratified carve-out of `--eval-fraction` from train.
@@ -95,11 +99,10 @@ hf jobs uv run --flavor cpu-basic --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit --num-samples 8
 
-# Try a larger body on a GPU; compare quality on the same evaluation rows
+# Same model and training settings on a GPU for faster training
 hf jobs uv run --flavor t4-small --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
-  fancyzhx/ag_news username/ag-news-setfit \
-  --body-model sentence-transformers/paraphrase-mpnet-base-v2
+  fancyzhx/ag_news username/ag-news-setfit-gpu --num-samples 8
 ```
 
 ### Measured

--- a/classification/README.md
+++ b/classification/README.md
@@ -83,20 +83,20 @@ logistic regression head on the resulting embeddings — no GPU required.
 - **Default body**: [`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) (22M), chosen for CPU speed. Swap it with `--body-model`.
 - **Evaluation split** follows the same precedence as `train-classifier.py`: `--eval-split` if given, else `validation`, else `test`, else a stratified carve-out of `--eval-fraction` from train.
 - **Single-label only.** A multi-label column exits with a pointer to `train-classifier.py`.
-- **Metrics match `train-classifier.py`** (accuracy + macro F1 on a held-out split), so the two rungs are directly comparable.
+- **Metrics match `train-classifier.py`** (accuracy + macro F1). Match evaluation rows and preprocessing when comparing runs.
 - **`--num-samples`** sets labelled examples per class (default 8). **`--sampling-strategy`** controls contrastive pairing: `oversampling` (default), `undersampling`, `unique`.
-- **Every run reports a floor.** `majority_baseline` sits next to accuracy, and the run warns when the model fails to beat it — or beats it by less than the ~5-point run-to-run noise of few-shot training.
-- **It refuses jobs it cannot finish.** Before training it encodes a sample of your actual texts on the actual hardware, projects the total, and exits above `--max-minutes` (default 60) rather than discovering it at the timeout.
+- **Every run reports a majority baseline.** The run warns when accuracy fails to beat it, or the gain is below five percentage points. That fixed threshold is a review heuristic, not a measured noise level or significance test.
+- **It estimates training time before starting.** The script times forward/backward passes on actual texts and hardware, then refuses training projected above `--max-minutes` (default 60). Setup, evaluation and upload take additional time. A measurement error can skip this guard; use Jobs `--timeout` to enforce a wall-clock limit.
 - **Rows with missing or blank labels or texts are dropped**, with a count. Missing labels include `ClassLabel`'s `-1` sentinel and numeric NaN; plain integer `-1` remains a valid class. Splits with no usable labelled text, fewer than two observed training classes, and missing or non-string text columns exit before model loading.
 
 ```bash
 # 8 labels per class, on CPU
-hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \
+hf jobs uv run --flavor cpu-basic --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit --num-samples 8
 
-# larger body on a GPU for the accuracy ceiling
-hf jobs uv run --flavor t4-small --secrets HF_TOKEN \
+# Try a larger body on a GPU; compare quality on the same evaluation rows
+hf jobs uv run --flavor t4-small --timeout 20m --secrets HF_TOKEN \
   https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \
   fancyzhx/ag_news username/ag-news-setfit \
   --body-model sentence-transformers/paraphrase-mpnet-base-v2
@@ -119,22 +119,23 @@ substantially with which examples happen to get sampled; SetFit's own benchmarks
 standard deviation across ten seeds for exactly this reason. Run your own task before trusting
 any of these numbers.
 
-`emotion` is the honest counter-example: six overlapping affect classes are hard from 8 examples
-each, and swapping the body barely moved it (`bge-small` 0.418, `paraphrase-mpnet-base-v2` 0.410).
-SetFit's docs report **0.591 on this dataset with no labels at all**, using synthetic examples
-generated from the class names — so when classes are semantically well-named but hard to separate
-from a handful of samples, the zero-shot route may beat few-shot.
+### Compare more than the majority baseline
 
-### The majority class is the lower floor
+The `emotion` run reached **0.370** accuracy against a **0.352** majority baseline. Other
+single-seed body-model runs reached 0.418 (`bge-small`) and 0.410 (`paraphrase-mpnet-base-v2`).
+These results call for further evaluation; they do not establish a limit on the task or method.
 
-`dair-ai/emotion` is the cautionary case. This script scores **0.370** on it; the majority class
-is **0.352**, so a naive "did it beat the baseline" check passes. SetFit's own documentation
-reports **0.591 on the same dataset with no labels at all**, using examples templated from the
-class names. Swapping the body barely moves it (`bge-small` 0.418, `paraphrase-mpnet-base-v2`
-0.410), so this is the task resisting few-shot learning, not the model being wrong.
+SetFit's [zero-shot guide](https://huggingface.co/docs/setfit/how_to/zero_shot) reports **0.591**
+on emotion using BGE and training examples templated from the class names. It uses a different
+evaluation setup from the table above, so this is motivation for a matched comparison rather
+than a controlled comparison with this recipe. Templated training needs no labeled documents,
+but still uses compute.
 
-The lesson generalises: before spending labels, measure what free costs. When classes are
-well-named but semantically entangled, zero-shot can win outright.
+For your task, compare with a simple baseline such as TF-IDF plus logistic regression using
+the same training and evaluation rows. A zero-shot comparison can also be useful when class
+names describe the task well. Use repeated seeds and appropriate task metrics before drawing
+conclusions from small accuracy differences. This recipe trains and evaluates a supervised
+classifier; built-in templated zero-shot training is a separate possible extension.
 
 ### Real-world data: a worked failure
 
@@ -146,11 +147,12 @@ produces no score:
   comparable to anything published.
 - **~9.5% of rows have a blank `party`**, which without the drop trains an `""` class.
 - **28 parties after cleaning, nine of which cannot supply 8 examples** (`Respect` 4,
-  `Independent SDP` 2, `Change UK` 1). The few-shot framing does not hold at any budget.
+  `Independent SDP` 2, `Change UK` 1). The requested eight-example budget cannot be met for those classes.
 - **1,878 steps at ~11s/step on CPU** — the script refuses it, projecting well past an hour.
 
-The model card discloses the first three automatically, so a run on messy data cannot quietly
-report a clean-looking number.
+On completed runs, the model card discloses a carved evaluation split, per-class training counts
+and classes below the requested sample count. Dropped-row counts and measured truncation are
+reported in the logs; retain those logs alongside the model when documenting data preparation.
 
 ### Many classes: watch the pair count
 
@@ -165,8 +167,9 @@ script logs the estimate before training starts:
 | banking77 (77 classes x 8) | `undersampling` | 4,312 | 270 |
 
 At 77 classes the default would take roughly 15 hours on `cpu-basic`; `--sampling-strategy
-undersampling` finished in 18 seconds on a T4. Above 5,000 estimated steps the script warns and
-names the cheaper alternative.
+undersampling` finished in 18 seconds on a T4 in the recorded run. The script reports the pair
+and step counts, then measures step time to check `--max-minutes`. When it refuses training,
+it suggests undersampling where applicable and estimates whether that would fit the budget.
 
 > **Note**: a SetFit model is a sentence-transformer body plus a scikit-learn head. Load it with
 > `SetFitModel.from_pretrained(repo)`, not `AutoModelForSequenceClassification`.

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -38,7 +38,7 @@ import random
 import sys
 import time
 from collections import Counter
-from math import ceil, comb
+from math import ceil, comb, isnan
 
 # tqdm reads TQDM_DISABLE when it is imported, so this must be set before any third-party import
 # pulls tqdm in — setting it later has no effect. Jobs logs have no TTY, so progress bars arrive
@@ -106,6 +106,8 @@ DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 def check_label_column(dataset: Dataset, label_column: str) -> None:
     """Fail early and clearly on a missing or multi-label column."""
+    if not len(dataset):
+        sys.exit("Dataset split is empty. Supply a non-empty labelled split.")
     if label_column not in dataset.column_names:
         sys.exit(
             f"Label column '{label_column}' not found. Columns are: {dataset.column_names}. "
@@ -153,13 +155,18 @@ def drop_unlabelled_rows(dataset: Dataset, label_column: str, split_name: str) -
     right default — an unlabelled row is not a class, and keeping it teaches the model to
     predict "no label".
     """
-    def has_label(example) -> bool:
-        value = example[label_column]
+    feature = dataset.features.get(label_column)
+
+    def has_label(value) -> bool:
         if value is None:
+            return False
+        if isinstance(feature, ClassLabel) and value == -1:
+            return False
+        if isinstance(value, float) and isnan(value):
             return False
         return not (isinstance(value, str) and not value.strip())
 
-    kept = dataset.filter(has_label)
+    kept = dataset.filter(has_label, input_columns=[label_column])
     dropped = len(dataset) - len(kept)
     if dropped:
         logger.warning(
@@ -167,6 +174,26 @@ def drop_unlabelled_rows(dataset: Dataset, label_column: str, split_name: str) -
             dropped, split_name, label_column, len(kept),
         )
     return kept
+
+
+def prepare_split(dataset, text_column, label_column, split_name):
+    """Validate both splits before loading a model or paying for training."""
+    check_label_column(dataset, label_column)
+    if text_column not in dataset.column_names:
+        sys.exit(
+            f"Text column '{text_column}' not found in {split_name}. "
+            f"Columns are: {dataset.column_names}. Pass --text-column."
+        )
+    # Check missing labels before casting: a float NaN otherwise becomes the class "nan".
+    dataset = drop_unlabelled_rows(dataset, label_column, split_name)
+    if not len(dataset):
+        sys.exit(f"No labelled rows remain in {split_name} after removing missing labels.")
+    if any(not isinstance(text, str) or not text.strip() for text in dataset[text_column]):
+        sys.exit(
+            f"Text column '{text_column}' in {split_name} contains null, blank or non-string "
+            "values. Clean the text column before training."
+        )
+    return normalise_label_column(dataset, label_column)
 
 
 def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:
@@ -206,13 +233,18 @@ def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction,
         return train_data, eval_data
 
     logger.info("No eval split found; carving %.0f%% off the train split.", eval_fraction * 100)
-    # Stratify when the labels are typed, so a rare class cannot vanish from a small carve.
-    feature = train_data.features.get(label_column)
-    stratify = label_column if isinstance(feature, ClassLabel) else None
+    check_label_column(train_data, label_column)
+    train_data = drop_unlabelled_rows(train_data, label_column, "train")
+    if len(train_data) < 2:
+        sys.exit("Need at least two labelled rows to carve out an evaluation split.")
+    # Encode plain labels as well, so string/int columns get the same stratification guarantee.
+    train_data = normalise_label_column(train_data, label_column)
+    if not isinstance(train_data.features[label_column], ClassLabel):
+        train_data = train_data.class_encode_column(label_column)
 
     try:
         parts = train_data.train_test_split(
-            test_size=eval_fraction, seed=seed, stratify_by_column=stratify
+            test_size=eval_fraction, seed=seed, stratify_by_column=label_column
         )
     except ValueError as error:
         # Stratification needs at least two members of every class, so it fails on exactly the
@@ -220,7 +252,7 @@ def split_train_eval(dataset_id, config, train_split, eval_split, eval_fraction,
         # crashing is not.
         logger.warning(
             "Could not stratify the carve-out (%s). Falling back to an unstratified split — a "
-            "very rare class may be absent from the eval set.",
+            "very rare class may be absent from either split.",
             error,
         )
         parts = train_data.train_test_split(test_size=eval_fraction, seed=seed)
@@ -616,11 +648,8 @@ def main(args) -> None:
         args.label_column,
     )
 
-    check_label_column(train_pool, args.label_column)
-    train_pool = normalise_label_column(train_pool, args.label_column)
-    eval_data = normalise_label_column(eval_data, args.label_column)
-
-    # Cap BEFORE filtering. Both caps are O(1) selects while the blank-label filter is a full
+    # Cap before final validation (a carved split already needed a pass over labels).
+    # Both caps are O(1) selects while the blank-label filter is a full
     # scan, and on a 2.4M-row corpus that ordering was eight minutes of preflight before a single
     # training step. sample_dataset also calls .to_pandas() on whatever pool it is handed, which
     # would OOM a cpu-basic job outright. The cap samples randomly, so a very rare class can be
@@ -632,13 +661,13 @@ def main(args) -> None:
         eval_data = eval_data.shuffle(seed=args.seed).select(range(args.max_eval_samples))
         logger.info("Capped eval set at %d examples.", args.max_eval_samples)
 
-    train_pool = drop_unlabelled_rows(train_pool, args.label_column, "train")
-    eval_data = drop_unlabelled_rows(eval_data, args.label_column, "eval")
+    train_pool = prepare_split(train_pool, args.text_column, args.label_column, "train")
+    eval_data = prepare_split(eval_data, args.text_column, args.label_column, "eval")
 
     label_names = resolve_label_names(train_pool, args.label_column)
     logger.info("Found %d classes: %s", len(label_names), label_names)
-    if len(label_names) < 2:
-        sys.exit(f"Only one class found in '{args.label_column}'. A classifier needs two or more.")
+    if len(set(train_pool[args.label_column])) < 2:
+        sys.exit(f"Fewer than two observed classes in '{args.label_column}'. A classifier needs two or more.")
 
     train_data = sample_dataset(
         train_pool, label_column=args.label_column, num_samples=args.num_samples, seed=args.seed
@@ -648,7 +677,9 @@ def main(args) -> None:
     counts = sorted(Counter(train_data[args.label_column]).items())
     feature = train_data.features.get(args.label_column)
     if isinstance(feature, ClassLabel):
-        per_class = {feature.int2str(int(value)): count for value, count in counts}
+        # Keep the full positional label table, but disclose declared classes with no examples.
+        per_class = dict.fromkeys(label_names, 0)
+        per_class.update({feature.int2str(int(value)): count for value, count in counts})
     else:
         per_class = {str(value): count for value, count in counts}
     logger.info("Sampled %d training examples; per class: %s", len(train_data), per_class)
@@ -782,7 +813,7 @@ def parse_args():
     parser.add_argument(
         "--eval-split",
         help="Eval split. Default: validation, else test, else carve --eval-fraction off "
-             "train. A slice such as train[:10%] is NOT checked for overlap with training.",
+             "train. A slice such as train[:10%%] is NOT checked for overlap with training.",
     )
     parser.add_argument("--eval-fraction", type=float, default=0.1, help="Eval fraction if no eval split (default: 0.1)")
     parser.add_argument("--max-eval-samples", type=int, default=2000, help="Cap eval examples (default: 2000)")

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -188,12 +188,25 @@ def prepare_split(dataset, text_column, label_column, split_name):
     dataset = drop_unlabelled_rows(dataset, label_column, split_name)
     if not len(dataset):
         sys.exit(f"No labelled rows remain in {split_name} after removing missing labels.")
-    if any(not isinstance(text, str) or not text.strip() for text in dataset[text_column]):
-        sys.exit(
-            f"Text column '{text_column}' in {split_name} contains null, blank or non-string "
-            "values. Clean the text column before training."
+    def has_text(text):
+        if text is None:
+            return False
+        if not isinstance(text, str):
+            sys.exit(
+                f"Text column '{text_column}' in {split_name} contains non-string values. "
+                "Clean the text column before training."
+            )
+        return bool(text.strip())
+
+    kept = dataset.filter(has_text, input_columns=[text_column])
+    if len(kept) < len(dataset):
+        logger.warning(
+            "Dropped %d %s rows with missing or blank '%s' (%d remain).",
+            len(dataset) - len(kept), split_name, text_column, len(kept),
         )
-    return normalise_label_column(dataset, label_column)
+    if not len(kept):
+        sys.exit(f"No usable text rows remain in {split_name} after removing missing texts.")
+    return normalise_label_column(kept, label_column)
 
 
 def resolve_label_names(dataset: Dataset, label_column: str) -> list[str]:

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -10,19 +10,22 @@
 # ]
 # ///
 """
-Few-shot text classification with SetFit — train on 8-64 labelled examples per class, on CPU.
+Few-shot text classification with SetFit — train on 8-64 labelled examples per class, on CPU or GPU.
 
 SetFit fine-tunes a sentence-transformer body with contrastive pairs, then fits a logistic
-regression head on the embeddings. With a handful of examples per class it reaches a useful
-classifier in minutes without a GPU, which makes it the cheap middle rung between zero-shot
-LLM labelling and a full encoder fine-tune (`train-classifier.py`).
+regression head on the embeddings. It supports small labelled datasets between zero-shot LLM
+labelling and a full encoder fine-tune (`train-classifier.py`). CPU is practical for small
+experiments; use a GPU for faster training, particularly with larger models, longer texts or
+more classes.
 
-Run on HF Jobs (cpu-basic is enough; no GPU needed):
+Run a small experiment on HF Jobs:
 
     hf jobs uv run --flavor cpu-basic --secrets HF_TOKEN \\
         https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py \\
         fancyzhx/ag_news username/ag-news-setfit \\
         --num-samples 8
+
+For faster training with the same model and settings, change --flavor to t4-small.
 
 Metrics match `train-classifier.py` (accuracy + macro F1 on a held-out split) so the two are
 directly comparable at equal eval settings.

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -335,7 +335,8 @@ def warn_on_truncation(model, texts, max_seq_length: int) -> None:
     logger.warning(
         "%d of %d sampled documents exceed --max-seq-length %d (median of those: %d tokens). "
         "Everything past the limit is discarded before training and before prediction. If the "
-        "signal for your labels sits late in the document, raise --max-seq-length.",
+        "signal for your labels sits late in the document, raise --max-seq-length within the "
+        "body model's supported context window, or choose a longer-context --body-model.",
         len(over), len(sample), max_seq_length, median_over,
     )
 
@@ -480,11 +481,15 @@ def estimate_training_steps(per_class, batch_size, num_epochs, strategy) -> tupl
 
 
 def build_reproduce_command(args) -> str:
-    """Rebuild the exact invocation, so the card's command produces the card's model.
+    """Rebuild recipe options for Jobs, preserving the recorded accelerator when available.
 
     Only non-default flags are appended, keeping the command short while staying faithful.
+    Outside Jobs, the hardware flavor is a suggested default rather than an exact record.
     """
     flavor = "t4-small" if torch.cuda.is_available() else "cpu-basic"
+    accelerator = os.environ.get("ACCELERATOR", "").strip()
+    if os.environ.get("JOB_ID") and accelerator.lower() not in ("", "none"):
+        flavor = accelerator
     parts = [
         f"hf jobs uv run --flavor {flavor} --secrets HF_TOKEN \\",
         f"  {SCRIPT_URL} \\",
@@ -647,9 +652,15 @@ def main(args) -> None:
 
     # Prove we can write the output repo BEFORE paying for training. A permissions failure
     # after trainer.train() costs the whole run and leaves no artifact behind.
-    HfApi(token=token).create_repo(
+    api = HfApi(token=token)
+    api.create_repo(
         args.output_repo, repo_type="model", private=args.private, exist_ok=True
     )
+    if args.private and not api.model_info(args.output_repo).private:
+        sys.exit(
+            f"Output repo '{args.output_repo}' is public. --private does not change an existing "
+            "repo's visibility. Choose a new output repo or make that repo private before training."
+        )
 
     logger.info("Loading %s", args.input_dataset)
     eval_split = pick_eval_split(

--- a/classification/train-setfit.py
+++ b/classification/train-setfit.py
@@ -87,8 +87,8 @@ SCRIPT_URL = (
     "https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py"
 )
 
-# Single-seed few-shot accuracy moves by roughly this much on its own (measured across body
-# models on one dataset), so any lift smaller than this is not evidence of anything.
+# Fixed threshold for prompting review of a small gain over the majority baseline.
+# This is a heuristic, not an estimate of seed variance or statistical significance.
 NOISE_BAND = 0.05
 
 # Applied to the measured step time. Covers what the measurement omits — optimizer update,
@@ -99,8 +99,8 @@ MEASUREMENT_MARGIN = 1.35
 
 # MiniLM-L6 is the default because it makes the CPU path viable: ~4.4x faster than
 # paraphrase-mpnet-base-v2 on cpu-basic (207s vs 915s for 8 examples/class on ag_news). It is
-# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788, a gap well
-# inside single-seed few-shot noise. Pass --body-model to try a larger body.
+# NOT chosen on accuracy — on ag_news's test split the two scored 0.804 and 0.788 in single-seed
+# runs, which do not establish a reliable ranking. Pass --body-model to try a larger body.
 DEFAULT_BODY = "sentence-transformers/all-MiniLM-L6-v2"
 
 
@@ -573,8 +573,9 @@ def build_card(args, label_names, metrics, per_class, train_seconds, eval_split)
         )
     caveats.append(
         f"Accuracy is reported against a majority-class baseline of "
-        f"`{metrics['majority_baseline']}`. The majority class is the LOWER floor — zero-shot "
-        "with no labels wins outright on some tasks and is the comparison that matters."
+        f"`{metrics['majority_baseline']}`. Also compare with a simple trained baseline on "
+        "the same rows, and consider a zero-shot comparison where suitable. A small "
+        "single-seed gain does not establish reliable improvement."
     )
     caveat_block = "\n".join(f"- {c}" for c in caveats)
 
@@ -778,11 +779,8 @@ def main(args) -> None:
     metrics = evaluate(model, eval_data, args.text_column, args.label_column)
     logger.info("Metrics: %s", metrics)
 
-    # Two floors matter, and the majority class is only the lower one. Single-seed few-shot
-    # results move by ~5 points on their own, so a lift inside that band is not a result.
-    # The floor that actually binds is the free zero-shot arm: on dair-ai/emotion this script
-    # scores 0.370 against a 0.352 majority — passing a naive check — while SetFit's templated
-    # zero-shot, which needs no labels at all, scores 0.591.
+    # A majority baseline is a useful first comparison. A small gain triggers review;
+    # the fixed threshold does not determine whether the difference is significant.
     lift = metrics["accuracy"] - metrics["majority_baseline"]
     if lift <= 0:
         logger.warning(
@@ -792,10 +790,10 @@ def main(args) -> None:
         )
     elif lift < NOISE_BAND:
         logger.warning(
-            "WITHIN NOISE OF FLOOR: accuracy %.3f versus a %.3f majority class is only %.1f "
-            "points, and single-seed few-shot results vary by about %.0f. Treat this as 'no "
-            "signal demonstrated', not as a working classifier. Re-run with other seeds before "
-            "believing it.",
+            "SMALL GAIN OVER BASELINE: accuracy %.3f versus a %.3f majority class is only %.1f "
+            "points, below the %.0f-point review threshold. This threshold is a heuristic, "
+            "not a significance test. Evaluate other seeds and matched baselines before "
+            "drawing conclusions.",
             metrics["accuracy"], metrics["majority_baseline"], lift * 100, NOISE_BAND * 100,
         )
     else:

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: setfit-on-jobs
+description: Train and evaluate a single-label SetFit text classifier using Hugging Face Jobs, preparing a small labeled Hub dataset from supplied documents when needed, then return a verified Hub model and inference example. Use for few-shot text classification or when the user explicitly requests SetFit on Jobs.
+---
+
+# SetFit on Hugging Face Jobs
+
+Train a Hub-hosted SetFit model with a bounded run and an honest evaluation. Start from labeled text or prepare a small labeled sample from supplied documents. Keep the task to one classification schema and one train/evaluate cycle; taxonomy discovery, automatic active-learning loops and corpus-wide annotation are separate workflows.
+
+## Prepare a small dataset when labels are missing
+
+Inspect representative documents and use the user's categories and definitions. If categories are unspecified or overlap materially, resolve that before assigning labels. Label a bounded sample of actual documents with the agent or a zero-shot teacher; preserve source IDs, original source locations/revisions, label origin and the labeling instructions. Leave genuinely ambiguous examples for review rather than forcing them into a class. Do not substitute invented class-description sentences for real documents or describe agent-labeled training as zero-shot SetFit.
+
+Reserve evaluation documents before labeling or sampling training rows. Prefer independently reviewed evaluation labels. If the agent labels both splits, explicitly report student–agent agreement; do not call those labels human ground truth. The current recipe requires labeled evaluation data: it has no skip-evaluation or unlabeled-inference mode. Without suitable evaluation labels, prepare candidates and explain the missing prerequisite instead of manufacturing an accuracy score.
+
+Prepare a small Hub dataset with `text`, `label` and source IDs, plus explicit train/validation splits and a card describing label provenance. Use the user's namespace and intended visibility; preserve the source corpus. Local files or documents in a bucket need only yield this small training/evaluation sample—the full corpus can stay where it is. Extract text first if inputs are PDFs or other document formats. Bucket mounts alone do not extract documents or create labels; this recipe's supported handoff is a Hub dataset ID and its output is a model, not corpus annotations.
+
+## Check the inputs
+
+Inspect the dataset config, text and label columns, splits and missing values before launching a Job. Compute class counts from the saved rows and check they sum to each split's size. This recipe supports one label per text. Labels may be human or model generated; record their origin. Evaluation against synthetic labels measures agreement with those labels, not independent human accuracy.
+
+Choose a held-out labeled split explicitly. The recipe otherwise prefers validation, then test, then carves training data. Check related documents and duplicates do not cross the evaluation boundary. For repeated experiments, use validation for decisions and reserve test for the final assessment.
+
+Measure text lengths with the selected body's tokenizer and check language suitability. Report truncation only when measured lengths exceed the configured limit; do not turn a possible limitation into an observed finding. The default English MiniLM body and 256-token truncation may not suit other languages or decisions requiring a whole document. Disclose material truncation or choose suitable settings within the budget.
+
+## Run the existing recipe
+
+Use the tested recipe rather than recreating SetFit training code. The executable link below pins a tested revision. The canonical recipe is https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py; verify it includes the pinned revision's input-validation fixes before switching to the mirror:
+
+https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py
+
+Read its help for flags and check `hf jobs uv run --help` if needed. A small first run can use `cpu-basic`; adapt sample counts, body model and hardware to the data and user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
+
+Example for a small pilot (replace the output namespace):
+
+```bash
+hf jobs uv run --flavor cpu-basic --timeout 10m --detach --secrets HF_TOKEN \
+  https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py \
+  fancyzhx/ag_news YOUR_NAMESPACE/ag-news-setfit \
+  --eval-split test --num-samples 8 --max-eval-samples 200 \
+  --sampling-strategy undersampling --max-minutes 5 --private
+```
+
+Use the requested output visibility. The destination is a model repo. Pass credentials through Jobs secrets. Record the source revision and actual invocation; preserve sampled row IDs and seed when reproducing a comparison.
+
+Inspect both `hf jobs logs` and `hf jobs inspect`: submission or a closed log stream does not establish completion. Keep retries within the authorized budget. A runtime guard refusal is a reason to reduce the workload or explain the limitation; do not silently override it or increase hardware. Stop after the requested run rather than starting an automatic tuning loop.
+
+## Evaluate and hand off
+
+Report actual training examples per class, evaluation size, accuracy, macro F1 and a majority baseline on the same evaluation rows. For an initial usefulness assessment, compare with TF-IDF plus logistic regression when practical. Match the exact training and evaluation rows; a baseline trained on more labels answers a different question. Additional zero-shot comparisons are optional, not part of every SetFit run.
+
+Derive any confusion matrix and error examples from that model's saved predictions and evaluation row IDs. The diagonal divided by the matrix total must match its accuracy. If only aggregate metrics are available, report that limit rather than inventing diagnostics. Inspect a few errors when predictions are available, and disclose dropped rows, missing classes and the limitations of a small single-seed evaluation.
+
+Verify the uploaded model reloads and predicts the expected label names. SetFit has a sentence-transformer body and classification head; load it with `SetFitModel.from_pretrained`, not `AutoModelForSequenceClassification`:
+
+```python
+from setfit import SetFitModel
+
+model = SetFitModel.from_pretrained("YOUR_NAMESPACE/ag-news-setfit")
+print(model.predict(["The team won the championship."]))
+```
+
+Return the model and Job links, exact command, measured results, short inference example and a concrete recommendation about suitability. Verify artifact links exist and, for private outputs, check visibility through authenticated metadata. A working training run and useful classification quality are separate findings.

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -23,6 +23,8 @@ Choose a held-out labeled split explicitly. The recipe otherwise prefers validat
 
 Measure text lengths with the selected body's tokenizer and check language suitability. Report truncation only when measured lengths exceed the configured limit; do not turn a possible limitation into an observed finding. The default English MiniLM body and 256-token truncation may not suit other languages or decisions requiring a whole document. Disclose material truncation or choose suitable settings within the budget.
 
+Keep `--max-seq-length` within the chosen body's supported context window. If prepared inputs were already shortened, restore the original text before testing longer context. Follow the body's task-prefix instructions consistently across training, evaluation and inference; the recipe does not add prefixes automatically. Record these preprocessing requirements in the handoff.
+
 ## Run the existing recipe
 
 Use the tested recipe rather than recreating SetFit training code. The executable link below pins a tested revision. The canonical recipe is https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py; verify it includes the pinned revision's input-validation fixes before switching to the mirror:

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -29,7 +29,7 @@ Keep `--max-seq-length` within the chosen body's supported context window. If pr
 
 Use the tested recipe rather than recreating SetFit training code. The executable link below pins a tested revision. The canonical recipe is https://huggingface.co/datasets/uv-scripts/classification/raw/main/train-setfit.py; verify it includes the pinned revision's input-validation fixes before switching to the mirror:
 
-https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py
+https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/11e6ae6250a2ae3dc67cd074679a6da70cac13b0/classification/train-setfit.py
 
 Read its help for flags and check `hf jobs uv run --help` if needed. CPU is practical for small experiments; use a GPU for faster training, particularly with larger models, longer texts or more classes. A small first run can use `cpu-basic`; changing to `t4-small` accelerates the same model and training settings. Choose hardware within the user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
 
@@ -37,7 +37,7 @@ Example for a small pilot (replace the output namespace):
 
 ```bash
 hf jobs uv run --flavor cpu-basic --timeout 10m --detach --secrets HF_TOKEN \
-  https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py \
+  https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/11e6ae6250a2ae3dc67cd074679a6da70cac13b0/classification/train-setfit.py \
   fancyzhx/ag_news YOUR_NAMESPACE/ag-news-setfit \
   --eval-split test --num-samples 8 --max-eval-samples 200 \
   --sampling-strategy undersampling --max-minutes 5 --private

--- a/skills/setfit-on-jobs/SKILL.md
+++ b/skills/setfit-on-jobs/SKILL.md
@@ -29,7 +29,7 @@ Use the tested recipe rather than recreating SetFit training code. The executabl
 
 https://raw.githubusercontent.com/davanstrien/uv-scripts-for-ai/d77b0338d577a9e5d35ead6df4ec681ca8e5c06e/classification/train-setfit.py
 
-Read its help for flags and check `hf jobs uv run --help` if needed. A small first run can use `cpu-basic`; adapt sample counts, body model and hardware to the data and user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
+Read its help for flags and check `hf jobs uv run --help` if needed. CPU is practical for small experiments; use a GPU for faster training, particularly with larger models, longer texts or more classes. A small first run can use `cpu-basic`; changing to `t4-small` accelerates the same model and training settings. Choose hardware within the user's budget. Four examples per class is a smoke test, not a quality target. `--num-samples` caps examples per class; it does not mean total training rows.
 
 Example for a small pilot (replace the output namespace):
 

--- a/skills/uv-recipes/SKILL.md
+++ b/skills/uv-recipes/SKILL.md
@@ -62,7 +62,7 @@ Keep the inline dependency block valid (new deps install at runtime); update the
 
 ## Compose a pipeline
 
-Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model. One pipeline ships pre-assembled as its own skill: `object-detection` carries a `SKILL.md` covering the full no-labels→detector loop (zero-shot teacher labels → validate → convert → train a small Apache-licensed detector) — fetch it from the repo when that is the task.
+Each recipe's output dataset is the next recipe's input (handoff through the Hub): e.g. `dataset-creation` (PDFs→dataset) → `ocr/glm-ocr.py` (→`markdown`) → `deduplication` → `build-atlas` (embed + map). A pipeline can also end in a trained model. For a small single-label text classifier, use the focused [setfit-on-jobs skill](../setfit-on-jobs/SKILL.md): it can prepare an agent-labeled sample, run SetFit on Jobs, and evaluate and reload the model. One pipeline ships pre-assembled as its own skill: `object-detection` carries a `SKILL.md` covering the full no-labels→detector loop (zero-shot teacher labels → validate → convert → train a small Apache-licensed detector) — fetch it from the repo when that is the task.
 
 ## Pre-label, then review
 

--- a/tests/test_train_setfit.py
+++ b/tests/test_train_setfit.py
@@ -1,0 +1,115 @@
+"""Data preflight regressions; no Hub access or model downloads required.
+
+Run with the recipe dependencies and pytest installed:
+    python -m pytest tests/test_train_setfit.py
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from datasets import ClassLabel, Dataset, Features, Value
+
+SCRIPT = Path(__file__).resolve().parents[1] / "classification" / "train-setfit.py"
+spec = importlib.util.spec_from_file_location("train_setfit", SCRIPT)
+recipe = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recipe)
+
+
+def typed_dataset(labels):
+    return Dataset.from_dict(
+        {"text": [f"document {i}" for i in range(len(labels))], "label": labels},
+        features=Features({"text": Value("string"), "label": ClassLabel(names=["a", "b", "c"])}),
+    )
+
+
+def test_missing_classlabel_is_dropped_without_remapping():
+    cleaned = recipe.prepare_split(typed_dataset([0, -1, 2, None]), "text", "label", "train")
+    assert list(cleaned["label"]) == [0, 2]
+    assert recipe.resolve_label_names(cleaned, "label") == ["a", "b", "c"]
+
+
+def test_plain_negative_integer_is_a_real_class():
+    data = Dataset.from_dict({"text": ["a", "b", "c"], "label": [-1, 0, 1]})
+    assert list(recipe.prepare_split(data, "text", "label", "train")["label"]) == ["-1", "0", "1"]
+
+
+def test_nan_is_removed_before_string_cast():
+    data = Dataset.from_dict({"text": ["a", "b", "c"], "label": [1.0, float("nan"), 2.0]})
+    cleaned = recipe.prepare_split(data, "text", "label", "train")
+    assert len(cleaned) == 2
+    assert "nan" not in cleaned["label"]
+
+
+@pytest.mark.parametrize("labels", [[], [None, None], ["", " "]])
+def test_empty_or_unlabelled_split_is_rejected(labels):
+    data = Dataset.from_dict({"text": ["document"] * len(labels), "label": labels})
+    with pytest.raises(SystemExit, match="empty|No labelled rows"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("text", [None, "", " ", 12])
+def test_invalid_text_is_rejected_before_training(text):
+    data = Dataset.from_dict({"text": [text], "label": ["a"]})
+    with pytest.raises(SystemExit, match="Clean the text column"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("column", ["text", "label"])
+def test_missing_columns_are_actionable(column):
+    data = Dataset.from_dict({"text": ["document"], "label": ["a"]}).remove_columns(column)
+    with pytest.raises(SystemExit, match=f"--{column}-column"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+def test_multilabel_eval_is_rejected():
+    data = Dataset.from_dict({"text": ["document"], "label": [["a", "b"]]})
+    with pytest.raises(SystemExit, match="multi-label"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("labels", [["a", "a", "b", "b"], [-1, -1, 2, 2]])
+def test_plain_labels_get_stratified_disjoint_carve(monkeypatch, labels):
+    data = Dataset.from_dict({"text": ["one", "two", "three", "four"], "label": labels})
+    monkeypatch.setattr(recipe, "load_dataset", lambda *args, **kwargs: data)
+    train, evaluation = recipe.split_train_eval("fixture", None, "train", None, 0.5, 2, "label")
+    assert len(set(train["label"])) == len(set(evaluation["label"])) == 2
+    assert set(train["text"]).isdisjoint(evaluation["text"])
+    assert set(train.features["label"].names) == {str(label) for label in labels}
+
+
+def test_carve_drops_missing_classlabel_before_stratifying(monkeypatch):
+    data = typed_dataset([0, 0, 2, 2, -1, None])
+    monkeypatch.setattr(recipe, "load_dataset", lambda *args, **kwargs: data)
+    train, evaluation = recipe.split_train_eval("fixture", None, "train", None, 0.5, 2, "label")
+    assert len(train) == len(evaluation) == 2
+    assert set(train["label"]) == set(evaluation["label"]) == {0, 2}
+
+
+def test_one_observed_class_stops_before_model_loading(monkeypatch):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "fixture", "user/model", "--hf-token", "fake"])
+    monkeypatch.setattr(recipe, "login", Mock())
+    monkeypatch.setattr(recipe, "HfApi", Mock())
+    monkeypatch.setattr(recipe, "pick_eval_split", lambda *args: "test")
+    monkeypatch.setattr(recipe, "split_train_eval", lambda *args: (typed_dataset([2, 2]), typed_dataset([0, 2])))
+    load_model = Mock()
+    monkeypatch.setattr(recipe.SetFitModel, "from_pretrained", load_model)
+    with pytest.raises(SystemExit, match="two observed classes"):
+        recipe.main(recipe.parse_args())
+    load_model.assert_not_called()
+
+
+def test_evaluation_decodes_its_own_classlabel_table():
+    evaluation = typed_dataset([2, 0])
+    model = Mock()
+    model.predict.return_value = ["c", "a"]
+    assert recipe.evaluate(model, evaluation, "text", "label")["accuracy"] == 1.0
+
+
+def test_help_renders_slice_example(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "--help"])
+    with pytest.raises(SystemExit) as result:
+        recipe.parse_args()
+    assert result.value.code == 0
+    assert "train[:10%]" in capsys.readouterr().out

--- a/tests/test_train_setfit.py
+++ b/tests/test_train_setfit.py
@@ -49,9 +49,23 @@ def test_empty_or_unlabelled_split_is_rejected(labels):
         recipe.prepare_split(data, "text", "label", "eval")
 
 
-@pytest.mark.parametrize("text", [None, "", " ", 12])
-def test_invalid_text_is_rejected_before_training(text):
+@pytest.mark.parametrize("text", [None, "", " "])
+def test_empty_text_split_is_rejected_before_training(text):
     data = Dataset.from_dict({"text": [text], "label": ["a"]})
+    with pytest.raises(SystemExit, match="No usable text rows"):
+        recipe.prepare_split(data, "text", "label", "eval")
+
+
+@pytest.mark.parametrize("text", [None, "", " "])
+def test_missing_text_is_dropped_without_rejecting_usable_rows(text):
+    data = Dataset.from_dict({"text": [text, "a real document"], "label": ["a", "b"]})
+    cleaned = recipe.prepare_split(data, "text", "label", "eval")
+    assert list(cleaned["text"]) == ["a real document"]
+    assert list(cleaned["label"]) == ["b"]
+
+
+def test_non_string_text_is_rejected_before_training():
+    data = Dataset.from_dict({"text": [12], "label": ["a"]})
     with pytest.raises(SystemExit, match="Clean the text column"):
         recipe.prepare_split(data, "text", "label", "eval")
 

--- a/tests/test_train_setfit.py
+++ b/tests/test_train_setfit.py
@@ -127,3 +127,39 @@ def test_help_renders_slice_example(monkeypatch, capsys):
         recipe.parse_args()
     assert result.value.code == 0
     assert "train[:10%]" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("job_id", "accelerator", "cuda", "expected"),
+    [
+        ("job-123", "l40sx1", True, "l40sx1"),
+        ("job-123", "a100-large", True, "a100-large"),
+        ("job-123", "none", False, "cpu-basic"),
+        ("job-123", "", False, "cpu-basic"),
+        ("", "l40sx1", True, "t4-small"),
+    ],
+)
+def test_reproduction_preserves_jobs_gpu_flavor(monkeypatch, job_id, accelerator, cuda, expected):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "fixture", "user/model"])
+    monkeypatch.setenv("JOB_ID", job_id)
+    monkeypatch.setenv("ACCELERATOR", accelerator)
+    monkeypatch.setattr(recipe.torch.cuda, "is_available", lambda: cuda)
+    command = recipe.build_reproduce_command(recipe.parse_args())
+    assert command.startswith(f"hf jobs uv run --flavor {expected} --secrets HF_TOKEN")
+
+
+@pytest.mark.parametrize("is_private", [False, True])
+def test_private_destination_visibility_checked_before_loading_data(monkeypatch, is_private):
+    monkeypatch.setattr("sys.argv", [str(SCRIPT), "fixture", "user/model", "--private", "--hf-token", "fake"])
+    monkeypatch.setattr(recipe, "login", Mock())
+    api = Mock()
+    api.model_info.return_value.private = is_private
+    monkeypatch.setattr(recipe, "HfApi", Mock(return_value=api))
+    load_data = Mock(side_effect=RuntimeError("data loading reached"))
+    monkeypatch.setattr(recipe, "pick_eval_split", load_data)
+    error = RuntimeError if is_private else SystemExit
+    message = "data loading reached" if is_private else "is public"
+    with pytest.raises(error, match=message):
+        recipe.main(recipe.parse_args())
+    assert load_data.call_count == int(is_private)
+    api.create_repo.assert_called_once_with("user/model", repo_type="model", private=True, exist_ok=True)


### PR DESCRIPTION
The SetFit recipe can fail after preflight on missing labels or invalid text. This PR fixes those cases and adds a focused `setfit-on-jobs` skill that takes labeled text—or a small agent-labeled sample of supplied documents—to an evaluated Hub model. It targets #108's `classification/train-setfit` branch.

The recipe now removes missing-label sentinels before conversion, checks both data splits, skips blank text with counts, preserves label mappings, counts observed classes and stratifies plain-label evaluation splits. It also fixes the argparse percent escape that broke `--help`.

The skill uses the existing recipe with bounded Jobs execution, explicit split and label provenance, matched baseline comparisons where useful, prediction-derived diagnostics, and verified model reload. Its optional preparation step stages only a small source-linked dataset; it does not add storage adapters, automatic annotation loops or corpus-wide inference. The root README and recipe-discovery skill link to it.

The README, warning text and generated model card now describe the five-point gain threshold as a heuristic, distinguish the training-time estimate from Jobs `--timeout`, qualify comparisons with published zero-shot results, and correctly locate dropped-row/truncation counts in the logs. The obsolete 5,000-step warning description is removed. Hardware guidance describes CPU as practical for small experiments and GPU as the option for faster training. CPU/GPU examples use the same model and training settings. Training logic and numerical thresholds are unchanged.

Validation:

- 22 regression tests, recipe `--help`, Ruff E4/E7/E9/F, skill structural validation and `git diff --check` pass. The existing runtime-estimator catch-all still triggers the broader BLE001 rule, outside this change.
- The Hub superset gate passes: all four existing classification files are preserved.
- Earlier `cpu-basic` Jobs on the fixed recipe completed training, private Hub upload and reload: [AG News](https://huggingface.co/jobs/davanstrien/6a9c39fe259f8e97255e35d3), 0.77 accuracy with 16 training/100 evaluation examples; [Enron](https://huggingface.co/jobs/davanstrien/6a9c39ec259f8e97255e35ab), 0.86 with 8/100. Three local fixture training/reload checks cover sparse ClassLabel, arbitrary integer and string labels.
- A fresh `gpt-5.6-luna` forward test started with unlabeled documents, created a private dataset with 32 agent-labeled training rows and 32 reserved evaluation rows, and completed one [cpu-basic Job](https://huggingface.co/jobs/davanstrien/6a9c53d8e686246ca69a41c9) in 108 seconds. The model reloaded and predicted 16 additional documents. Parent verification matched all 48 saved model predictions and both model/baseline metrics. SetFit scored 0.90625 agreement with agent evaluation labels, versus 0.25 for matched TF-IDF; against original source labels withheld from the agent, SetFit accuracy was 0.8125. The independent audit caught an incorrect manifest class count and unsupported truncation claim; the artifacts were corrected and the skill now explicitly requires measured counts and token lengths.

These are bounded smoke tests, including one forward test of the unlabeled preparation path, not broad skill-reliability or classification benchmarks. No new training-script feature or direct bucket adapter is added. Zero-shot SetFit templates and corpus-wide inference remain separate work.

